### PR TITLE
Add GTM tags and nationalarchives cookie consent banner

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -190,6 +190,7 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
+                "judgments.context_processors.cookie_consent",
             ],
         },
     }

--- a/ds_caselaw_editor_ui/sass/includes/cookie_consent/README.md
+++ b/ds_caselaw_editor_ui/sass/includes/cookie_consent/README.md
@@ -1,0 +1,5 @@
+# See TNA cookie consent repository
+
+The styles within `ds-cookie-consent.scss` are from the main TNA cookie consent repository and have therefore been isolated into their own directory. Style overrides specific to this system are included in `_cookie-consent.scss`.
+
+To see the main repository visit: https://github.com/nationalarchives/ds-cookie-consent

--- a/ds_caselaw_editor_ui/sass/includes/cookie_consent/_cookie-consent.scss
+++ b/ds_caselaw_editor_ui/sass/includes/cookie_consent/_cookie-consent.scss
@@ -1,0 +1,13 @@
+#ds-cookie-consent-banner {
+  .container {
+
+    @include container;
+
+    padding: $spacer__unit calc($spacer__unit  * 2);
+
+    .cookie_head {
+      font-family: $font__roboto;
+      font-size: 1.8rem;
+    }
+  }
+}

--- a/ds_caselaw_editor_ui/sass/includes/cookie_consent/ds-cookie-consent.scss
+++ b/ds_caselaw_editor_ui/sass/includes/cookie_consent/ds-cookie-consent.scss
@@ -1,0 +1,153 @@
+#ds-cookie-consent-form {
+  input[type="radio"] {
+    margin-right: 7px;
+    + label {
+      cursor: pointer;
+      @media only screen and (max-width: 818px) {
+        display: inline;
+      }
+    }
+  }
+
+  #form_submit:focus {
+    background-color: #fff;
+    color: #26262a;
+  }
+
+  .form-group {
+    margin-bottom: 10px;
+  }
+
+  .reduced-margin {
+    margin-bottom: 1rem;
+  }
+}
+
+#ds-cookie-consent-banner {
+  z-index: 999;
+  padding: 10px 10px 20px 10px;
+  position: fixed;
+  display: block;
+  bottom: 0px;
+  font-size: 14px;
+  width: 100%;
+  color: #fff;
+  .container {
+    background: #134571;
+    padding: 10px 25px 25px 40px;
+    box-sizing: border-box;
+    border-radius: 5px;
+    .cookie_head {
+      font-family: "Roboto Mono";
+      font-style: normal;
+      font-weight: normal;
+      font-size: 20.8px;
+      line-height: inherit;
+      color: #ffffff;
+      margin-top: 10px;
+      margin-bottom: 0;
+    }
+    .cookie-p {
+      font-family: "Open Sans";
+      font-size: 16px;
+      line-height: inherit;
+      color: #ffffff;
+      margin-bottom: 15px;
+      margin-top: 10px;
+      br {
+        content: "";
+        display: block;
+        font-size: 100%;
+        height: 0.25em;
+        display: block;
+      }
+      a {
+        color: #fff;
+        text-decoration: underline;
+        &:hover {
+          color: #000;
+          outline-offset: 0;
+          z-index: 999;
+          background-color: #fff;
+          outline: 5px solid #1d70b8;
+        }
+        &:focus {
+          color: #000;
+        }
+      }
+    }
+    #hide_this_message,
+    #reject_optional_cookies,
+    #accept_optional_cookies {
+      background: #eee;
+      color: #000;
+      border: #eee;
+      text-decoration: none;
+      margin-right: 20px;
+      border: 2px solid #fff;
+      font-family: "Roboto Mono",monospace;
+      padding: .5em .9em;
+      display: inline-block;
+      min-width: 24px;
+      text-align: center;
+      &:hover,
+      &:focus {
+        background: #000;
+        color: #fff;
+        border: 2px solid #fff;
+      }
+      &:focus {
+        outline: 5px solid #fff;
+      }
+      @media (max-width: 560px) {
+        display: block;
+        margin-bottom: 15px;
+        width:100%;
+      }
+    }
+    #btn_preferences {
+      background: none;
+      border: none;
+      border: 2px solid transparent;
+      text-decoration: underline;
+      &:hover,
+      &:focus {
+        background: #000;
+        color: #fff;
+        text-decoration: none;
+        border: 2px solid #fff;
+      }
+      &:focus {
+        outline: 5px solid #fff;
+      }
+      @media (max-width: 675px) {
+        margin-top: 5px;
+      }
+      @media (max-width: 560px) {
+        display: block;
+      }
+    }
+    @media (max-width: 560px) {
+      padding: 10px 30px 25px 30px;
+    }
+  }
+}
+
+.cookie-consent-table {
+  @media only screen and (max-width: 768px) {
+    tr {
+      td:first-of-type {
+        word-break: break-all;
+      }
+    }
+  }
+}
+
+.tna-form-engagement {
+  .jsON {
+    display: none;
+  }
+  .jsOFF {
+    display: block;
+  }
+}

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -24,3 +24,5 @@
 @import "includes/sources";
 @import "includes/unpublished_judgments_controls";
 @import "includes/loading_indicator";
