### PR TITLE
(Fix) When moving & retreiving items in S3, strip the leading slash from keys

### DIFF
--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -101,10 +101,14 @@ def set_metadata(old_uri, new_uri):
 def copy_assets(old_uri, new_uri):
     client = create_s3_client()
     bucket = env("PRIVATE_ASSET_BUCKET")
+    old_uri = old_uri.lstrip("/")
+    new_uri = new_uri.lstrip("/")
+
     response = client.list_objects(Bucket=bucket, Prefix=old_uri)
+
     for result in response.get("Contents", []):
         old_key = str(result["Key"])
-        new_key = build_new_key(old_key, new_uri.lstrip("/"))
+        new_key = build_new_key(old_key, new_uri)
         if new_key is not None:
             try:
                 source = {"Bucket": bucket, "Key": old_key}

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -425,6 +425,7 @@ def generate_docx_url(uri: str):
         return ""
 
     client = create_s3_client()
+    uri = uri.lstrip("/")
 
     key = f'{uri}/{uri.replace("/", "_")}.docx'
 
@@ -439,6 +440,7 @@ def generate_pdf_url(uri: str):
         return ""
 
     client = create_s3_client()
+    uri = uri.lstrip("/")
 
     key = f'{uri}/{uri.replace("/", "_")}.pdf'
 


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

While debugging the functionality to move assets around in S3 when a judgment is
moved, we found that the S3 moving & retrieval functions are very sensitive
to a leading slash on the uri. For example looking for a prefix of `/xxx/2022`
in S3 returns nothing but `xxx/2022` returns items.

Additionally, the docx/pdf URL generation will look for a filename with a leading
underscore if a leading slash is on the URI.

To mitigate this, strip the URI of a leading slash whenever we use it to
find items in S3.

## Trello card / Rollbar error (etc)

https://trello.com/c/cy2ZElXN

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
