### PR TITLE
Exclude parser log and tar from public assets

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -322,9 +322,12 @@ def publish_documents(uri: str) -> None:
     response = client.list_objects(Bucket=private_bucket, Prefix=uri)
 
     for result in response.get("Contents", []):
-        source = {"Bucket": private_bucket, "Key": result["Key"]}
-        extra_args = {"ACL": "public-read"}
-        client.copy(source, public_bucket, result["Key"], extra_args)
+        key = str(result["Key"])
+
+        if not key.endswith("parser.log") and not key.endswith(".tar.gz"):
+            source = {"Bucket": private_bucket, "Key": key}
+            extra_args = {"ACL": "public-read"}
+            client.copy(source, public_bucket, key, extra_args)
 
 
 def unpublish_documents(uri: str) -> None:


### PR DESCRIPTION
When we publish a document, all of the files in the private asset bucket were being copied to the public bucket, but instead we want to exclude the parser log and the TRE tar payload