### PR TITLE
Edit the Judgment metadata on the API Client side

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -93,45 +93,24 @@ class EditJudgmentView(View):
             else:
                 unpublish_documents(judgment_uri)
 
-            xml = self.get_judgment(judgment_uri)
-
             # Set name
-            name = xml_tools.get_metadata_name_element(xml)
             new_name = request.POST["metadata_name"]
-            name.set("value", new_name)
-            frbrwork_parent = xml.find(
-                ".//akn:FRBRWork",
-                namespaces=akn_namespace,
-            )
-            if frbrwork_parent:
-                frbrwork_parent.append(name)
-            # Set neutral citation
-            citation = xml_tools.get_neutral_citation_element(xml)
-            new_citation = request.POST["neutral_citation"]
-            citation.text = new_citation
-            uk_parent = xml.find(
-                ".//uk:proprietary",
-                namespaces=uk_namespace,
-            )
-            if uk_parent:
-                uk_parent.append(name)
-            # Set court
-            court = xml_tools.get_court_element(xml)
-            new_court = request.POST["court"]
-            court.text = new_court
-            if uk_parent:
-                uk_parent.append(name)
-            # Date
-            date = xml_tools.get_judgment_date_element(xml)
-            new_date = request.POST["judgment_date"]
-            date.set("date", new_date)
-            if frbrwork_parent:
-                frbrwork_parent.append(date)
+            api_client.set_judgment_name(judgment_uri, new_name)
 
-            # Save
-            api_client.save_judgment_xml(judgment_uri, xml)
+            # Set neutral citation
+            new_citation = request.POST["neutral_citation"]
+            api_client.set_judgment_citation(judgment_uri, new_citation)
+
+            # Set court
+            new_court = request.POST["court"]
+            api_client.set_judgment_court(judgment_uri, new_court)
+
+            # Date
+            new_date = request.POST["judgment_date"]
+            api_client.set_judgment_date(judgment_uri, new_date)
 
             context["success"] = "Judgment successfully updated"
+            xml = self.get_judgment(judgment_uri)
             context.update(self.get_metadata(judgment_uri, xml))
 
         except MarklogicAPIError as e:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests-toolbelt~=0.9.1
 lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=4.4
+ds-caselaw-marklogic-api-client~=4.5.1
 rollbar
 django-stronghold==0.4.0
 boto3==1.21.45


### PR DESCRIPTION
Bump the API Client to v4.5.1

Previously we were editing the Judgment XML in the editor using ETree, and
saving it back to the database via the client. This was causing namespaces
to be lost when deserialising the XML.

In the latest API Client version (4.5.1) we have enabled single-node editing
using XQuery, which preserves the namespaces in the XML document as a whole.
This should fix various issues we've seen with namespaces vanishing, and
data not appearing on the public and editor UIs.