+@import "includes/cookie_consent/ds-cookie-consent";
+@import "includes/cookie_consent/cookie-consent";

--- a/ds_caselaw_editor_ui/static/js/cookie_consent/README.md
+++ b/ds_caselaw_editor_ui/static/js/cookie_consent/README.md
@@ -1,0 +1,5 @@
+# See TNA cookie consent repository
+
+The JavaScript for the cookie consent banner is from the main TNA cookie-consent repository at: https://github.com/nationalarchives/ds-cookie-consent
+
+This JavaScript is shared by all TNA services and is therefore isolated from other scripts (to support maintainability) but included in its source form (to allow for inspection)

--- a/ds_caselaw_editor_ui/static/js/cookie_consent/src/api/dsCookieConsentBannerAPI.js
+++ b/ds_caselaw_editor_ui/static/js/cookie_consent/src/api/dsCookieConsentBannerAPI.js
@@ -1,0 +1,127 @@
+import Data from "../data";
+
+// DS COOKIE CONSENT BANNER API
+const dsCookieConsentBannerAPI = (() => {
+  // Delete cookie
+  function deleteCookie(...cname) {
+    let cookies = document.cookie.split(";");
+    for (let i = 0; i < cookies.length; i++) {
+      let cookie = cookies[i];
+      let eqPos  = cookie.indexOf("=");
+      let name   = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
+
+      cname.forEach((c) => {
+        if (name.trim() === c) {
+          document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;domain="`;
+
+          /* The below line fixes discovery only deleting cookies on discovery.nationalarchives.gov.uk instead of just .nationalarchives.gov.uk */
+          document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;domain=.nationalarchives.gov.uk`;
+
+          /*below line is to delete the google analytics cookies. they are set with the domain*/
+          document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;domain=${location.hostname.replace(
+            /^www\./i,
+            ""
+          )}`;
+        }
+      });
+    }
+  }
+
+  // Set cookie
+  function setCookie(name, value, options) {
+    options = {
+      path: "/",
+      domain: "", // once deployed to a TNA domain this should be "nationalarchives.gov.uk"
+      secure: true,
+      ...options,
+    };
+
+    if (options.expires instanceof Date) {
+      options.expires = options.expires.toUTCString();
+    }
+
+    let updatedCookie =
+      encodeURIComponent(name) + "=" + encodeURIComponent(value);
+
+    for (let optionKey in options) {
+      updatedCookie += "; " + optionKey;
+      let optionValue = options[optionKey];
+      if (optionValue !== true) {
+        updatedCookie += "=" + optionValue;
+      }
+    }
+
+    document.cookie = updatedCookie;
+  }
+
+  // Check if cookie exists
+  function checkCookie(name) {
+    return -1 !== document.cookie.indexOf(name);
+  }
+
+  // Create link element inside the banner
+  function createLink(text, url, id, className) {
+    const getInnerElem = document.querySelector(Data.buttonPreferences.id);
+    const createUrl   = document.createElement("a");
+    const linkText     = document.createTextNode(text);
+
+    if (getInnerElem) {
+      const parentElement = getInnerElem.parentNode;
+      createUrl.appendChild(linkText);
+      createUrl.href      = url;
+      createUrl.className = className;
+      createUrl.id        = id;
+      parentElement.insertBefore(createUrl, getInnerElem);
+    }
+  }
+
+  // Get cookie value
+  // If cookies_policy get its value, decode it, parse it and return an object
+  // For any other cookies return its value as a string
+  function getCookieValue(cname) {
+    let cookies     = document.cookie.split(";");
+    let cookieValue = "";
+
+    for (let i = 0; i < cookies.length; i++) {
+      let cookie       = cookies[i];
+      let equalSignPos = cookie.indexOf("=");
+          cookieValue  = cookie.slice(equalSignPos + 1);
+      let cookieName   =
+        equalSignPos > -1 ? cookie.substr(0, equalSignPos).trim(): cookie;
+
+      if (cookieName === cname) {
+        cookieValue = decodeURIComponent(cookieValue);
+        const parseCookieValue = JSON.parse(cookieValue);
+        return parseCookieValue;
+      }
+    }
+    return cookieValue;
+  }
+
+  // Create link element inside the banner
+  function createButton(text, id, className) {
+    const getInnerElem = document.querySelector(Data.buttonPreferences.id);
+    const createBtn    = document.createElement("button");
+    const linkText     = document.createTextNode(text);
+
+    if (getInnerElem) {
+      const parentElement = getInnerElem.parentNode;
+      createBtn.appendChild(linkText);
+      createBtn.className = className;
+      createBtn.id        = id;
+      parentElement.insertBefore(createBtn, getInnerElem);
+    }
+  }
+
+  // Revealing public API
+  return {
+    createButton,
+    createLink,
+    setCookie,
+    checkCookie,
+    deleteCookie,
+    getCookieValue,
+  };
+})();
+
+export default dsCookieConsentBannerAPI;

