### PR TITLE
Bump boto3 to 1.26.26 and botocore to 1.29.26, the most recent versions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,5 +26,5 @@ ds-caselaw-marklogic-api-client~=5.1.3
 ds-caselaw-utils~=0.4.1
 rollbar
 django-stronghold==0.4.0
-boto3==1.21.45
-botocore==1.24.45
+boto3==1.26.26
+botocore==1.29.26


### PR DESCRIPTION
Re-applies these version bumps by reverting nationalarchives/ds-caselaw-editor-ui#546