### PR TITLE
tidied up unpublished judgement metadata table by shortening flexbox …

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgments_list.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgments_list.scss
@@ -108,6 +108,7 @@
     padding: 0;
     float: left;
     width: 100%;
+    line-height: 22px;
     @media (min-width: $grid__breakpoint-large) {
       width: 80%;
     }
@@ -125,7 +126,7 @@
       box-sizing: border-box;
       span:nth-child(odd) {
         float: left;
-        width: 33%;
+        width: 27%;
       }
       span:nth-child(even) {
         float: left;

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -95,7 +95,7 @@ msgstr "TDR Ref:"
 
 #: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:56
 msgid "judgments.ncn"
-msgstr "NCN"
+msgstr "NCN:"
 
 #: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:64
 msgid "judgments.court"
@@ -104,7 +104,7 @@ msgstr "Court:"
 #: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:72
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:6
 msgid "judgments.submitter"
-msgstr "Submitted by:"
+msgstr "Submitter:"
 
 #: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:80
 msgid "judgments.editor_priority"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Tidied up unpublished judgement metadata table by shortening flexbox container to reduce gap. added some line-height. Added a missing colon and shorted label from Submitted by:' to 'Submitter:'.

## Trello card / Rollbar error (etc)
https://trello.com/c/LuIgElFW/256-eui-unpublished-judgments-screen-metadata-table-display-improvements
## Screenshots of UI changes:

### Before
![Screenshot 2022-12-23 at 10 09 07](https://user-images.githubusercontent.com/102584881/209322815-610cf5ae-64aa-4e4a-a000-aba61af73d4d.png)

### After
![Screenshot 2022-12-23 at 10 08 41](https://user-images.githubusercontent.com/102584881/209322840-f08c77d1-e441-4a9d-ad20-cbc6ca11eef5.png)

- [ ] Requires env variable(s) to be updated
