### PR TITLE
Handle expected exceptions in 'fab run' and close Docker container

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 
 from invoke import run as local
+from invoke.exceptions import UnexpectedExit
 from invoke.tasks import task
 
 # Process .env file
@@ -74,8 +75,16 @@ def run(c):
     django_exec("python manage.py migrate")
     django_exec("python manage.py collectstatic")
     # Piping Marklogic logs to marklogic.log
-    local("docker logs marklogic > marklogic.log")
-    return django_exec("python manage.py runserver_plus 0.0.0.0:3000")
+    try:
+        local("docker logs marklogic > marklogic.log")
+    except UnexpectedExit:
+        print("Unable to collect MarkLogic logs!")
+        pass
+    try:
+        django_exec("python manage.py runserver 0.0.0.0:3000")
+    except KeyboardInterrupt:
+        pass
+    stop(c, "django")
 
 
 @task


### PR DESCRIPTION
There are two anticipated errors that can occur locally whilst
running `fab run`:

* If MarkLogic is not running locally, getting the logs out of
  Docker will fail -- this is now optional

* When Ctrl-C is pressed to stop the execution of the server, it would
  instead stop the execution of the `run()` function.
  We now catch that explicitly.

In addition, we now stop the `django` Docker container we opened,
so that the user doesn't have to manually do something about the
still-running server which prevents new servers from running on the
old port.