### PR TITLE
335 - remove unneeded link in breadcrumbs on homepage

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/breadcrumbs.html
+++ b/ds_caselaw_editor_ui/templates/includes/breadcrumbs.html
@@ -4,7 +4,15 @@
   <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
     <span class="page-header__breadcrumb-you-are-in">You are in: </span>
     <ol>
-      <li><a href="{% url 'home' %}" {% if current == "home"  %}aria-current="page"{% endif %}>{% translate "common.findcaselaw" %}</a></li>
+      <li>
+        {% if current == "home"  %}
+          {% translate "common.findcaselaw" %}
+        {% else %}
+          <a href="{% url 'home' %}">
+            {% translate "common.findcaselaw" %}
+          </a>
+        {% endif %}
+      </li>
       {% if title and link %}
         <li>{{ title }}</li>
       {% endif %}


### PR DESCRIPTION
## Changes in this PR:

The current page in the breadcrumbs should not display as a link, for accessibility and general usability reasons. Previously, the homepage always displayed as a link, whether or not you were currently on that page. This fixes it so that it's only displayed as a link when you are on another page of the site.

## Trello card / Rollbar error (etc)

https://trello.com/c/DSRGbtiK/335-aa-%F0%9F%94%A6-eui-pui-home-page-breadcrumbs-accessibility
