### PR TITLE
Remove links to Open Justice License

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -9,11 +9,6 @@ from . import views
 
 urlpatterns = [
     path(
-        "open-justice-licence",
-        views.OpenJusticeLicenceView.as_view(),
-        name="open_justice_licence",
-    ),
-    path(
         "no_results",
         views.NoResultsView.as_view(),
         name="no_results",

--- a/config/views.py
+++ b/config/views.py
@@ -12,12 +12,6 @@ class TemplateViewWithContext(TemplateView):
             }
         }
 
-
-class OpenJusticeLicenceView(TemplateViewWithContext):
-    template_name = "pages/open_justice_licence.html"
-    page_title = "openjusticelicence.title"
-
-
 class SourcesView(TemplateViewWithContext):
     template_name = "pages/sources.html"
     page_title = "judgmentsources.title"

--- a/ds_caselaw_editor_ui/templates/includes/footer.html
+++ b/ds_caselaw_editor_ui/templates/includes/footer.html
@@ -2,9 +2,8 @@
   <div class="judgments-footer__container">
     <h2 class="judgments-footer__heading">Footer</h2>
     <ul class="judgments-footer__links">
-      <li>All content is available under the
-        <a class="judgments-footer__link" href="{% url 'open_justice_licence' %}">Open Justice Licence</a>,
-        except where otherwise stated.
+      <li>
+        All content is available under the Open Justice Licence, except where otherwise stated.
       </li>
     </ul>
   </div>


### PR DESCRIPTION
This isn't needed on the Editor UI. The links were mistakenly copied from the
Public UI.

Rollbar: https://rollbar.com/dxw/tna-caselaw-editor-ui/items/7/