### PR TITLE
Set public-read ACL on copy

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -259,7 +259,8 @@ def publish_documents(uri: str) -> None:
 
     for result in response.get("Contents", []):
         source = {"Bucket": private_bucket, "Key": result["Key"]}
-        client.copy(source, public_bucket, result["Key"])
+        extra_args = {"ACL": "public-read"}
+        client.copy(source, public_bucket, result["Key"], extra_args)
 
 
 def unpublish_documents(uri: str) -> None:


### PR DESCRIPTION
When we copy files to the public bucket, we need to set the `public-read` ACL, otherwise nobody can see them.

relevant boto3 docs: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.copy and https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS