### PR TITLE
Download the Judgment PDF from the PRIVATE_ASSET_BUCKET

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -18,8 +18,8 @@
           {% if context.docx_url %}
             <a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a>
           {% endif %}
-          {% if context.has_pdf %}
-            <a href="{% url 'detail_pdf' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_pdf" %}</a>
+          {% if context.pdf_url %}
+            <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
           {% endif %}
           {% if context.is_failure %}
             <a class="judgment-toolbar__delete" href="{% url 'delete' %}?judgment_uri={{ context.judgment_uri }}">{% translate "judgment.delete" %}</a>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -2,9 +2,11 @@
 {% block content %}
 {% load i18n %}
    <aside class="judgment-info-component">
-    <a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a>
-    {% if context.has_pdf %}
-      <a href="{% url 'detail_pdf' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_pdf" %}</a>
+    {% if context.docx_url %}
+      <a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a>
+    {% endif %}
+    {% if context.pdf_url %}
+      <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
     {% endif %}
   </aside>
   <div class="edit-component">

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -1,23 +1,10 @@
-import os
 import re
-from unittest import mock, skip
-from unittest.mock import patch
+from unittest import skip
 
 from django.test import TestCase
 
 from judgments import converters, views
 from judgments.models import Judgment
-
-
-def mocked_requests_head(*args):
-    class MockResponse:
-        def __init__(self, status_code):
-            self.status_code = status_code
-
-    if "ewca/civ/2004/632" in args[0]:
-        return MockResponse(200)
-
-    return MockResponse(404)
 
 
 class TestJudgment(TestCase):
@@ -34,24 +21,6 @@ class TestJudgment(TestCase):
         decoded_response = response.content.decode("utf-8")
         self.assertIn("Judgment was not found", decoded_response)
         self.assertEqual(response.status_code, 404)
-
-    @patch.dict(
-        os.environ,
-        {"PUBLIC_ASSET_BUCKET": "public-asset-bucket", "S3_REGION": "eu-west-2"},
-        clear=True,
-    )
-    @mock.patch("requests.head", side_effect=mocked_requests_head)
-    def test_has_pdf_true(self, mock_head):
-        self.assertEqual(views.has_pdf("ewca/civ/2004/632"), True)
-
-    @patch.dict(
-        os.environ,
-        {"PUBLIC_ASSET_BUCKET": "public-asset-bucket", "S3_REGION": "eu-west-2"},
-        clear=True,
-    )
-    @mock.patch("requests.head", side_effect=mocked_requests_head)
-    def test_has_pdf_false(self, mock_head):
-        self.assertEqual(views.has_pdf("ewca/civ/2004/XXX"), False)
 
 
 class TestJudgmentModel(TestCase):

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -5,7 +5,6 @@ from . import views
 urlpatterns = [
     path("edit", views.EditJudgmentView.as_view(), name="edit"),
     path("detail", views.detail, name="detail"),
-    path("detail_pdf", views.detail_pdf, name="detail_pdf"),
     path("results", views.results, name="results"),
     path("delete", views.delete, name="delete"),
     path("", views.index, name="home"),


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

In an earlier PR we added the ability to download the Judgment PDF from the
public asset bucket. This is incorrect - editors shoud download the PDF from the
*private* asset bucket, so they can check it before publication.

We have refactored this to work more in line with downloading the docx -
rather than getting the PDF from the bucket and returning it in an HTTPResponse,
we can generate a presigned URL and download the PDF in the same way we download
the docx. This simplifies the views and urls considerably.

## Trello card / Rollbar error (etc)

https://trello.com/c/ScgjuPqS/608-ability-for-editors-to-download-pdf

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
