### PR TITLE
Use SNS Message correctly, by not using MessageStructure

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -415,6 +415,10 @@ def notify_changed(uri: str, status: str, name: str, enrich: bool = False) -> No
         "DataType": "String",
         "StringValue": status,
     }
+    message_attributes["uri_reference"] = {
+        "DataType": "String",
+        "StringValue": uri,
+    }
     if enrich:
         message_attributes["trigger_enrichment"] = {
             "DataType": "String",
@@ -423,8 +427,7 @@ def notify_changed(uri: str, status: str, name: str, enrich: bool = False) -> No
 
     client.publish(
         TopicArn=env("SNS_TOPIC"),
-        MessageStructure="json",
-        Message=json.dumps({"uri_reference": uri, "status": status, "default": ""}),
+        Message=json.dumps({"uri_reference": uri, "status": status}),
         Subject=f"{name} updated: {status}",
         MessageAttributes=message_attributes,
     )


### PR DESCRIPTION
The MessageStructure being set to JSON means that there are multiple messages, customised for each format. We just want to send one type of message to all users, which just *happens* to be JSON, so we shouldn't set MessageStructure. The blank "default" key was just setting the Message to be blank for all non-recognised users (which was everyone.)

We've also added `uri_reference` to the MessageAttributes. This was mostly added as it was a way of potentially getting the data out in some format until I understood what was wrong, but it'll also let people subscribe to "uri starts with /ewhc/2022" which is useful.

### After (via script/show_sns.sh)
```{
    "Messages": [
        {
            "MessageId": "981c6d4c-42f1-4e04-8021-8c692f9c267e",
            "ReceiptHandle": "N2IwYjJkMzYtYjdmZS00ZjdiLWI1Y2QtMmRiYWQ3MDFiY2YzIGFybjphd3M6c3FzOnVzLWVhc3QtMTowMDAwMDAwMDAwMDA6ZHVtbXktcXVldWUgOTgxYzZkNGMtNDJmMS00ZTA0LTgwMjEtOGM2OTJmOWMyNjdlIDE2NjQ5NzI1ODguOTY5NzMx",
            "MD5OfBody": "38495d7c60c32b0bbd23a0ce43795c29",
            "Body": "{\"Type\": \"Notification\", \"MessageId\": \"16c4850f-d962-4047-b05b-5cb4671fa255\", \"TopicArn\": \"arn:aws:sns:us-east-1:000000000000:caselaw-stg-judgment-updated\", \"Message\": \"{\\\"uri_reference\\\": \\\"ewhc/fam/2022/2146\\\", \\\"status\\\": \\\"published\\\"}\", \"Timestamp\": \"2022-10-05T12:22:31.264Z\", \"SignatureVersion\": \"1\", \"Signature\": \"EXAMPLEpH+..\", \"SigningCertURL\": \"https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem\", \"Subject\": \"A LOCAL AUTHORITY v THE MOTHER updated: published\"}"
        }
    ]
}
```