--- a/ds_caselaw_editor_ui/static/js/cookie_consent/src/data.js
+++ b/ds_caselaw_editor_ui/static/js/cookie_consent/src/data.js
@@ -1,0 +1,78 @@
+// Typed data
+const Data = {
+  buttonAccept: {
+    text: "Accept cookies",
+    url: "#",
+    id: "accept_optional_cookies",
+    class: "button",
+  },
+  buttonReject: {
+    text: "Reject cookies",
+    url: "#",
+    id: "reject_optional_cookies",
+    class: "button",
+  },
+  hideThisMessage: {
+    text: "Close this message",
+    url: "#",
+    id: "hide_this_message",
+    class: "button",
+  },
+  buttonPreferences: {
+    id: "#btn_preferences",
+  },
+  bannerParagraph: {
+    id: ".cookie-p",
+  },
+  bannerHeadline: {
+    id: ".cookie_head",
+  },
+  bannerWrapper: {
+    id: "#ds-cookie-consent-banner",
+  },
+  cookies: {
+    cookieOne: "dontShowCookieNotice",
+    cookieTwo: "cookies_policy",
+    gaCookies: ["_ga", "_gid", "_gat_UA-2827241-22", "_gat_UA-2827241-1", "_ga_2CP7QT8TDG"],
+    settings: ["dontAutoStartResultsTour"]
+  },
+  formWrapper: {
+    id: "#ds-cookie-consent-form",
+  },
+  acceptMessageAfterInteraction: {
+    text:
+      "You have accepted optional cookies. You can change your cookie settings on the <a href='https://www.nationalarchives.gov.uk/legal/cookies/'>Cookies page</a>.",
+    ariaLabel: "Cookie consent confirmation message",
+  },
+  rejectMessageAfterInteraction: {
+    text:
+      "You have rejected optional cookies. You can change your cookie settings on the <a href='https://www.nationalarchives.gov.uk/legal/cookies/'>Cookies page</a>.",
+    ariaLabel: "Cookie consent confirmation message",
+  },
+  oldCookieBannerWrapper: {
+    class: ".cookieNotice",
+  },
+  cookiesToRemove: {
+    one: "_ga",
+    two: "_gid",
+    three: "_gat_UA-2827241-1",
+    four: "_gat_UA-2827241-22",
+    five: "_ga_2CP7QT8TDG"
+  },
+  DOM: {
+    on: ".jsON",
+    off: ".jsOFF",
+  },
+  form: {
+    analytics: {
+      measure: "#measure_website_use",
+      doNotMeasure: "#donot_measure_website_use",
+    },
+    settings: {
+      rememberSettings: "#remember_your_settings",
+      doNotRememberSettings: "#donot_remember_your_settings"
+    }
+  },
+};
+
+export default Data;

