### PR TITLE
Correctly handle a Marklogic Not Found error if a URI is *not* a duplicate

### DIFF
--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -170,7 +170,7 @@ class TestUtils(TestCase):
     def test_update_judgment_uri_success(self, fake_client):
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
         attrs = {
-            "get_judgment_xml.return_value": "",
+            "get_judgment_xml.side_effect": MarklogicAPIError,
             "copy_judgment.return_value": True,
             "delete_judgment.return_value": True,
         }

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -131,8 +131,6 @@ class EditJudgmentView(View):
                 return redirect(reverse("edit") + f"?judgment_uri={new_judgment_uri}")
 
             context["success"] = "Judgment successfully updated"
-            xml = self.get_judgment(judgment_uri)
-            context.update(self.get_metadata(judgment_uri, xml))
 
         except (MoveJudgmentError, NeutralCitationToUriError) as e:
             context[
@@ -142,6 +140,8 @@ class EditJudgmentView(View):
         except MarklogicAPIError as e:
             context["error"] = f"There was an error saving the Judgment: {e}"
 
+        xml = self.get_judgment(judgment_uri)
+        context.update(self.get_metadata(judgment_uri, xml))
         invalidate_caches(judgment_uri)
 
         return self.render(request, context)


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

https://trello.com/c/WxHIRUDZ

![image (4)](https://user-images.githubusercontent.com/1089521/176422322-af384c5a-13d0-4695-b300-a92d61f8bfdd.png)

In a previous commit, we were assuming that a Not Found response from Marklogic
would be returned as an empty judgment (""). However what is actually returned
is a MarklogicApiError.

We need to handle this response. if a MarklogicApiError is returned,
try to move the judgment to  new URI.

If a MarklogicApiError is *not* returned, we assume there is a judgment at that
URI, show an error to the editor informing them that there is already a judgment
at that URI, and do not attempt to move the "failure" judgment