### PR TITLE
(Fix) Publish assets for moved "failure" judgments

### DIFF
--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -102,8 +102,8 @@ def set_metadata(old_uri, new_uri):
 def copy_assets(old_uri, new_uri):
     client = create_s3_client()
     bucket = env("PRIVATE_ASSET_BUCKET")
-    old_uri = old_uri.lstrip("/")
-    new_uri = new_uri.lstrip("/")
+    old_uri = uri_for_s3(old_uri)
+    new_uri = uri_for_s3(new_uri)
 
     response = client.list_objects(Bucket=bucket, Prefix=old_uri)
 
@@ -141,3 +141,7 @@ def create_s3_client():
         region_name=env("PRIVATE_ASSET_BUCKET_REGION", default=None),
         config=botocore.client.Config(signature_version="s3v4"),
     )
+
+
+def uri_for_s3(uri: str):
+    return uri.lstrip("/")

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -374,6 +374,7 @@ def publish_documents(uri: str) -> None:
     public_bucket = env("PUBLIC_ASSET_BUCKET")
     private_bucket = env("PRIVATE_ASSET_BUCKET")
 
+    uri = uri.lstrip('/')
     response = client.list_objects(Bucket=private_bucket, Prefix=uri)
 
     for result in response.get("Contents", []):
@@ -391,6 +392,7 @@ def publish_documents(uri: str) -> None:
 
 
 def unpublish_documents(uri: str) -> None:
+    uri = uri.lstrip('/')
     delete_from_bucket(uri, env("PUBLIC_ASSET_BUCKET"))
 
 

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import re
 import time
@@ -381,7 +382,12 @@ def publish_documents(uri: str) -> None:
         if not key.endswith("parser.log") and not key.endswith(".tar.gz"):
             source = {"Bucket": private_bucket, "Key": key}
             extra_args = {"ACL": "public-read"}
-            client.copy(source, public_bucket, key, extra_args)
+            try:
+                client.copy(source, public_bucket, key, extra_args)
+            except botocore.client.ClientError as e:
+                logging.warning(
+                    f"Unable to copy file {key} to new location {public_bucket}, error: {e}"
+                )
 
 
 def unpublish_documents(uri: str) -> None:


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

The background: When moving a "failure" judgment from a failure URI to a
real, NCN-generated URI, the judgment's assets (docx, pdf and images) were
moving to a new prefix in the unpublished assets bucket. But when publishing
the judgment, the assets were not being copied into the published assets bucket.

At first we thought this was due to permissions or encryption on the new
assets. Possibly caused by something to do with permissions differences
between an object created with PutObject, vs an object created with CopyObject.

After much digging, we discovered that the assets were not being published
because the call to `client.list_objects` in `publish_documents()` was always
returning an empty array.

After even more digging, we discovered that `list_objects` doesn't recognise
bucket prefixes that start with a leading slash `/`. Trailing slashes are
fine but leading slashes are not.

For now, trim the leading slash wherever we perform the `list_objects`
action on a bucket.

TODO: standardise URIs *everywhere*, so we have no adding/removing slashes shenanigans. 

## Trello card / Rollbar error (etc)

https://trello.com/c/Cg0efVdm

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
