### PR TITLE
Remove links to "Terms of Use" page

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -14,11 +14,6 @@ urlpatterns = [
         name="open_justice_licence",
     ),
     path(
-        "terms-of-use",
-        views.TermsOfUseView.as_view(),
-        name="terms_of_use",
-    ),
-    path(
         "no_results",
         views.NoResultsView.as_view(),
         name="no_results",

--- a/config/views.py
+++ b/config/views.py
@@ -18,11 +18,6 @@ class OpenJusticeLicenceView(TemplateViewWithContext):
     page_title = "openjusticelicence.title"
 
 
-class TermsOfUseView(TemplateViewWithContext):
-    template_name = "pages/terms_of_use.html"
-    page_title = "terms.title"
-
-
 class SourcesView(TemplateViewWithContext):
     template_name = "pages/sources.html"
     page_title = "judgmentsources.title"

--- a/ds_caselaw_editor_ui/templates/includes/footer.html
+++ b/ds_caselaw_editor_ui/templates/includes/footer.html
@@ -6,9 +6,6 @@
         <a class="judgments-footer__link" href="{% url 'open_justice_licence' %}">Open Justice Licence</a>,
         except where otherwise stated.
       </li>
-      <li>
-        <a class="judgments-footer__link" href="{% url 'terms_of_use' %}">Terms of use</a>
-      </li>
     </ul>
   </div>
 </footer>


### PR DESCRIPTION
Rollbar: https://rollbar.com/dxw/tna-caselaw-editor-ui/items/7/

The "Terms of Use" page does not have a template in this project (it exists in
the public UI project). We do not need a "Terms of Use" page for the Editor UI
as it is not part of the public website, so we can remove any references to it.