### PR TITLE
Fix bug where assignment field empty after editing judgment

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -89,15 +89,8 @@ class EditJudgmentView(View):
         judgment_uri = params.get("judgment_uri")
         context = {"judgment_uri": judgment_uri}
         context.update(self.get_metadata(judgment_uri))
-        users = User.objects.all()
-        users_dict = [
-            {
-                "name": u.get_username(),
-                "print_name": u.get_full_name() or u.get_username(),
-            }
-            for u in users
-        ]
-        context.update({"users": users_dict})
+
+        context.update({"users": users_dict()})
 
         return self.render(request, context)
 
@@ -169,6 +162,8 @@ class EditJudgmentView(View):
 
         context.update(self.get_metadata(judgment_uri))
         invalidate_caches(judgment_uri)
+
+        context.update({"users": users_dict()})
 
         return self.render(request, context)
 
@@ -581,3 +576,14 @@ def generate_pdf_url(uri: str):
     return client.generate_presigned_url(
         "get_object", Params={"Bucket": bucket, "Key": key}
     )
+
+
+def users_dict():
+    users = User.objects.all()
+    return [
+        {
+            "name": u.get_username(),
+            "print_name": u.get_full_name() or u.get_username(),
+        }
+        for u in users
+    ]


### PR DESCRIPTION
## Changes in this PR:

This was caused by the fact that the dictionary of user names and ids was not populated in the handler for the POST request, so the dropdown was empty on rendering the template. Fixed by factoring the code to generate this out into a helper method, then calling it from both the POST and GET handler for judgment edits.


## Trello card / Rollbar error (etc)

https://trello.com/c/fIcztXy5/93-%F0%9F%91%A9%F0%9F%92%BB%F0%9F%90%9E-after-submitting-change-to-judgment-assigned-to-is-visually-empty
