### PR TITLE
Feature/222 assign to me switch

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_loading_indicator.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_loading_indicator.scss
@@ -1,0 +1,21 @@
+.loading-indicator {
+    content: "";
+    border: 6px solid $color__light-grey;
+    border-radius: 50%;
+    border-top-color: $color__almost-black;
+    width: 6px !important;
+    height: 6px !important;
+    display: inline-block;
+    -webkit-animation: spin 2s linear infinite;
+    animation: spin 2s linear infinite;
+}
+
+@-webkit-keyframes spin {
+    0% { -webkit-transform: rotate(0deg); }
+    100% { -webkit-transform: rotate(360deg); }
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/ds_caselaw_editor_ui/sass/includes/_unpublished_judgments.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_unpublished_judgments.scss
@@ -143,7 +143,11 @@
     outline-color: $color__dark-blue;
     font-weight: normal;
     margin-top: 0;
-    padding: 0.2rem 0.5rem;
-    font-size: 0.8rem;
+    padding: 0.5rem;
+    font-size: .9rem;
+    &:hover {
+      background-color: $color__link-blue-hover;
+      cursor: grab;
+    }
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_unpublished_judgments.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_unpublished_judgments.scss
@@ -34,7 +34,15 @@
   }
 
   &__table-header-submitted {
-    flex-basis: 25%;
+    flex-basis: 12.5%;
+    display: none;
+    @media (min-width: $grid__breakpoint-medium) {
+      display: block;
+    }
+  }
+
+  &__table-header-assigned {
+    flex-basis: 12.5%;
     display: none;
     @media (min-width: $grid__breakpoint-medium) {
       display: block;
@@ -68,7 +76,15 @@
   }
 
   &__judgment-submitted {
-    flex-basis: 25%;
+    flex-basis: 12.5%;
+    display: none;
+    @media (min-width: $grid__breakpoint-medium) {
+      display: block;
+    }
+  }
+
+  &__judgment-assigned {
+    flex-basis: 12.5%;
     display: none;
     @media (min-width: $grid__breakpoint-medium) {
       display: block;
@@ -76,6 +92,12 @@
   }
 
   &__judgment-details-submitted-mobile {
+    @media(min-width: $grid__breakpoint-medium) {
+      display: none;
+    }
+  }
+
+  &__judgment-details-assigned-mobile {
     @media(min-width: $grid__breakpoint-medium) {
       display: none;
     }
@@ -116,4 +138,12 @@
     color: $color__dark-grey;
   }
 
+  &__action-button {
+    @include call-to-action-button;
+    outline-color: $color__dark-blue;
+    font-weight: normal;
+    margin-top: 0;
+    padding: 0.2rem 0.5rem;
+    font-size: 0.8rem;
+  }
 }

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -23,3 +23,4 @@
 @import "includes/sources_introduction";
 @import "includes/sources";
 @import "includes/unpublished_judgments_controls";
+@import "includes/loading_indicator";

--- a/ds_caselaw_editor_ui/static/js/src/app.js
+++ b/ds_caselaw_editor_ui/static/js/src/app.js
@@ -1,49 +1,80 @@
-import $ from 'jquery'
+import $ from "jquery";
 
 (function ($) {
-    $.fn.manage_filters = function (options) {
-        const settings = $.extend({}, $.fn.manage_filters.defaults, options);
-        return this.each(() => {
+  $.fn.manage_filters = function (options) {
+    const settings = $.extend({}, $.fn.manage_filters.defaults, options);
+    return this.each(() => {
+      const $toggle_area = $(".js-results-facets", $(this));
 
-            const $toggle_area = $('.js-results-facets', $(this));
+      const $control_container = $(".js-results-control-container", $(this));
 
-            const $control_container = $('.js-results-control-container', $(this));
+      const btn = $("<button>", {
+        class: "results-search-component__toggle-control",
+        type: "button",
+        text: settings.expanded_text,
+        click: (e) => {
+          $toggle_area.toggle();
 
-            const btn = $('<button>', {
-                'class': 'results-search-component__toggle-control',
-                'type': 'button',
-                'text': settings.expanded_text,
-                'click': (e) => {
-                    $toggle_area.toggle();
+          const $el = $(e.target);
 
-                    const $el = $(e.target);
+          $el.toggleClass("collapsed");
 
-                    $el.toggleClass('collapsed');
+          $el.text(() => {
+            return $el.text() === settings.collapsed_text
+              ? settings.expanded_text
+              : settings.collapsed_text;
+          });
+        },
+      });
 
-                    $el.text(() => {
-                        return $el.text() === settings.collapsed_text ? settings.expanded_text : settings.collapsed_text;
-                    })
-                }
-            });
+      if (settings.initially_hidden) {
+        btn.trigger("click");
+      }
 
-            if (settings.initially_hidden) {
-                btn.trigger('click');
-            }
+      $control_container.append(btn);
+    });
+  };
 
-            $control_container.append(btn)
-        });
-    };
+  $.fn.manage_filters.defaults = {
+    collapsed_text: "Show filter options",
+    expanded_text: "Hide filter options",
+    initially_hidden: true,
+  };
+})($);
 
-    $.fn.manage_filters.defaults = {
-        'collapsed_text': 'Show filter options',
-        'expanded_text': 'Hide filter options',
-        'initially_hidden': true
-    }
-}($));
+$(".js-results-facets-wrapper").manage_filters();
 
