### PR TITLE
Stop start script failing because it tries to cd to a file

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -6,6 +6,7 @@ set -o nounset
 
 npm run build
 python /app/manage.py collectstatic --noinput
-( cd /app/manage.py ; django-admin compilemessages )
+cd /app
+django-admin compilemessages
 
 /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app


### PR DESCRIPTION
Production containers fail with the following error
```
/start: line 9: cd: /app/manage.py: Not a directory
```

this is because app/mange.py is not a directory. This updates to cd into
the app directory.