### PR TITLE
Bump ds-caselaw-marklogic-api-client to 4.8.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests-toolbelt~=0.9.1
 lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=4.7.1
+ds-caselaw-marklogic-api-client~=4.8.0
 ds-caselaw-utils~=0.1.4
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
This version bump enables editors to edit judgment & tribunal dates
while preserving the correct `name` attribute for the date in the XML.

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