+$(".judgment-toolbar__delete").click(() =>
+  confirm(
+    "Are you sure you want to delete this judgment? Deletion is permanent."
+  )
+);
 
-$('.js-results-facets-wrapper').manage_filters();
-
-$('.judgment-toolbar__delete').click(() =>
-     confirm("Are you sure you want to delete this judgment? Deletion is permanent.")
-)
+$(".unpublished-judgments__judgment-assign-form").on(
+  "submit",
+  function (event) {
+    event.preventDefault();
+    const form = $(this);
+    const uri = form.find("input[name='judgment_uri']").val();
+    const action = form.attr("action");
+    const loading = $(
+      "<span class='loading-indicator' role='progressbar' aria-valuetext='Loading' aria-busy='true' aria-live='polite'></span>"
+    );
+    form.replaceWith(loading);
+    $.ajax({
+      type: "POST",
+      url: action,
+      data: form.serialize(),
+      success: function (data) {
+        const assigned_to = data["assigned_to"];
+        loading.replaceWith(
+          "<a aria-busy='false' href='/edit?judgment_uri=" +
+            uri +
+            "#assigned_to'>" +
+            assigned_to +
+            "</a>"
+        );
+      },
+    });
+  }
+);

--- a/ds_caselaw_editor_ui/static/js/src/app.js
+++ b/ds_caselaw_editor_ui/static/js/src/app.js
@@ -69,7 +69,7 @@ $(".unpublished-judgments__judgment-assign-form").on(
         const assigned_to = data["assigned_to"];
         loading.replaceWith(
           "<a aria-busy='false' href='/edit?judgment_uri=" +
-            uri +
+            encodeURIComponent(uri) +
             "#assigned_to'>" +
             assigned_to +
             "</a>"

--- a/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
+++ b/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
@@ -17,6 +17,9 @@
         <div class="unpublished-judgments__table-header-submitted">
           {% translate "judgments.submission_datetime" %}
         </div>
+        <div class="unpublished-judgments__table-header-assigned">
+          {% translate "judgments.submission_assigned" %}
+        </div>
       </div>
       <ul class="unpublished-judgments__list">
         {% for item in context.recent_judgments %}
@@ -74,19 +77,6 @@
                 </li>
                 <li>
                   <span class="unpublished-judgments__judgment-details-meta-key">
-                    {% translate "judgments.assigned_to" %}
-                  </span>
-                  <span class="unpublished-judgments__judgment-details-meta-value">
-                    {{item.meta.assigned_to | default:"no-one"}}
-                    <form action="/assign" method="post">
-                      {% csrf_token %}
-                      <input type="hidden" name="judgment_uri" value="{{item.uri}}">
-                      <input type="submit" name="assign" value="Assign to me">
-                    </form>
-                  </span>
-                </li>
-                <li>
-                  <span class="unpublished-judgments__judgment-details-meta-key">
                     {% translate "judgments.editor_priority" %}
                   </span>
                   <span class="unpublished-judgments__judgment-details-meta-value">
@@ -118,12 +108,39 @@
                     {% endif %}
                   </span>
                 </li>
+                <li class="unpublished-judgments__judgment-details-assigned-mobile">
+                  <span class="unpublished-judgments__judgment-details-meta-key">
+                    {% translate "judgments.assigned_to" %}
+                  </span>
+                  <span class="unpublished-judgments__judgment-details-meta-value">
+                    {% if item.meta.assigned_to %}
+                      <a href="{% url 'edit' %}?judgment_uri={{item.uri}}#assigned_to">{{ item.meta.assigned_to }}</a>
+                    {% else %}
+                      <form action="/assign" method="post" class="unpublished-judgments__judgment-assign-form">
+                        {% csrf_token %}
+                        <input type="hidden" name="judgment_uri" value="{{item.uri}}">
+                        <input type="submit" class="unpublished-judgments__action-button" name="assign" value="Assign to me">
+                      </form>
+                    {% endif %}
+                  </span>
+                </li>
               </ul>
             </div>
             <div class="unpublished-judgments__judgment-submitted">
               {{ item.meta.submission_datetime|date:"d M Y" }}
               <br />
               {{ item.meta.submission_datetime|time:"h:i a"}}
+            </div>
+            <div class="unpublished-judgments__judgment-assigned">
+              {% if item.meta.assigned_to %}
+                <a href="{% url 'edit' %}?judgment_uri={{item.uri}}#assigned_to">{{ item.meta.assigned_to }}</a>
+              {% else %}
+                <form action="/assign" method="post" class="unpublished-judgments__judgment-assign-form">
+                  {% csrf_token %}
+                  <input type="hidden" name="judgment_uri" value="{{item.uri}}">
+                  <input type="submit" class="unpublished-judgments__action-button" name="assign" value="Assign to me">
+                </form>
+              {% endif %}
             </div>
           </li>
         {% endfor %}

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -267,8 +267,14 @@ def assign_judgment_button(request):
     judgment_uri = request.POST["judgment_uri"]
     api_client.set_property(judgment_uri, "assigned-to", request.user.username)
     target_uri = request.META.get("HTTP_REFERER") or "/"
-    messages.success(request, "Judgment assigned to you.")
-    return redirect(target_uri)
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+        return HttpResponse(
+            json.dumps({"assigned_to": request.user.username}),
+            content_type="application/json",
+        )
+    else:
+        messages.success(request, "Judgment assigned to you.")
+        return redirect(target_uri)
 
 
 def prioritise_judgment_button(request):

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-26 09:24+0000\n"
+"POT-Creation-Date: 2022-12-15 13:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,38 +36,38 @@ msgstr ""
 msgid "common.findcaselaw"
 msgstr "Find and manage case law"
 
-#: ds_caselaw_editor_ui/templates/base.html:25
+#: ds_caselaw_editor_ui/templates/base.html:33
 #: ds_caselaw_editor_ui/templates/layout_judgment_html.html:25
 msgid "skiplink"
 msgstr "Skip to Main Content"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:6
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:7
 msgid "judgment.back"
 msgstr "Back to search results"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:12
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:15
 msgid "judgment.edit_this_judgment"
 msgstr "Edit this Judgment"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:14
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:19
 msgid "judgment.view_this_judgment"
 msgstr "View this Judgment"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:19
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:25
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:11
 msgid "judgment.download_docx"
 msgstr "Download the original judgment"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:22
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:30
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:14
 msgid "judgment.download_pdf"
 msgstr "Download PDF"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:24
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:34
 msgid "judgment.download_xml"
 msgstr "Download XML"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:26
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:47
 msgid "judgment.delete"
 msgstr "Delete judgment"
 
@@ -80,46 +80,53 @@ msgid "judgments.details"
 msgstr "Judgment details:"
 
 #: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:18
-#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:37
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:40
 msgid "judgments.submission_datetime"
 msgstr "Submitted:"
 
-#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:45
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:21
+msgid "judgments.submission_assigned"
+msgstr "Assigned:"
+
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:48
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:8
 msgid "judgments.consignmentref"
 msgstr "TDR Ref:"
 
-#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:53
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:56
 msgid "judgments.ncn"
 msgstr "NCN"
 
-#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:61
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:64
 msgid "judgments.court"
 msgstr "Court:"
 
-#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:69
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:72
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:6
 msgid "judgments.submitter"
 msgstr "Submitted by:"
 
-msgid "judgments.assigned_to"
-msgstr "Assigned to:"
-
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:80
 msgid "judgments.editor_priority"
 msgstr "Priority:"
 
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:97
 msgid "judgments.editor_status"
 msgstr "Status:"
 
-#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:84
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:113
+msgid "judgments.assigned_to"
+msgstr "Assigned to:"
+
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:159
 msgid "judgments.allrecent"
 msgstr "See all recent judgments"
 
-#: ds_caselaw_editor_ui/templates/judgment/deleted.html:13
+#: ds_caselaw_editor_ui/templates/judgment/deleted.html:12
 msgid "judgment.deleted"
 msgstr "Judgment successfully deleted"
 
-#: ds_caselaw_editor_ui/templates/judgment/deleted.html:14
+#: ds_caselaw_editor_ui/templates/judgment/deleted.html:13
 msgid "judgment.return_home"
 msgstr "Return to Find and manage case law"
 
@@ -177,7 +184,7 @@ msgstr "Previous versions of this Judgment"
 
 #: ds_caselaw_editor_ui/templates/judgment/results.html:5
 #: ds_caselaw_editor_ui/templates/judgment/results.html:9
-#: judgments/views.py:284
+#: judgments/views.py:330
 msgid "results.search.title"
 msgstr "Search results"
 
@@ -202,7 +209,7 @@ msgstr ""
 "Improve your search results by removing filters, double-checking your "
 "spelling, using fewer keywords or searching for something less specific."
 
-#: judgments/views.py:245
+#: judgments/views.py:235
 msgid "judgment.delete_a_judgment"
 msgstr "Delete a judgment"
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
This fulfils two user needs - one the need to see at a glance who is working on a judgment, and two the need to take responsibility for a new judgment as it comes in.

After some discussion, we simplified the design from the azure template to better tackle these core use cases.

As a result we've done the following:
 - moved the assignment functionality into a new column at desktop breakpoints for easy at a glance listing of current assignments
 - styled the assign button to be consistent with the site-wide styles (this might need a litte tweak for spacing etc)
 - Changed the 'assigned' state to a link to the edit page for reassignment when necessary
 - Added a progressive enhancement to the submit form to assign via AJAX request when available, for easy rapid assignments. This will gracefully fallback to a regular HTTP form submit with a flash confirmation message when javasript isn't available. I've also added a minimal reusable 'waiting' spinner to display while the request is in flight (again, some styling might be necessary for this).

Squashed commits for reference:

 - First attempt at backend logic for unassigning judgments
 - Refactor out separate /unassign endpoint.
 - Broad-strokes table layout change for 'assign to me' FE design
 - Get rid of unassignments, add link to edit form for reassigning
 - Allow users to be assigned with an AJAX request when available.
 - Style the assignment button

## Trello card / Rollbar error (etc)

https://trello.com/c/ZJLPy4Jn/222-eui-fe-for-assign-to-me-switch

## Screenshots of UI changes:

### Before

#### Desktop
<img width="1306" alt="Screenshot 2022-12-15 at 17 03 10" src="https://user-images.githubusercontent.com/4279/207912803-b830804b-55cd-4b61-94b2-11ec25fcd984.png">

#### Mobile
<img width="604" alt="Screenshot 2022-12-15 at 17 02 56" src="https://user-images.githubusercontent.com/4279/207912854-b689894a-2ff7-4a25-9283-9652efec3589.png">

### After

#### Desktop
<img width="1521" alt="Screenshot 2022-12-15 at 17 01 46" src="https://user-images.githubusercontent.com/4279/207912912-19a394b3-4914-441c-9eb8-3b847640bafe.png">

#### Mobile

<img width="604" alt="Screenshot 2022-12-15 at 17 02 08" src="https://user-images.githubusercontent.com/4279/207912889-60938b08-d54c-45d9-8d82-107ab99603ac.png">
