### PR TITLE
Force locale to be en-gb

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -29,6 +29,7 @@ if env("SECRET_KEY", default=None):
 TIME_ZONE = "UTC"
 # https://docs.djangoproject.com/en/dev/ref/settings/#language-code
 LANGUAGE_CODE = "en-gb"
+LANGUAGES = [("en-gb", "British English")]
 # https://docs.djangoproject.com/en/dev/ref/settings/#site-id
 SITE_ID = 1
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-i18n


### PR DESCRIPTION
If the browser locale is set to a locale other than `en-gb`, untranslated strings appear (e.g. `judgments.details` instead of `Judgment details:`.

We state explicitly that `en-gb` is the only locale available so everything will fall back to it.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/85497046/210817546-20696210-575b-406e-9ba7-9d780112f2ce.png">
<img width="365" alt="image" src="https://user-images.githubusercontent.com/85497046/210817737-46864d94-f019-4953-b96d-11a033422519.png">