### PR TITLE
Hold judgments button and new/in progress/held status

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
+++ b/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
@@ -104,6 +104,22 @@
                       </form>
                     </span>
                   </li>
+                  <li>
+                    <span class="unpublished-judgments__judgment-details-meta-key">
+                      {% translate "judgments.editor_status" %}
+                    </span>
+                    <span class="unpublished-judgments__judgment-details-meta-value">
+                      {{item.meta.editor_status}}
+                      {% if item.meta.assigned_to %}
+                      <form action="/hold" method="post">
+                        {% csrf_token %}
+                        <input type="hidden" name="judgment_uri" value="{{item.uri}}">
+                        <input type="hidden" name="hold" value="{% if item.meta.editor_hold == 'true' %}false{% else %}true{% endif %}">
+                        <input type="submit" name="submit" value="{% if item.meta.editor_hold == 'true' %}Release{% else %}Hold{% endif %} judgment">
+                      </form>
+                      {% endif %}
+                    </span>
+                  </li>
                 </ul>
               </div>
               <div class="unpublished-judgments__judgment-submitted">

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -37,8 +37,15 @@ class SearchResultMeta:
             else datetime.min
         )
         self.assigned_to = assigned_to
-        self.editor_hold = editor_hold
+        self.editor_hold = editor_hold or "false"
         self.editor_priority = editor_priority
+
+        if editor_hold == "true":
+            self.editor_status = "hold"
+        elif assigned_to:
+            self.editor_status = "in progress"
+        else:
+            self.editor_status = "new"
 
     @staticmethod
     def create_from_uri(uri: str):

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -100,6 +100,39 @@ class TestSearchResultMeta(TestCase):
         assert metadata.assigned_to == "dragon"
         assert metadata.editor_priority == "20"  # default priority, medium
 
+    def test_editor_status(self):
+        assigned = """
+        <property-results>
+          <property-result uri="/ukut/lc/2022/241.xml">
+            <assigned-to>dragon</assigned-to>
+          </property-result>
+        </property-results>
+        """
+        unassigned = """
+        <property-results>
+          <property-result uri="/ukut/lc/2022/241.xml">
+          </property-result>
+        </property-results>
+        """
+
+        held = """
+        <property-results>
+          <property-result uri="/ukut/lc/2022/241.xml">
+            <assigned-to>dragon</assigned-to>
+            <editor-hold>true</editor-hold>
+          </property-result>
+        </property-results>
+        """
+        metadata = SearchResultMeta.create_from_node(etree.fromstring(assigned))
+        assert metadata.editor_status == "in progress"
+        assert metadata.editor_hold == "false"
+        metadata = SearchResultMeta.create_from_node(etree.fromstring(unassigned))
+        assert metadata.editor_status == "new"
+        assert metadata.editor_hold == "false"
+        metadata = SearchResultMeta.create_from_node(etree.fromstring(held))
+        assert metadata.editor_status == "hold"
+        assert metadata.editor_hold == "true"
+
 
 class TestSearchResultModel(TestCase):
     @patch("judgments.models.SearchResultMeta")

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path("delete", views.delete, name="delete"),
     path("assign", views.assign_judgment_button, name="assign"),
     path("prioritise", views.prioritise_judgment_button, name="prioritise"),
+    path("hold", views.hold_judgment_button, name="hold"),
     path("", views.index, name="home"),
 ]

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -259,6 +259,22 @@ def delete(request):
     return HttpResponse(template.render({"context": context}, request))
 
 
+def hold_judgment_button(request):
+    judgment_uri = request.POST["judgment_uri"]
+    # we probably shouldn't hold if the judgment isn't assigned but we won't check
+    hold = request.POST["hold"]
+    if hold not in ["false", "true"]:
+        raise RuntimeError("Hold value must be '0' or '1'")
+    api_client.set_property(judgment_uri, "editor-hold", hold)
+    target_uri = request.META.get("HTTP_REFERER") or "/"
+    if hold == "true":
+        word = "held"
+    else:
+        word = "released"
+    messages.success(request, f"Judgment {word}.")
+    return redirect(target_uri)
+
+
 def assign_judgment_button(request):
     judgment_uri = request.POST["judgment_uri"]
     api_client.set_property(judgment_uri, "assigned-to", request.user.username)

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -108,6 +108,9 @@ msgstr "Assigned to:"
 msgid "judgments.editor_priority"
 msgstr "Priority:"
 
+msgid "judgments.editor_status"
+msgstr "Status:"
+
 #: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:84
 msgid "judgments.allrecent"
 msgstr "See all recent judgments"


### PR DESCRIPTION
## Changes in this PR:
Add 'hold judgment' button, display status. No sort/filter.

## Trello card / Rollbar error (etc)
https://trello.com/b/OYgnaYZc/find-case-law-beta

## Screenshots of UI changes:
<img width="177" alt="image" src="https://user-images.githubusercontent.com/85497046/199543751-5d78c240-c4ca-44c0-8974-77c114c31c8b.png">
<img width="181" alt="image" src="https://user-images.githubusercontent.com/85497046/199543849-1394f373-273a-4005-8a63-8ead4509b46f.png">
<img width="114" alt="image" src="https://user-images.githubusercontent.com/85497046/199543978-831501ea-4eea-4baf-a3fe-0e2078dc06fc.png">