--- a/ds_caselaw_editor_ui/static/js/cookie_consent/src/ds-cookie-consent.js
+++ b/ds_caselaw_editor_ui/static/js/cookie_consent/src/ds-cookie-consent.js
@@ -1,0 +1,356 @@
+import Data from "./data";
+import dsCookieConsentBannerAPI from "./api/dsCookieConsentBannerAPI";
+
+const getBannerElement = document.querySelector(Data.bannerWrapper.id);
+const getCookieForm = document.querySelector(Data.formWrapper.id);
+const getCookieObject = dsCookieConsentBannerAPI.getCookieValue(
+  Data.cookies.cookieTwo
+);
+let measureRadioInput = document.querySelector(Data.form.analytics.measure);
+let doNotMeasureRadioInput = document.querySelector(
+  Data.form.analytics.doNotMeasure
+);
+let settingsRadioInput = document.querySelector(Data.form.settings.rememberSettings);
+let doNotRememberSettingsRadioInput = document.querySelector(
+  Data.form.settings.doNotRememberSettings
+);
+
+// Polyfill the remove() method IE9 and higher
+// from:https://github.com/jserz/js_piece/blob/master/DOM/ChildNode/remove()/remove().md
+(function (arr) {
+  arr.forEach(function (item) {
+    if (item.hasOwnProperty("remove")) {
+      return;
+    }
+    Object.defineProperty(item, "remove", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: function remove() {
+        this.parentNode.removeChild(this);
+      },
+    });
+  });
+})([Element.prototype, CharacterData.prototype, DocumentType.prototype]);
+
+// Treat DOM elements while the page is loading
+(function () {
+  // If the cookie dontShowCookieNotice exists
+  // Hide the banner if visible
+  if (dsCookieConsentBannerAPI.checkCookie(Data.cookies.cookieOne)) {
+    if (getBannerElement) {
+      getBannerElement.remove();
+    }
+  }
+
+  if (getCookieForm) {
+    // Update the state on the form radio elements
+    // based on the cookie_policy value
+    if (!dsCookieConsentBannerAPI.checkCookie(Data.cookies.cookieTwo)) {
+      // Hide the banner if visible
+      if (getBannerElement) {
+        getBannerElement.remove();
+      }
+      doNotMeasureRadioInput.checked = true;
+      doNotRememberSettingsRadioInput.checked = true;
+    }
+
+    if (getBannerElement) {
+      getBannerElement.remove();
+    }
+  }
+})();
+
+// Create/delete cookies on page load
+(function () {
+  document.addEventListener("DOMContentLoaded", () => {
+    if (!dsCookieConsentBannerAPI.checkCookie(Data.cookies.cookieTwo)) {
+      const cookieValue = {
+        usage: false,
+        settings: false,
+        essential: true,
+      };
+
+      dsCookieConsentBannerAPI.setCookie(
+        Data.cookies.cookieTwo,
+        JSON.stringify(cookieValue),
+        {
+          "max-age": 90 * 24 * 60 * 60,
+        }
+      );
+
+      // Delete GA cookies if cookies_policy cookie value is set to false
+      Data.cookies.gaCookies.forEach((cookie) => {
+        dsCookieConsentBannerAPI.deleteCookie(cookie);
+      });
+    } else {
+      if (
+        getCookieObject.hasOwnProperty("usage") &&
+        getCookieObject.usage === false
+      ) {
+        Data.cookies.gaCookies.forEach((cookie) => {
+          dsCookieConsentBannerAPI.deleteCookie(cookie);
+        });
+      }
+
+      if (
+        getCookieObject.hasOwnProperty("settings") &&
+        getCookieObject.settings === false
+      ) {
+        Data.cookies.settings.forEach((cookie) => {
+          dsCookieConsentBannerAPI.deleteCookie(cookie);
+        });
+      }
+
+      // If Cookie Settings page
+      // handle form state based on cookie_policy value / settings
+      if (getCookieForm) {
+        // Update the state on the form radio elements
+        // based on the cookie_policy value
+        if (
+          getCookieObject.hasOwnProperty("usage") &&
+          getCookieObject.usage === true &&
+          !measureRadioInput.checked
+        ) {
+          measureRadioInput.checked = true;
+        } else {
+          doNotMeasureRadioInput.checked = true;
+        }
+
+        // Remove the functional cookies if the user hasn't consent
+        if (
+          getCookieObject.hasOwnProperty("settings") &&
+          getCookieObject.settings === true &&
+          !settingsRadioInput.checked
+        ) {
+          settingsRadioInput.checked = true;
+        } else {
+          doNotRememberSettingsRadioInput.checked = true;
+        }
+      }
+    }
+  });
+})();
+
+// Banner DOM implementation
+(function () {
+  document.addEventListener("DOMContentLoaded", () => {
+    const oldCookieNotice = document.querySelector(
+      Data.oldCookieBannerWrapper.class
+    );
+    const jsON = document.querySelector(Data.DOM.on);
+    const jsOFF = document.querySelector(Data.DOM.off);
+
+    // Display form elements if JS is enable
+    if (jsON) {
+      jsON.style.display = "block";
+    }
+
+    // Hide JS is not enabled message if JS is enabled
+    if (jsOFF) {
+      jsOFF.style.display = "none";
+    }
+
+    // Hide the old yellow Cookie banner for the MVP
+    if (oldCookieNotice) {
+      oldCookieNotice.remove();
+    }
+
+    // Check if cookie banner exists
+    if (getBannerElement) {
+      // Create Accept Optional Cookies
+      dsCookieConsentBannerAPI.createButton(
+        Data.buttonAccept.text,
+        Data.buttonAccept.id,
+        Data.buttonAccept.class,
+      );
+
+      // Create Reject Optional Cookies
+      dsCookieConsentBannerAPI.createButton(
+        Data.buttonReject.text,
+        Data.buttonReject.id,
+        Data.buttonReject.class,
+      );
+
+      // Select the buttons
+      // !important - Do not move these above the DOM implementation
+      const btnAccept = document.querySelector(`#${Data.buttonAccept.id}`);
+      const btnReject = document.querySelector(`#${Data.buttonReject.id}`);
+      const btnPreference = document.querySelector(Data.buttonPreferences.id);
+      const bannerParagraph = document.querySelector(Data.bannerParagraph.id);
+      const cookieHead = document.querySelector(Data.bannerHeadline.id);
+      const getBannerElementContainer = getBannerElement.querySelector(
+        ".container"
+      );
+
+      // Check if the button Accept Optional Cookies exists
+      if (btnAccept) {
+        // Binding to document (event delegation)
+        btnAccept.addEventListener("click", (e) => {
+          e.preventDefault();
+
+          // Create dontShowCookieNotice cookie
+          dsCookieConsentBannerAPI.setCookie(Data.cookies.cookieOne, "true", {
+            "max-age": 90 * 24 * 60 * 60,
+          });
+
+          // Create/Update cookies_policy cookie
+          dsCookieConsentBannerAPI.setCookie(
+            Data.cookies.cookieTwo,
+            '{"usage":true,"settings":true,"essential":true}',
+            {
+              "max-age": 90 * 24 * 60 * 60,
+            }
+          );
+
+          dsCookieConsentBannerAPI.createButton(
+            Data.hideThisMessage.text,
+            Data.hideThisMessage.id,
+            Data.hideThisMessage.class,
+          );
+
+          if (btnAccept) {
+            btnAccept.remove();
+          }
+
+          if (btnReject) {
+            btnReject.remove();
+          }
+
+          if (btnPreference) {
+            btnPreference.remove();
+          }
+
+          if (cookieHead) {
+            cookieHead.remove();
+          }
+
+          if (bannerParagraph) {
+            bannerParagraph.innerHTML = Data.acceptMessageAfterInteraction.text;
+            getBannerElementContainer.setAttribute(
+              "aria-label",
+              Data.acceptMessageAfterInteraction.ariaLabel
+            );
+          }
+
+          // Get the Close This Message DOM element
+          const hideThisMessage = document.querySelector(
+            `#${Data.hideThisMessage.id}`
+          );
+
+          // If Close This Message DOM exists, hide banner
+          if (hideThisMessage) {
+            hideThisMessage.addEventListener("click", (e) => {
+              e.preventDefault();
+              // Hide the banner after Reject btn was clicked
+              if (
+                dsCookieConsentBannerAPI.checkCookie(Data.cookies.cookieOne)
+              ) {
+                if (getBannerElement) {
+                  getBannerElement.remove();
+                }
+              }
+            });
+            bannerParagraph.focus();
+          }
+
+          // Add GA script and set the cookies at the client side
+          const DOMhead = document.head;
+          const gaScript = document.createElement("script");
+          gaScript.id = "frontEndGA";
+          gaScript.src =
+            "/static/js/dist/gtm_script.js";
+          DOMhead.appendChild(gaScript);
+        });
+      }
+
+      // Check if the button Reject Optional Cookies exists
+      if (btnReject) {
+        // Binding to document (event delegation)
+        btnReject.addEventListener("click", (e) => {
+          e.preventDefault();
+
+          // Create dontShowCookieNotice cookie
+          dsCookieConsentBannerAPI.setCookie(Data.cookies.cookieOne, "true", {
+            "max-age": 90 * 24 * 60 * 60,
+          });
+
+          // Create/Update cookies_policy cookie
+          dsCookieConsentBannerAPI.setCookie(
+            Data.cookies.cookieTwo,
+            '{"usage":false,"settings":false,"essential":true}',
+            {
+              "max-age": 90 * 24 * 60 * 60,
+            }
+          );
+
+          dsCookieConsentBannerAPI.createButton(
+            Data.hideThisMessage.text,
+            Data.hideThisMessage.id,
+            Data.hideThisMessage.class,
+          );
+
+          if (btnAccept) {
+            btnAccept.remove();
+          }
+
+          if (btnReject) {
+            btnReject.remove();
+          }
+
+          if (btnPreference) {
+            btnPreference.remove();
+          }
+
+          if (cookieHead) {
+            cookieHead.remove();
+          }
+
+          if (bannerParagraph) {
+            bannerParagraph.innerHTML = Data.rejectMessageAfterInteraction.text;
+            getBannerElementContainer.setAttribute(
+              "aria-label",
+              Data.rejectMessageAfterInteraction.ariaLabel
+            );
+          }
+
+          // Get the Close This Message DOM element
+          const hideThisMessage = document.querySelector(
+            `#${Data.hideThisMessage.id}`
+          );
+
+          // If Close This Message DOM exists, hide banner
+          if (hideThisMessage) {
+            hideThisMessage.addEventListener("click", (e) => {
+              e.preventDefault();
+              // Hide the banner after Reject btn was clicked
+              if (
+                dsCookieConsentBannerAPI.checkCookie(Data.cookies.cookieOne)
+              ) {
+                if (getBannerElement) {
+                  getBannerElement.remove();
+                }
+              }
+            });
+            bannerParagraph.focus();
+          }
+
+          const cookiesToUnset = [
+            Data.cookiesToRemove.one,
+            Data.cookiesToRemove.two,
+            Data.cookiesToRemove.three,
+            Data.cookiesToRemove.four,
+            Data.cookiesToRemove.five
+          ];
+
+          // Unset GA cookies if available
+          for (const cookie of cookiesToUnset) {
+            if (dsCookieConsentBannerAPI.checkCookie(cookie)) {
+              dsCookieConsentBannerAPI.deleteCookie(cookie);
+            }
+          }
+        });
+      }
+    }
+  });
+})();

