### PR TITLE
added two sort values for priority to the sort dropdown

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/pagination.html
+++ b/ds_caselaw_editor_ui/templates/includes/pagination.html
@@ -37,7 +37,7 @@
     <li class="pagination__list-item">
       {% if context.paginator.has_next_page %}
         <a class="pagination__page-chevron-next"
-           href="{{request.path}}?{% if context.query_string %}{{context.query_string}}&{% endif %}&page={{context.paginator.next_page}}">
+           href="{{request.path}}?{% if context.query_string %}{{context.query_string}}&{% endif %}page={{context.paginator.next_page}}">
           <span>Next page</span>
         </a>
       {% else %}

--- a/ds_caselaw_editor_ui/templates/includes/unpublished_judgments_controls.html
+++ b/ds_caselaw_editor_ui/templates/includes/unpublished_judgments_controls.html
@@ -13,8 +13,8 @@
       <select class="unpublished-judgments-controls__select" id="order_by" name="order">
         <option value="-date" {% if context.order == "-date" or context.order is None %}selected='selected'{% endif %}>Date received &ndash; Newest</option>
         <option value="date" {% if context.order == "date" %}selected='selected'{% endif %}>Date received &ndash; Oldest</option>
-        <option value="date" {% if context.order == "date" %}selected='selected'{% endif %}>Priority &ndash; High to Low</option>
-        <option value="date" {% if context.order == "date" %}selected='selected'{% endif %}>Priority &ndash; Low to High</option>
+        <option value="-priority" {% if context.order == "-priority" or context.order is None %}selected='selected'{% endif %}>Priority &ndash; High to Low</option>
+        <option value="priority" {% if context.order == "priority" %}selected='selected'{% endif %}>Priority &ndash; Low to High</option>
       </select>
     </div>
     <input aria-label="sort unpublished judgments" type="submit" value="Go" class="unpublished-judgments-controls__button">

--- a/ds_caselaw_editor_ui/templates/includes/unpublished_judgments_controls.html
+++ b/ds_caselaw_editor_ui/templates/includes/unpublished_judgments_controls.html
@@ -13,6 +13,8 @@
       <select class="unpublished-judgments-controls__select" id="order_by" name="order">
         <option value="-date" {% if context.order == "-date" or context.order is None %}selected='selected'{% endif %}>Date received &ndash; Newest</option>
         <option value="date" {% if context.order == "date" %}selected='selected'{% endif %}>Date received &ndash; Oldest</option>
+        <option value="date" {% if context.order == "date" %}selected='selected'{% endif %}>Priority &ndash; High to Low</option>
+        <option value="date" {% if context.order == "date" %}selected='selected'{% endif %}>Priority &ndash; Low to High</option>
       </select>
     </div>
     <input aria-label="sort unpublished judgments" type="submit" value="Go" class="unpublished-judgments-controls__button">

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -298,7 +298,9 @@ def index(request):
         params = request.GET
         page = params.get("page") if params.get("page") else "1"
         order = (
-            params.get("order") if params.get("order") in ["date", "-date"] else "-date"
+            params.get("order")
+            if params.get("order") in ["date", "-date", "priority", "-priority"]
+            else "-date"
         )
         model = perform_advanced_search(order=order, only_unpublished=True, page=page)
         search_results = [
@@ -309,6 +311,8 @@ def index(request):
         context["count_judgments"] = model.total
         context["paginator"] = paginator(int(page), model.total)
         context["order"] = order
+        # we leave out the 'page' parameter here, as it's always overwritten on pagination.
+        context["query_string"] = "order=%s" % order
 
     except MarklogicResourceNotFoundError as e:
         raise Http404(


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Added two extra values to the Sort dropdow for the unpublished judgments screen for Priority:
- Priority - High to Low
- Priority - Low to High

## Trello card / Rollbar error (etc)
https://trello.com/c/JXMNBZTk/77-%F0%9F%91%A9%F0%9F%92%BB-eui-sorting-unpublished-judgments
## Screenshots of UI changes:

### Before
![Screenshot 2022-12-07 at 15 26 47](https://user-images.githubusercontent.com/102584881/206220251-70eed647-72b7-433d-83e1-6c8bd5a62752.png)

### After
![Screenshot 2022-12-07 at 15 26 20](https://user-images.githubusercontent.com/102584881/206220218-62622763-071f-4738-8f7f-243ddc7c4e59.png)


- [ ] Requires env variable(s) to be updated
