### PR TITLE
Assign documents to editors

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_unpublished_judgments.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_unpublished_judgments.scss
@@ -65,7 +65,7 @@
     }
   }
 
-  &__court, &__submitter, &__submitteremail,  &__submissiondate, &__consignmentrefence {
+  &__court, &__submitter, &__submitteremail,  &__submissiondate, &__consignmentrefence, &__assignedto {
     display: block;
     font-size: 0.9rem;
     color: $color__dark-grey;

--- a/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
+++ b/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
@@ -46,6 +46,10 @@
           <span class="unpublished-judgments__consignmentrefence">
             {% translate "judgments.consignmentref" %} {{ item.meta.consignment_reference }}
           </span>
+          <span class="unpublished-judgments__assignedto">
+            {% translate "judgments.assignedto" %} {{ item.meta.assigned_to|default:"no-one" }}
+          </span>
+
         </span>
       </li>
       {% endfor %}

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -62,6 +62,15 @@
           <input type="checkbox" class="edit-component__anonymised-input" {% if context.anonymised %}checked{% endif %} name="anonymised" id="anonymised"/>
         </div>
         <div class="edit-component__panel">
+          <label for="assigned_to">{% translate "judgment.assigned_to" %}</label>
+          <select class="edit-component__assigned_to-input" name="assigned_to" id="assigned_to">
+            <option value="" {% if context.assigned_to == "" %}selected{% endif %}>{% translate "judgments.noone" %}</option>
+            {% for user in context.users %}
+            <option value="{{user.name}}"{% if context.assigned_to == user.name %} selected{% endif %}>{{user.print_name}}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="edit-component__panel">
           <input type="hidden" name="judgment_uri" value="{{context.judgment_uri}}"/>
           <input type="submit" value="Save"/>
         </div>

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -102,7 +102,7 @@ class SearchResult:
             )
         except caselawclient.Client.MarklogicAPIError as e:
             logging.warning(
-                f"Deleted item uri: {uri} in search results. Full error: {e}"
+                f"Unable to create search result for {uri}. Has it been deleted? Full error: {e}"
             )
             return None
 

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -16,6 +16,7 @@ class SearchResultMeta:
         author_email="",
         consignment_reference="",
         submission_datetime="",
+        assigned_to="",
     ):
         self.author = author
         self.author_email = author_email
@@ -25,6 +26,7 @@ class SearchResultMeta:
             if submission_datetime
             else datetime.min
         )
+        self.assigned_to = assigned_to
 
     @staticmethod
     def create_from_uri(uri: str):
@@ -35,6 +37,7 @@ class SearchResultMeta:
                 uri, "transfer-consignment-reference"
             ),
             submission_datetime=api_client.get_property(uri, "transfer-received-at"),
+            assigned_to=api_client.get_property(uri, "assigned-to"),
         )
 
 
@@ -48,6 +51,7 @@ class SearchResult:
         date="",
         matches=[],
         meta=SearchResultMeta(),
+        assigned_to="",
     ) -> None:
         self.uri = uri
         self.neutral_citation = neutral_citation

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -84,9 +84,8 @@ class TestSearchResults(TestCase):
 
 class TestSearchResultModel(TestCase):
     @patch("judgments.models.SearchResultMeta")
-    def test_create_from_node(self, fake_model):
-        model_attrs = {"create_from_uri.return_value": "a/fake/uri.xml"}
-        fake_model.configure_mock(**model_attrs)
+    def test_create_from_node(self, fake_meta):
+        fake_meta.create_from_uri.return_value.assigned_to = "someone"
         search_result_str = """
         <search:result xmlns:search="http://marklogic.com/appservices/search" index="1" uri="/ukut/lc/2022/241.xml">
             <search:snippet/>
@@ -110,6 +109,7 @@ class TestSearchResultModel(TestCase):
         self.assertEqual("ukut/lc/2022/241", search_result.uri)
         self.assertEqual("[2022] UKUT 241 (LC)", search_result.neutral_citation)
         self.assertEqual("UKUT-LC", search_result.court)
+        self.assertEqual("someone", search_result.meta.assigned_to)
 
     @patch("judgments.models.SearchResultMeta")
     def test_create_from_node_with_missing_elements(self, fake_model):

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -163,7 +163,7 @@ msgstr "Previous versions of this Judgment"
 
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:67
 msgid "judgment.assigned_to"
-msgstr "Assigned to:"
+msgstr "Assigned to"
 
 #: ds_caselaw_editor_ui/templates/includes/recent_judgments.html:5
 msgid "home.recent"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -161,6 +161,10 @@ msgstr "This Judgment has been anonymised"
 msgid "judgment.previous_versions"
 msgstr "Previous versions of this Judgment"
 
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:67
+msgid "judgment.assigned_to"
+msgstr "Assigned to:"
+
 #: ds_caselaw_editor_ui/templates/includes/recent_judgments.html:5
 msgid "home.recent"
 msgstr "Unpublished judgments"
@@ -180,6 +184,14 @@ msgstr "Submission date:"
 #: ds_caselaw_editor_ui/templates/includes/recent_judgments.html:36
 msgid "judgments.consignmentref"
 msgstr "Consignment Reference:"
+
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:50
+msgid "judgments.assignedto"
+msgstr "Assigned to:"
+
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:50
+msgid "judgments.noone"
+msgstr "No one"
 
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:5
 msgid "judgment.download_docx"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 addopts = --ds=config.settings.test --reuse-db
 python_files = tests.py test_*.py
+filterwarnings = ignore:.*The providing_args argument is deprecated.*


### PR DESCRIPTION
## Changes in this PR:
We add a property `assigned-to` to the database which can be set to the django username of an editor. No locking etc. takes place.

## Screenshots of UI changes:

### After

<img width="982" alt="image" src="https://user-images.githubusercontent.com/85497046/196737843-bb8ce4de-f692-46e4-abc3-97a019439d89.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/85497046/196722387-d8eea422-da39-4814-96fd-bc4660122f37.png">