--- a/ds_caselaw_editor_ui/static/js/src/gtm_script.js
+++ b/ds_caselaw_editor_ui/static/js/src/gtm_script.js
@@ -1,0 +1,13 @@
+(function (w, d, s, l, i) {
+  w[l] = w[l] || [];
+  w[l].push({
+    "gtm.start": new Date().getTime(),
+    event: "gtm.js",
+  });
+  var f = d.getElementsByTagName(s)[0],
+    j = d.createElement(s),
+    dl = l != "dataLayer" ? "&l=" + l : "";
+  j.async = true;
+  j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+  f.parentNode.insertBefore(j, f);
+})(window, document, "script", "dataLayer", "GTM-MMVM4CJ");

--- a/ds_caselaw_editor_ui/templates/base.html
+++ b/ds_caselaw_editor_ui/templates/base.html
@@ -18,10 +18,15 @@
 
     {% block javascript %}
       <script defer src="{% static 'js/dist/app.js' %}"></script>
+      <script defer src="{% static 'js/dist/cookie_consent.js' %}"></script>
     {% endblock javascript %}
+
+    {% include 'includes/gtm/gtm_head.html' %}
   </head>
 
   <body>
+    {% include 'includes/cookie_consent/cookie_banner.html' %}
+    {% include 'includes/gtm/gtm_body.html' %}
     {% if messages %}
       <ul class="messages">
         {% for message in messages %}

