### PR TITLE
Bump version of ds-caselaw-utils

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=4.7.1
-ds-caselaw-utils
+ds-caselaw-utils~=0.1.4
 rollbar
 django-stronghold==0.4.0
 boto3==1.21.45


### PR DESCRIPTION

<!-- Amend as appropriate -->

## Changes in this PR:

Bump the version of ds-caselaw-utils to enable the new GRC subdivision of the
UKFTT tribunal.

## Trello card / Rollbar error (etc)

To fix https://trello.com/c/pd72ON4g



## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
