### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ You can then access the site in your browser as usual:
 
 <http://127.0.0.1:3000>
 
+
+#### Fixing an issue when another project is already running
+When starting up, if you encounter an error message like this:
+
+```ERROR: for postgres  Cannot start service postgres: driver failed programming external connectivity on endpoint ds-caselaw-editor-ui_postgres_1 (0fb7572d583761d3a348e8fd9139b0007638a17c6f91b15e8678f2575f94ffa7): Bind for 0.0.0.0:5432 failed: port is already allocated```
+
+It's because the public UI project is still running, you'll need to reopen that project and run the command `fab stop`.
+Now go back to the Editor UI project and use the same command `fab stop`.
+Now you can restart the project up again with `fab run`.
+
+
 ### Localstack
 
 The button that submits an edited document needs S3 and SNS services


### PR DESCRIPTION
Added a common error for when another project is still running and how to resolve it.

<!-- Amend as appropriate -->

## Changes in this PR:
Added how to resolve and issue where a project is already running and how to resolve it.
## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After
#### Fixing an issue when another project is already running
When starting up, if you encounter an error message like this:

```ERROR: for postgres  Cannot start service postgres: driver failed programming external connectivity on endpoint ds-caselaw-public-ui_postgres_1 (0fb7572d583761d3a348e8fd9139b0007638a17c6f91b15e8678f2575f94ffa7): Bind for 0.0.0.0:5432 failed: port is already allocated```

It's because the editor UI project is still running, you'll need to reopen that project and run the command `fab stop`.
Now go back to the Public UI project and use the same command `fab stop`.
Now you can restart the project up again with `fab run`.
- [ ] Requires env variable(s) to be updated
