### PR TITLE
Update API Client to avoid errors when editing metadata

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests-toolbelt~=0.9.1
 lxml~=4.8.0
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=5.1.2
+ds-caselaw-marklogic-api-client~=5.1.3
 ds-caselaw-utils~=0.4.1
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
v5.1.3 has a fix to support multipart data being an empty string.