### PR TITLE
(Fix) Restore the edit button for failure judgments

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -7,7 +7,7 @@
             {% endif %}
         </div>
         <div class="judgment-toolbar__edit">
-          {% if not context.is_failure %}
+          {% if context.is_editable %}
             {% if context.judgment  %}
               <a class="" href="{% url 'edit' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.edit_this_judgment" %}</a>
             {% else %}

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -160,10 +160,12 @@ def detail(request):
     try:
         judgment_xml = api_client.get_judgment_xml(judgment_uri, show_unpublished=True)
         judgment_root = get_judgment_root(judgment_xml)
+        context["is_editable"] = True
         if "failures" in judgment_uri:
             context["is_failure"] = True
 
         if "error" in judgment_root:
+            context["is_editable"] = False
             judgment = judgment_xml
             metadata_name = judgment_uri
         else:


### PR DESCRIPTION
In https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/247 we
restored the Delete button for `failure` judgments, but this had the unitended
side effect of removing the edit button. This fix is more robust - add
`failure` and `editable` flags for a judgment, because they can be both states.

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
