### PR TITLE
Correct the transfer-consignment-reference property name

### DIFF
--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -73,7 +73,7 @@ def set_metadata(old_uri, new_uri):
         ("source-organisation", source_organisation),
         ("source-name", source_name),
         ("source-email", source_email),
-        ("transfer-consignment_reference", transfer_consignment_reference),
+        ("transfer-consignment-reference", transfer_consignment_reference),
         ("transfer-received-at", transfer_received_at),
     ]:
         if value is not None:


### PR DESCRIPTION
It's transfer-consignment-reference not transfer-consignment_reference

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
