### PR TITLE
Move Dockerfile to root with working static assets for production images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,96 @@
+ARG PYTHON_VERSION=3.9-slim-bullseye
+
+
+
+# define an alias for the specfic python version used in this file.
+FROM python:${PYTHON_VERSION} as python
+
+# Python build stage
+FROM python as python-build-stage
+
+ARG BUILD_ENVIRONMENT=production
+
+# Install apt packages
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  # dependencies for building Python packages
+  build-essential \
+  # psycopg2 dependencies
+  libpq-dev
+  # WeasyPrint dependencies \
+  weasyprint \
+  python3-cffi python3-brotli libpango-1.0-0 libpangoft2-1.0-0
+
+# Requirements are installed here to ensure they will be cached.
+COPY ./requirements .
+
+# Create Python Dependency and Sub-Dependency Wheels.
+RUN pip wheel --wheel-dir /usr/src/app/wheels  \
+  -r ${BUILD_ENVIRONMENT}.txt
+
+
+# Python 'run' stage
+FROM python as python-run-stage
+
+ARG BUILD_ENVIRONMENT=production
+ARG APP_HOME=/app
+
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV BUILD_ENV ${BUILD_ENVIRONMENT}
+
+WORKDIR ${APP_HOME}
+
+RUN addgroup --system django \
+    && adduser --system --ingroup django django
+
+
+# Install required system dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  # psycopg2 dependencies
+  libpq-dev \
+  # Translations dependencies
+  gettext \
+  curl \
+  # WeasyPrint dependencies \
+  weasyprint \
+  python3-cffi python3-brotli libpango-1.0-0 libpangoft2-1.0-0 \
+  # node install
+  nodejs npm \
+  # cleaning up unused files
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/*
+RUN npm i -g sass
+
+# All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
+# copy python dependency wheels from python-build-stage
+COPY --from=python-build-stage /usr/src/app/wheels  /wheels/
+
+# use wheels to install python dependencies
+RUN pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \
+  && rm -rf /wheels/
+COPY --chown=django:django package-lock.json package-lock.json
+COPY --chown=django:django package.json package.json
+RUN npm ci
+COPY --chown=django:django ./compose/production/django/entrypoint /entrypoint
+RUN sed -i 's/\r$//g' /entrypoint
+RUN chmod +x /entrypoint
+
+
+COPY --chown=django:django ./compose/production/django/start /start
+RUN sed -i 's/\r$//g' /start
+RUN chmod +x /start
+
+
+# copy application code to WORKDIR
+COPY --chown=django:django . ${APP_HOME}
+
+# make django owner of the WORKDIR directory as well.
+RUN chown django:django ${APP_HOME}
+
+USER django
+
+ENTRYPOINT ["/entrypoint"]
+
+EXPOSE 5000
+
+CMD /start

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-
+npm run build
 python /app/manage.py collectstatic --noinput
 ( cd /app/manage.py ; django-admin compilemessages )
 


### PR DESCRIPTION
Moving Dockerfile to root to make hosting set up easier. 
Install `sass` and it's dependencies and configure npm to compile the sites css.