### PR TITLE
Bump API Client to v4.5.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests-toolbelt~=0.9.1
 lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=4.5.1
+ds-caselaw-marklogic-api-client~=4.5.2
 rollbar
 django-stronghold==0.4.0
 boto3==1.21.45


### PR DESCRIPTION
To fix an issue where judgment metadata names were not being saved in the Editor
UI if the `FRBRname` element did not exist in the judgment XML.