### PR TITLE
Bump version of caselaw-utils to include new tribunals

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=5.0.0
-ds-caselaw-utils~=0.1.6
+ds-caselaw-utils~=0.3.2
 rollbar
 django-stronghold==0.4.0
 boto3==1.21.45


### PR DESCRIPTION
## Changes in this PR:

Fairly self explanatory - this fixes the filters for upper tier tribunals and brings in the new lower tier tribunals to the list and filters