### PR TITLE
Invalidate cloudfront cache on change (publish/unpublish)

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -276,9 +276,14 @@ def unpublish_documents(uri: str) -> None:
         )
 
 
-def create_s3_client():
-    session = boto3.session.Session(
+def aws_session():
+    return boto3.session.Session(
         aws_access_key_id=env("AWS_ACCESS_KEY_ID", default=None),
         aws_secret_access_key=env("AWS_SECRET_KEY", default=None),
     )
-    return session.client("s3", endpoint_url=env("AWS_ENDPOINT_URL", default=None))
+
+
+def create_s3_client():
+    return aws_session().client(
+        "s3", endpoint_url=env("AWS_ENDPOINT_URL", default=None)
+    )


### PR DESCRIPTION
Whenever a document is published, this should invalidate the entire cloudfront cache. This could be more efficient and only clear relevant URLs, but I don't have time right now to get it almost right but slightly wrong, so it's better to nuke the lot.

When we come back to this, this code generates a list of the URI parts to invalidate, though it needs things like feed URLs adding in:

```
>>> parts = uri.split('/')
>>> paths = ['/'.join(parts[0:i+1]) for i in range(1,len(parts))] + ['/', uri+"*"]
>>> print(paths)
['/ewca', '/ewca/help', '/ewca/help/2022', '/ewca/help/2022/23', '/', '/ewca/help/2022/23*']
```