### PR TITLE
Add King's Bench Division to Subdivision converter

### DIFF
--- a/judgments/converters.py
+++ b/judgments/converters.py
@@ -35,7 +35,7 @@ class CourtConverter:
 
 
 class SubdivisionConverter:
-    regex = "civ|crim|admin|admlty|ch|comm|costs|fam|ipec|mercantile|pat|qb|tcc"
+    regex = "civ|crim|admin|admlty|ch|comm|costs|fam|ipec|mercantile|pat|qb|kb|tcc"
 
     def to_python(self, value):
         return value


### PR DESCRIPTION
Double of https://github.com/nationalarchives/ds-caselaw-public-ui/pull/366.  Shouldn't break anything if there's no King's Bench stuff or the other layers of the King's Bench search aren't installed. (see https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/87)