### PR TITLE
Set "is_editable" to True on the edit view

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -67,6 +67,7 @@ class EditJudgmentView(View):
             )
             meta["source_name"] = api_client.get_property(uri, "source-name")
             meta["source_email"] = api_client.get_property(uri, "source-email")
+            meta["is_editable"] = True
         except JudgmentMissingMetadataError:
             meta[
                 "error"


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

Because if we're on the Edit view, the judgment is editable.

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