--- a/ds_caselaw_editor_ui/templates/includes/cookie_consent/README.md
+++ b/ds_caselaw_editor_ui/templates/includes/cookie_consent/README.md
@@ -1,0 +1,5 @@
+# See TNA cookie consent repository
+
+The HTML for the cookie consent banner is from the main TNA cookie-consent repository at: https://github.com/nationalarchives/ds-cookie-consent
+
+This HTML is shared by all TNA services and is therefore isolated from other templates (to support maintainability)

--- a/ds_caselaw_editor_ui/templates/includes/cookie_consent/cookie_banner.html
+++ b/ds_caselaw_editor_ui/templates/includes/cookie_consent/cookie_banner.html
@@ -1,0 +1,15 @@
+{% if not dontShowCookieNotice %}
+  <div id="ds-cookie-consent-banner" class="cookieConsent" role="region" aria-label="Cookie banner">
+    <div class="container" role="region" aria-label="Cookies on The National Archives">
+      <div class="row">
+        <p class="cookie_head">This website uses cookies</p>
+        <p class="cookie-p">
+          We place some essential cookies on your device to make this website work. <br><br>
+          We'd like to use additional cookies to remember your settings and understand how you use our services. <br><br>
+          This information will help us make improvements to the website.
+        </p>
+        <a href="https://www.nationalarchives.gov.uk/legal/cookies/" id="btn_preferences" class="button">Set cookie preferences</a>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/ds_caselaw_editor_ui/templates/includes/gtm/gtm_body.html
+++ b/ds_caselaw_editor_ui/templates/includes/gtm/gtm_body.html
@@ -1,0 +1,9 @@
+{% if showGTM %}
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MMVM4CJ"
+            height="0" width="0" style="display:none;visibility:hidden">
+    </iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+{% endif %}

