### PR TITLE
Allow XML download of judgment

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
@@ -58,7 +58,7 @@
     }
 
     @media (min-width: $grid__breakpoint-medium) {
-      max-width: 46rem;
+      max-width: 51rem;
     }
   }
 }

--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -21,6 +21,7 @@
           {% if context.pdf_url %}
             <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
           {% endif %}
+          <a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_xml" %}</a>
           {% if context.is_failure %}
             <a class="judgment-toolbar__delete" href="{% url 'delete' %}?judgment_uri={{ context.judgment_uri }}">{% translate "judgment.delete" %}</a>
           {% endif %}

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -5,6 +5,7 @@ from . import views
 urlpatterns = [
     path("edit", views.EditJudgmentView.as_view(), name="edit"),
     path("detail", views.detail, name="detail"),
+    path("xml", views.detail_xml, name="detail_xml"),
     path("results", views.results, name="results"),
     path("delete", views.delete, name="delete"),
     path("", views.index, name="home"),

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -188,6 +188,7 @@ def detail(request):
     judgment_uri = params.get("judgment_uri", None)
     version_uri = params.get("version_uri", None)
     context = {"judgment_uri": judgment_uri, "is_failure": False}
+
     try:
         judgment_xml = api_client.get_judgment_xml(judgment_uri, show_unpublished=True)
         judgment_root = get_judgment_root(judgment_xml)
@@ -222,6 +223,19 @@ def detail(request):
         raise Http404(f"Judgment was not found at uri {judgment_uri}, {e}")
     template = loader.get_template("judgment/detail.html")
     return HttpResponse(template.render({"context": context}, request))
+
+
+def detail_xml(request):
+    params = request.GET
+    judgment_uri = params.get("judgment_uri", None)
+    try:
+        judgment_xml = api_client.get_judgment_xml(judgment_uri, show_unpublished=True)
+    except MarklogicResourceNotFoundError as e:
+        raise Http404(f"Judgment was not found at uri {judgment_uri}, {e}")
+
+    response = HttpResponse(judgment_xml, content_type="application/xml")
+    response["Content-Disposition"] = f"attachment; filename={judgment_uri}.xml"
+    return response
 
 
 def delete(request):

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -200,6 +200,9 @@ msgstr "Download the original judgment"
 msgid "judgment.download_pdf"
 msgstr "Download PDF"
 
+msgid "judgment.download_xml"
+msgstr "Download XML"
+
 #: ds_caselaw_editor_ui/templates/judgment/deleted.html:13
 msgid "judgment.deleted"
 msgstr "Judgment successfully deleted"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

A quick button/hackable URL to enable download of the XML for a judgment from the editor.

This can be made nicer in Editor2.0!!

## Trello card / Rollbar error (etc)

https://trello.com/c/5YX4JwZ9/1106-add-ability-to-see-xml-in-editor-site-editorfindcaselaw

<img width="1176" alt="Screenshot 2022-10-24 at 16 03 54" src="https://user-images.githubusercontent.com/1089521/197559626-78a77d03-029a-436d-9ae9-87d14c1dceb7.png">
