### PR TITLE
Fix: Strip whitespace from around NCN

### DIFF
--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -260,6 +260,25 @@ class TestUtils(TestCase):
         assert result == "new/uri"
 
     @patch("judgments.utils.api_client")
+    @patch("boto3.session.Session.client")
+    def test_update_judgment_uri_strips_whitespace(
+        self, fake_boto3_client, fake_api_client
+    ):
+        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
+        api_attrs = {
+            "get_judgment_xml.side_effect": MarklogicAPIError,
+            "copy_judgment.return_value": True,
+            "delete_judgment.return_value": True,
+        }
+        fake_api_client.configure_mock(**api_attrs)
+        boto_attrs = {"list_objects.return_value": []}
+        fake_boto3_client.configure_mock(**boto_attrs)
+
+        update_judgment_uri("old/uri", " [2002] EAT 1 ")
+
+        ds_caselaw_utils.neutral_url.assert_called_with("[2002] EAT 1")
+
+    @patch("judgments.utils.api_client")
     def test_update_judgment_uri_exception_copy(self, fake_client):
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
         attrs = {

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -40,7 +40,7 @@ def get_judgment_root(judgment_xml) -> str:
 
 
 def update_judgment_uri(old_uri, new_citation):
-    new_uri = caselawutils.neutral_url(new_citation)
+    new_uri = caselawutils.neutral_url(new_citation.strip())
     if new_uri is None:
         raise NeutralCitationToUriError(
             f"Unable to form new URI for {old_uri} from neutral citation: {new_citation}"


### PR DESCRIPTION
Trello: https://trello.com/c/cXbWogEp/1053-issue-editing-a-judgment

An editor was having trouble editing the NCN for a failed judgment. It appears the NCN they were pasting into the form had a trailing space, which was not being stripped, and was causing the call to ds_caselaw_utils.neutral_uri() to fail.

Trim any leading or trailing whitespace from the NCN before sending it to ds_caselaw_utils.neutral_uri()

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
