### PR TITLE
Guard against deleted judgments appearing in search results

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -210,7 +210,7 @@ def index(request):
         search_results = [
             SearchResult.create_from_node(result) for result in model.results
         ]
-        context["recent_judgments"] = search_results
+        context["recent_judgments"] = list(filter(None, search_results))
         context["paginator"] = paginator(int(page), model.total)
 
     except MarklogicResourceNotFoundError as e:


### PR DESCRIPTION




<!-- Amend as appropriate -->

## Changes in this PR:

Something I have noticed on dev/staging but not production - deleted judgments
appearing in the search results. I am not sure if Marklogic caches search
results? 

The effect has been a 500 error on the index page.

In the meantime this change guards against the side effects if this is the case.
If a judgment appears in search results, we try to build a SearchResult
model from it. If we cannot (because the judgment does not exist) a
MarklogicApiError is thrown, which we catch and return None.

If the list of SearchResult objects contains a None, filter it out before
the search results are rendered to the page.

## Trello card / Rollbar error (etc)

Rollbar: https://rollbar.com/dxw/tna-caselaw-editor-ui/items/50/

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
