### PR TITLE
Bump the API Client version to 4.10.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests-toolbelt~=0.9.1
 lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=4.8.0
+ds-caselaw-marklogic-api-client~=4.10.0
 ds-caselaw-utils~=0.1.6
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
Among other things, this version bump ensures the editor UI is using the renamed XSLT file in Marklogic, `accessible-html.xsl`

