### PR TITLE
Do not return a 404 if the `parser.log` is not found

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -227,8 +227,11 @@ def get_parser_log(uri: str) -> str:
     s3 = create_s3_client()
     private_bucket = env("PRIVATE_ASSET_BUCKET")
 
-    parser_log = s3.get_object(Bucket=private_bucket, Key=f"{uri}/parser.log")
-    return parser_log["Body"].read().decode("utf-8")
+    try:
+        parser_log = s3.get_object(Bucket=private_bucket, Key=f"{uri}/parser.log")
+        return parser_log["Body"].read().decode("utf-8")
+    except KeyError:
+        return ""
 
 
 def paginator(current_page, total):


### PR DESCRIPTION
We had a Rollbar warning indicating that a 404 was being returned if the
`parser.log` file isn't found with a `failure` document. This should not be a
404-able offense - the Editors should still be able to  download the `docx`
for checking & re-parsing. Return an empty string instead of a KeyError when
the `parser.log` is not found.