### PR TITLE
Don't create blank uk:court tag if no court provided

### DIFF
--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -112,8 +112,8 @@ class EditJudgmentView(View):
             api_client.set_judgment_citation(judgment_uri, new_citation)
 
             # Set court
-            new_court = request.POST["court"]
-            api_client.set_judgment_court(judgment_uri, new_court)
+            if new_court := request.POST["court"]:
+                api_client.set_judgment_court(judgment_uri, new_court)
 
             # Date
             new_date = request.POST["judgment_date"]


### PR DESCRIPTION
Having completed this, I've just realised I'm fixing it in the wrong spot -- should probably fix it in set_judgment_court in the api client...

This might be worth having anyway.