--- a/ds_caselaw_editor_ui/templates/includes/gtm/gtm_head.html
+++ b/ds_caselaw_editor_ui/templates/includes/gtm/gtm_head.html
@@ -1,0 +1,4 @@
+{% load static %}
+{% if showGTM %}
+  <script src="{% static 'js/dist/gtm_script.js' %}"></script>
+{% endif %}

--- a/ds_caselaw_editor_ui/templates/layout_judgment_html.html
+++ b/ds_caselaw_editor_ui/templates/layout_judgment_html.html
@@ -19,9 +19,13 @@
 
     {% block javascript %}
       <script defer src="{% static 'js/dist/app.js' %}"></script>
+      <script defer src="{% static 'js/dist/cookie_consent.js' %}"></script>
     {% endblock javascript %}
+    {% include 'includes/gtm/gtm_head.html' %}
   </head>
   <body>
+    {% include 'includes/cookie_consent/cookie_banner.html' %}
+    {% include 'includes/gtm/gtm_body.html' %}
     <a id="skip-to-main-content" href="#main-content">{% translate "skiplink" %}</a>
     <header class="page-header">
       {% include 'includes/breadcrumbs.html' with current=context.page_title title=context.page_title link=request.get_full_path %}

--- a/judgments/context_processors.py
+++ b/judgments/context_processors.py
@@ -1,0 +1,19 @@
+import json
+from urllib.parse import unquote
+
+
+def cookie_consent(request):
+    showGTM = False
+    dontShowCookieNotice = False
+    cookie_policy = request.COOKIES.get("cookies_policy", None)
+    dont_show_cookie_notice = request.COOKIES.get("dontShowCookieNotice", None)
+
+    if cookie_policy:
+        decoder = json.JSONDecoder()
+        decoded = decoder.decode(unquote(cookie_policy))
+        showGTM = decoded["usage"] or False
+
+    if dont_show_cookie_notice == "true":
+        dontShowCookieNotice = True
+
+    return {"showGTM": showGTM, "dontShowCookieNotice": dontShowCookieNotice}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,25 +1,30 @@
-const path = require('path');
+const path = require("path");
 
 module.exports = {
-  mode: 'development',
+  mode: "development",
   devtool: false,
-  entry: './ds_caselaw_editor_ui/static/js/src/app.js',
+  entry: {
+    app: "./ds_caselaw_editor_ui/static/js/src/app.js",
+    cookie_consent:
+      "./ds_caselaw_editor_ui/static/js/cookie_consent/src/ds-cookie-consent.js",
+    gtm_script: "./ds_caselaw_editor_ui/static/js/src/gtm_script.js",
+  },
   output: {
-    filename: 'app.js',
-    path: path.resolve(__dirname, 'ds_caselaw_editor_ui/static/js/dist'),
+    filename: "[name].js",
+    path: path.resolve(__dirname, "ds_caselaw_editor_ui/static/js/dist"),
   },
   module: {
-  rules: [
-    {
-      test: /\.m?js$/,
-      exclude: /(node_modules|bower_components)/,
-      use: {
-        loader: 'babel-loader',
-        options: {
-          presets: ['@babel/preset-env']
-        }
-      }
-    }
-  ]
-}
+    rules: [
+      {
+        test: /\.m?js$/,
+        exclude: /(node_modules|bower_components)/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env"],
+          },
+        },
+      },
+    ],
+  },
 };


### PR DESCRIPTION

## Changes in this PR:

This follows the pattern set in the public UI, including the standard NA cookie banner, and a django context processor to selectively include the GTM tags based on whether the cookie is set and consent given.

## Trello card / Rollbar error (etc)

https://trello.com/c/dRqicmMo/246-google-analytics-for-eui
