### PR TITLE
Add CSS sharing to `fab run`

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -75,6 +75,15 @@ def run(c):
     django_exec("python manage.py migrate")
     django_exec("rm -rf /app/staticfiles")
     django_exec("python manage.py collectstatic")
+    # Get the public-ui version of _judgment_text.scss
+    django_exec("apt-get update && apt-get install -y jq curl")
+    django_exec(
+        "curl https://raw.githubusercontent.com/nationalarchives/ds-caselaw-public-ui/"
+        "$(curl -H 'Accept: application/vnd.github+json' "
+        "https://api.github.com/repos/nationalarchives/ds-caselaw-public-ui/releases/latest | jq -r .tag_name)"
+        "/ds_judgements_public_ui/sass/includes/_judgment_text.scss "
+        "-o ds_caselaw_editor_ui/sass/includes/_judgment_text.scss"
+    )
     # Piping Marklogic logs to marklogic.log
     try:
         local("docker logs marklogic > marklogic.log")


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

In https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/355 we added shared CSS from ds-caselaw-public-ui to this repository via the Dockerfile.

However, some of the developers found that they were unable to see the shared CSS when running the application with `fab run`. `fab build` and `fab start` build and run the Docker containers using the Dockerfile and retrieve the latest version of the CSS every time they are run. But `fab run` is more "lightweight" and does not retrieve the latest CSS every time.

Amend `fab run` to explicitly get the CSS from public-ui, so that developers using this command to run the application always get the most recent version of the shared CSS.

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
