### PR TITLE
Remove screenreader-only styles to reveal h2 headings in the judgment

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text.scss
@@ -147,11 +147,6 @@
 
     @media (min-width: $grid__breakpoint-medium) {
 
-
-      h2 {
-        @include sr-only;
-      }
-
       ul {
         padding: 0;
       }
@@ -170,10 +165,6 @@
 
   &__hearing-dates {
     text-align: center;
-
-    h2 {
-      @include sr-only;
-    }
   }
 
   &__approved-judgment {
@@ -182,10 +173,6 @@
 }
 
 .judgment-body {
-  h2 {
-    @include sr-only;
-  }
-
   h3 {
     font-size: 1rem;
   }


### PR DESCRIPTION
Copied from e52373ace751969bc36d7e1bdbe29bf8ff7c2b01 in ds-caselaw-public-ui
as this commit is required in this application as well.

## Trello card / Rollbar error (etc)

https://trello.com/c/tptkA4BN/46-missing-headings-in-html

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
