### PR TITLE
Bump the version of ds-caselaw-utils

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=5.1.1
-ds-caselaw-utils~=0.3.2
+ds-caselaw-utils~=0.4.1
 rollbar
 django-stronghold==0.4.0
 boto3==1.21.45


### PR DESCRIPTION
To fix https://trello.com/c/shEyapgh

Two of the canonical params for Court of Appeal courts were incorrect, they were ecwa instead of ewca

