### PR TITLE
Bump API Client version to 4.7.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests-toolbelt~=0.9.1
 lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=4.7.0
+ds-caselaw-marklogic-api-client~=4.7.1
 ds-caselaw-utils
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
Bumping the version fixes a problem with FRBRUri and FRBRThis

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
