### PR TITLE
FCL-15 Ensure there is always a string for the judgment

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/results_list.html
+++ b/ds_caselaw_editor_ui/templates/includes/results_list.html
@@ -8,7 +8,7 @@
         <dd>
           <a class="results__result-title" href="{% url 'detail' %}?judgment_uri={{result.uri}}">
             {% if not result.is_failure %}
-              {{ result.name | safe }}
+              {{ result.name | default:"[Untitled judgment]" | safe }}
             {% else %}
               <span class="results__result-failed">Failed processing:</span> {{result.uri}}
             {% endif %}


### PR DESCRIPTION
Whilst this doesn't fix the underlying issue, and is technically wrong (there is a title for the judgment, it's just not coming through to the front end in this context for some reason, probably related to how the Custom API's request to MarkLogic), having a placeholder here means the editor has a chance to be able to click a link to visit the judgment and make changes.

There are legitimately unpublished judgments which may have "" as a title, so this is a useful change.

<img width="837" alt="image" src="https://user-images.githubusercontent.com/85497046/203581494-273e50cc-9993-4017-984e-827111bdff7f.png">

[note also that the search box is blank and it shouldn't be... possibly related...]
