### PR TITLE
Add more explicit error messages for missing judgment XML or parser log

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -34,7 +34,7 @@ class EditJudgmentView(View):
             judgment_xml = api_client.get_judgment_xml(uri, show_unpublished=True)
             return ET.XML(bytes(judgment_xml, encoding="utf-8"))
         except MarklogicResourceNotFoundError:
-            raise Http404("Judgment was not found")
+            raise Http404(f"Judgment XML was not found at uri {uri}")
 
     def get_metadata(self, uri: str, judgment: ET.Element) -> dict:
         meta = dict()
@@ -149,8 +149,10 @@ def detail(request):
 
         if version_uri:
             context["version"] = re.search(r"([\d])-([\d]+)", version_uri).group(1)
-    except (MarklogicResourceNotFoundError, ClientError):
-        raise Http404("Judgment was not found")
+    except MarklogicResourceNotFoundError:
+        raise Http404(f"Judgment was not found at uri {judgment_uri}")
+    except ClientError:
+        raise Http404(f"Parser log was not found at for judgment at uri {judgment_uri}")
     template = loader.get_template("judgment/detail.html")
     return HttpResponse(template.render({"context": context}, request))
 
@@ -166,7 +168,7 @@ def delete(request):
 
         delete_documents(judgment_uri)
     except MarklogicResourceNotFoundError:
-        raise Http404("Judgment was not found")
+        raise Http404(f"Judgment was not found at uri {judgment_uri}")
 
     template = loader.get_template("judgment/deleted.html")
     return HttpResponse(template.render({"context": context}, request))

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -131,7 +131,10 @@ def detail(request):
     context = {"judgment_uri": judgment_uri, "is_failure": False}
     try:
         if "failures" in judgment_uri:
-            judgment = get_parser_log(judgment_uri)
+            try:
+                judgment = get_parser_log(judgment_uri)
+            except ClientError:
+                judgment = f"No parser.log found for {judgment_uri}"
             metadata_name = judgment_uri
             context["is_failure"] = True
         else:
@@ -151,8 +154,6 @@ def detail(request):
             context["version"] = re.search(r"([\d])-([\d]+)", version_uri).group(1)
     except MarklogicResourceNotFoundError:
         raise Http404(f"Judgment was not found at uri {judgment_uri}")
-    except ClientError:
-        raise Http404(f"Parser log was not found at for judgment at uri {judgment_uri}")
     template = loader.get_template("judgment/detail.html")
     return HttpResponse(template.render({"context": context}, request))
 


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

Some "failure" judgments are showing a 404 in the editor UI, which is not helpful for the editors as they are unable to move forward with resolving failed ingestions. 

Some of the 404s are being thrown because the uri does not exist in Marklogic. Some are being thrown because the parser.log (which helps diagnose ingester failures) does not exist.

If the parser.log does not exist, we should still show a page to the editors, allowing them to download the original judgment docx (if it exists). The second commit in this PR enables this (see screenshot).

The first commit gives some more explicit error reporting for the 404 pages. 

To fully resolve this ticket, we will also need to make some changes to the ingester code, so that editors are not sent an email if a document is not inserted into Marklogic. 

## Trello card / Rollbar error (etc)

Trello: https://trello.com/c/hfOotu2k

## Screenshots of UI changes:

### Before

### After

<img width="1598" alt="Screenshot 2022-06-14 at 12 28 00" src="https://user-images.githubusercontent.com/1089521/173566982-d3aad567-9be9-4f6c-b4ce-88d3241a8277.png">


<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
