### PR TITLE
View previous versions of a Judgment

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -1,4 +1,4 @@
-.edit-component {
+.edit-component, .list-versions-component {
   background-color: $color__light-grey;
   padding: $spacer__unit;
 

--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
@@ -29,6 +29,11 @@
     display: inline-block;
   }
 
+  &__version {
+    margin-top: $spacer__unit;
+    font-weight: bold;
+  }
+
   &__container {
     margin: auto;
 

--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -13,5 +13,10 @@
             <a class="" href="{% url 'detail' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.view_this_judgment" %}</a>
           {% endif %}
         </div>
+        {% if context.version %}
+          <div class="judgment-toolbar__version">
+            <b>You are viewing version {{ context.version }} of this Judgment.</b>
+          </div>
+        {% endif %}
     </div>
 </div>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -36,4 +36,20 @@
       </form>
     </div>
   </div>
+  {% if context.previous_versions %}
+  <div class="list-versions-component">
+    <div class="list-versions-component__container">
+      <h2 class="list-versions-component__header">{% translate "judgment.previous_versions" %}</h2>
+      <ul>
+        {% for version in context.previous_versions %}
+          <li>
+            <a class="list-versions__version-title" href="{% url 'detail' %}?judgment_uri={{context.judgment_uri}}&version_uri={{version.uri}}">
+              v{{ version.version }} ( {{version.uri}} )
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
 {% endblock content %}

--- a/locale/en_gb/LC_MESSAGES/django.po
+++ b/locale/en_gb/LC_MESSAGES/django.po
@@ -140,3 +140,7 @@ msgstr "Contains sensitive information?"
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:29
 msgid "judgment.supplemental"
 msgstr "Has supplemental documents?"
+
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:42
+msgid "judgment.previous_versions"
+msgstr "Previous versions of this Judgment"


### PR DESCRIPTION
Show a list of previous versions of a Judgment on the `edit` page.
Any version can be clicked through to, and viewed as normal.

This relies on using v2.1.0 of the API client!