### PR TITLE
Overhaul metadata collection and display assignment details in index page

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
+++ b/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
@@ -72,14 +72,13 @@
                       {{ item.meta.author }}
                     </span>
                   </li>
-                  <!--
                   <li>
 
                     <span class="unpublished-judgments__judgment-details-meta-key">
                       {% translate "judgments.assigned_to" %}
                     </span>
                     <span class="unpublished-judgments__judgment-details-meta-value">
-                      TODO: display value
+                      {{item.meta.assigned_to}}
                       <form action="/assign" method="post">
                         {% csrf_token %}
                         <input type="hidden" name="judgment_uri" value="{{item.uri}}">
@@ -88,7 +87,6 @@
 
                     </span>
                   </li>
-                  -->
                 </ul>
               </div>
               <div class="unpublished-judgments__judgment-submitted">

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -10,7 +10,7 @@ from lxml import etree
 
 import judgments
 from judgments import converters, views
-from judgments.models import SearchResult
+from judgments.models import SearchResult, SearchResultMeta
 from judgments.utils import build_new_key, get_judgment_root, update_judgment_uri
 from judgments.views import extract_version, render_versions
 
@@ -80,6 +80,25 @@ class TestSearchResults(TestCase):
             order="date", only_unpublished=True, page="1"
         )
         assert b"<option value=\"date\" selected='selected'>" in response.content
+
+
+class TestSearchResultMeta(TestCase):
+    def test_create_from_node(self):
+        meta_str = """
+        <property-results>
+          <property-result uri="/ukut/lc/2022/241.xml">
+            <source-name>Fireman Sam</source-name>
+            <transfer-consignment-reference>TDR-2022-BAG</transfer-consignment-reference>
+            <transfer-received-at>2022-09-09T09:18:45Z</transfer-received-at>
+            <assigned-to>dragon</assigned-to>
+          </property-result>
+        </property-results>
+        """
+        metadata = SearchResultMeta.create_from_node(etree.fromstring(meta_str))
+        assert metadata.author == "Fireman Sam"
+        assert metadata.author_email == ""  # most things default to empty string
+        assert metadata.assigned_to == "dragon"
+        assert metadata.editor_priority == "20"  # default priority, medium
 
 
 class TestSearchResultModel(TestCase):

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -276,6 +276,7 @@ def index(request):
         search_results = [
             SearchResult.create_from_node(result) for result in model.results
         ]
+
         context["recent_judgments"] = list(filter(None, search_results))
         context["count_judgments"] = model.total
         context["paginator"] = paginator(int(page), model.total)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests-toolbelt~=0.9.1
 lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=5.0.0
+ds-caselaw-marklogic-api-client~=5.1.1
 ds-caselaw-utils~=0.3.2
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
Uses the new get_metadata_for_search_results to populate via existing metadata structure - requires version 5.1.1 of the custom-api-client.

Makes ten calls per page rather than sixty; this could be one if we pass the pages urls all at once.

## Trello card / Rollbar error (etc)
https://trello.com/c/m8KuGSEk/33-%F0%9F%91%A9%F0%9F%92%BBeui-assign-judgments-http-endpoint

## Screenshots of UI changes:
<img width="392" alt="image" src="https://user-images.githubusercontent.com/85497046/199295762-0e3bb8c8-e649-4af4-8186-0db052bd6b47.png">

