### PR TITLE
Set internal URI in judgments when they are moved to a new URI

### DIFF
--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -57,6 +57,7 @@ def update_judgment_uri(old_uri, new_citation):
             api_client.copy_judgment(old_uri, new_uri)
             set_metadata(old_uri, new_uri)
             copy_assets(old_uri, new_uri)
+            api_client.set_judgment_this_uri(new_uri)
         except MarklogicAPIError as e:
             raise MoveJudgmentError(
                 f"Failure when attempting to copy judgment from {old_uri} to {new_uri}: {e}"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests-toolbelt~=0.9.1
 lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=4.6.0
+ds-caselaw-marklogic-api-client~=4.7.0
 ds-caselaw-utils
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION

## Changes in this PR:

When a "failure" judgment is moved to a new URI in Marklogic, set the new
URI in the judgment XML. This is so that the URI can be used to build the src
URL for images inside the document.

v4.7.0 of the API Client contains the method `set_judgment_this_uri` to achieve
this.

<!-- Amend as appropriate -->


## Trello card / Rollbar error (etc)

https://trello.com/c/RMFrsylw

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
