### PR TITLE
Restore the Delete button for "failure" judgments

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -155,8 +155,10 @@ def detail(request):
     try:
         judgment_xml = api_client.get_judgment_xml(judgment_uri, show_unpublished=True)
         judgment_root = get_judgment_root(judgment_xml)
-        if "error" in judgment_root:
+        if "failures" in judgment_uri:
             context["is_failure"] = True
+
+        if "error" in judgment_root:
             judgment = judgment_xml
             metadata_name = judgment_uri
         else:


### PR DESCRIPTION
Trello: https://trello.com/c/ZfEJWIbN

In an earlier commit, we removed the "Delete" button for "failure" judgments
which had legitimate judgment content in them. We only showed the delete button
for judgments which were "total" failures (i.e. there was no judgment xml).

The thinking behind this was that once a judgment was edited and had a genuine
URI, the "failure" would be deleted behind the scenes.

However, it appears that some "failure" judgments are duplicates, and will not
be edited as there is already a judgment in Marklogic with that NCN/URI. These
judgments need to be deleted.

Therefore, restore the Delete button for any judgment with "failure" in the
URI.

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
