### PR TITLE
Don't ask about overwriting staticfiles

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -72,6 +72,7 @@ def run(c):
     django_exec("pip install -r requirements/local.txt -U")
     django_exec("DJANGO_SETTINGS_MODULE= django-admin compilemessages")
     django_exec("python manage.py migrate")
+    django_exec("rm -rf /app/staticfiles")
     django_exec("python manage.py collectstatic")
     # Piping Marklogic logs to marklogic.log
     local("docker logs marklogic > marklogic.log")


### PR DESCRIPTION
Whilst running 'fab run' locally, we'd be asked if we wanted to
overwrite the /app/staticfiles directory. We now delete the
contents of that directory first, to avoid the error message.

This works even when the staticfiles directory doesn't exist.
