### PR TITLE
Add breadcrumbs and back links on 404/403/500 pages

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_header.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_header.scss
@@ -24,6 +24,7 @@
       display: inline-block;
       position: relative;
       margin-right: calc($spacer__unit / 2);
+      color: $color__white;
 
       &:not(:nth-child(1)) {
         padding-left: $spacer__unit;

--- a/ds_caselaw_editor_ui/templates/403.html
+++ b/ds_caselaw_editor_ui/templates/403.html
@@ -3,7 +3,21 @@
 {% block title %}Forbidden (403){% endblock %}
 
 {% block content %}
-<h1>Forbidden (403)</h1>
+  <header class="page-header">
+      <div class="page-header__breadcrumb">
+      <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
+      <span class="page-header__breadcrumb-you-are-in">You are in: </span>
+        <ol>
+          <li><a href="{% url 'home' %}">Find case law</a></li>
+          <li>Forbidden</li>
+        </ol>
+      </nav>
+    </div>
+  </header>
+  <div class="standard-text-template">
+    <h1>Forbidden (403)</h1>
 
-<p>{% if exception %}{{ exception }}{% else %}Access to this page is forbidden.{% endif %}</p>
+    <p>{% if exception %}{{ exception }}{% else %}Access to this page is forbidden.{% endif %}</p>
+    <p><a href="{% url 'home' %}">Return to Find case law</a></p>
+  </div>
 {% endblock content %}

--- a/ds_caselaw_editor_ui/templates/404.html
+++ b/ds_caselaw_editor_ui/templates/404.html
@@ -3,7 +3,22 @@
 {% block title %}Page not found{% endblock %}
 
 {% block content %}
-<h1>Page not found</h1>
+  <header class="page-header">
+      <div class="page-header__breadcrumb">
+      <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
+      <span class="page-header__breadcrumb-you-are-in">You are in: </span>
+        <ol>
+          <li><a href="{% url 'home' %}">Find case law</a></li>
+          <li>Page not found</li>
+        </ol>
+      </nav>
+    </div>
+  </header>
 
-<p>{% if exception %}{{ exception }}{% else %}Sorry, this page could not be found.{% endif %}</p>
+  <div class="standard-text-template">
+    <h1>Page not found</h1>
+
+    <p>{% if exception %}{{ exception }}{% else %}Sorry, this page could not be found.{% endif %}</p>
+    <p><a href="{% url 'home' %}">Return to Find case law</a></p>
+  </div>
 {% endblock content %}

--- a/ds_caselaw_editor_ui/templates/500.html
+++ b/ds_caselaw_editor_ui/templates/500.html
@@ -3,7 +3,22 @@
 {% block title %}Server Error{% endblock %}
 
 {% block content %}
-<h1>internal Server Error</h1>
+  <header class="page-header">
+      <div class="page-header__breadcrumb">
+      <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
+      <span class="page-header__breadcrumb-you-are-in">You are in: </span>
+        <ol>
+          <li><a href="{% url 'home' %}">Find case law</a></li>
+          <li>Server error</li>
+        </ol>
+      </nav>
+    </div>
+  </header>
 
-<p>Sorry, there seems to be an error. Please try again soon.</p>
+  <div class="standard-text-template">
+    <h1>Internal Server Error</h1>
+
+    <p>Sorry, there seems to be an error. Please try again soon.</p>
+    <p><a href="{% url 'home' %}">Return to Find case law</a></p>
+  </div>
 {% endblock content %}


### PR DESCRIPTION
The error pages in the application offered no way for a user to return
to the Find case law homepage. Add a breadcrumb & a link back to the main
site on these pages.

Trello: https://trello.com/c/vcqbPLxF

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
