### PR TITLE
Bump APIClient version to 5.1.2 and remove all references to XMLTools

### DIFF
--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -390,7 +390,6 @@ class TestUtils(TestCase):
 class TestJudgmentEditor(TestCase):
     @patch("judgments.views.api_client")
     def test_assigned(self, mock_api):
-        mock_api.get_judgment_xml.return_value = "<x>Kitten</x>"
         mock_api.get_published.return_value = "6"
         mock_api.get_sensitive.return_value = "6"
         mock_api.get_supplemental.return_value = "6"
@@ -402,6 +401,5 @@ class TestJudgmentEditor(TestCase):
         User.objects.get_or_create(username="otheruser")[0]
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])
         response = self.client.get("/edit?judgment_uri=ewhc/ch/1999/1")
-        mock_api.get_judgment_xml.assert_called()
         mock_api.get_property.assert_called_with("ewhc/ch/1999/1", "assigned-to")
         assert b"selected>otheruser" in response.content

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests-toolbelt~=0.9.1
 lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=5.1.1
+ds-caselaw-marklogic-api-client~=5.1.2
 ds-caselaw-utils~=0.4.1
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
XMLTools in the API Client is deprecated. Since we bumped to version 5.1.1 we have been seeing deprecation warnings in the EUI logs.

In order to remove all references to XMLTools, we had to fix some of the API methods in the client (see https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/96)

We now retrieve all metadata for a judgment via API Client calls, not via extracting the values from the judgment XML using XMLTools.

