### PR TITLE
Uncomment ANYMAIL config for production

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -94,9 +94,9 @@ INSTALLED_APPS += ["anymail"]  # noqa F405
 # https://anymail.readthedocs.io/en/stable/esps/mailgun/
 EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 ANYMAIL = {
-    # "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
-    # "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
-    # "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
+    "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
+    "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
+    "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
 }
 
 


### PR DESCRIPTION
This is required according to error message below.

```
anymail.exceptions.AnymailConfigurationError: You must set ANYMAIL_MAILGUN_API_KEY or ANYMAIL = {'MAILGUN_API_KEY': ...} or MAILGUN_API_KEY in your Django settings
```