### PR TITLE
Magic 'create issue' link for Jira

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,5 @@ PRIVATE_ASSET_BUCKET=private-asset-bucket
 PRIVATE_ASSET_BUCKET_REGION=us-east-1
 S3_REGION=eu-west-2
 SNS_TOPIC=arn:aws:sns:us-east-1:000000000000:caselaw-stg-judgment-updated
+
+JIRA_INSTANCE=tna.atlassian.net

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -288,3 +288,5 @@ STRONGHOLD_PUBLIC_URLS = (
     r"^/accounts/password/reset/",
     r"^/check",
 )
+
+JIRA_INSTANCE = env("JIRA_INSTANCE")

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -20,6 +20,10 @@
       <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
     {% endif %}
     <a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_xml" %}</a>
+
+    <h4>Tools</h4>
+
+    <p><a href="{{ context.jira_create_link }}" target="_blank" rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a></p>
   </aside>
   <div class="edit-component">
     <div class="edit-component__container">

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -2,11 +2,17 @@
 {% block content %}
   {% load i18n %}
   <aside class="judgment-info-component">
+
+    <h4>Submission</h4>
+
     <ul>
       <li>{% translate "judgments.submitter" %} {{context.source_name}}</li>
       <li>{% translate "judgments.submitteremail" %} {{context.source_email}}</li>
       <li>{% translate "judgments.consignmentref" %} {{context.consignment_reference}}</li>
     </ul>
+
+    <h4>Downloads</h4>
+
     {% if context.docx_url %}
       <a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a>
     {% endif %}

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-23 20:26+0000\n"
+"POT-Creation-Date: 2023-01-24 11:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,13 +52,13 @@ msgstr "View as HTML"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:31
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:35
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:11
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:17
 msgid "judgment.download_docx"
 msgstr "Download original .docx"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:41
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:45
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:14
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:20
 msgid "judgment.download_pdf"
 msgstr "Download PDF"
 
@@ -85,7 +85,7 @@ msgid "judgments.submission_assigned"
 msgstr "Assigned:"
 
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:25
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:8
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:11
 msgid "judgments.consignmentref"
 msgstr "TDR Ref:"
 
@@ -98,7 +98,7 @@ msgid "judgments.court"
 msgstr "Court:"
 
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:49
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:6
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:9
 msgid "judgments.submitter"
 msgstr "Submitter:"
 
@@ -131,59 +131,63 @@ msgstr "Judgment successfully deleted"
 msgid "judgment.return_home"
 msgstr "Return to Find and manage case law"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:7
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:10
 msgid "judgments.submitteremail"
 msgstr "Contact email:"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:16
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:22
 msgid "judgment.download_xml"
 msgstr "Download XML"
 
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:26
+msgid "judgment.create_in_jira"
+msgstr "Create in Jira"
+
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:36
 msgid "judgment.edit_judgment"
 msgstr "Edit Judgment"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:30
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:40
 msgid "judgment.judgment_name"
 msgstr "Judgment name"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:35
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:45
 msgid "judgment.neutral_citation"
 msgstr "Neutral citation"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:40
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:50
 msgid "judgment.court"
 msgstr "Court"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:45
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:55
 msgid "judgment.judgment_date"
 msgstr "Judgment date"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:50
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:60
 msgid "judgment.published"
 msgstr "Published?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:54
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:64
 msgid "judgment.sensitive"
 msgstr "Contains sensitive information?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:58
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:68
 msgid "judgment.supplemental"
 msgstr "Has supplemental documents?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:62
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:72
 msgid "judgment.anonymised"
 msgstr "This Judgment has been anonymised"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:66
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:76
 msgid "judgment.assigned_to"
 msgstr "Assigned to"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:68
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:78
 msgid "judgments.noone"
 msgstr "No one"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:84
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:94
 msgid "judgment.previous_versions"
 msgstr "Previous versions of this Judgment"
 


### PR DESCRIPTION
## Changes in this PR:

Adds a magic link to a judgment's detail view, which when clicked will pop open a prefilled issue creation form in Jira (as per [their documentation](https://confluence.atlassian.com/jirakb/how-to-create-issues-using-direct-html-links-in-jira-server-159474.html).

- [ ] Requires `JIRA_INSTANCE` env variable(s) to be created
