### PR TITLE
Judgment toolbar refinements

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
@@ -5,15 +5,33 @@
   padding: $spacer__unit;
   border-bottom: 0.125rem solid $color__grey;
 
-  a {
+  &__button {
     background-color: $color__aqua-blue;
     color: $color__white;
     padding: calc($spacer__unit / 2) calc($spacer__unit * 1.5);
     display: inline-block;
     text-decoration: none;
+    transition: all 0.2s;
+
+    &:hover {
+      background-color: scale-color($color__aqua-blue, $lightness: +8%);
+      color: $color__white;
+    }
+
+    &:visited {
+      color: $color__white;
+    }
 
     &.judgment-toolbar__delete {
-      background-color: red;
+      background-color: $color__red;
+    }
+
+    &-selected {
+      background-color: scale-color($color__aqua-blue, $lightness: -30%);
+    }
+
+    &[aria-disabled="true"]{
+      background-color: scale-color($color__aqua-blue, $saturation: -95%, $lightness: +55%);
     }
   }
 

--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 <div class="judgment-toolbar">
   <div class="judgment-toolbar__container">
-    <div class="judgment-toolbar__return-link">
-      {% if request.args.origin == 'results' %}
+    {% if request.args.origin == 'results' %}
+      <div class="judgment-toolbar__return-link">
         <a href="{{ request.args.return_link }}">
           {% translate "judgment.back" %}
         </a>
-      {% endif %}
-    </div>
+      </div>
+    {% endif %}
     <div class="judgment-toolbar__edit">
       {% if context.is_editable %}
         {% if context.judgment %}

--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -30,9 +30,6 @@
           {% translate "judgment.download_pdf" %}
         </a>
       {% endif %}
-      <a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">
-        {% translate "judgment.download_xml" %}
-      </a>
       {% if context.published %}
         <a href="https://caselaw.nationalarchives.gov.uk/{{context.judgment_uri}}" target="_blank">
           {% translate "judgment.view_on_public" %}

--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -9,32 +9,53 @@
       </div>
     {% endif %}
     <div class="judgment-toolbar__edit">
+
       {% if context.is_editable %}
-        {% if context.judgment %}
-          <a class="" href="{% url 'edit' %}?judgment_uri={{context.judgment_uri}}">
-            {% translate "judgment.edit_this_judgment" %}
-          </a>
-        {% else %}
-          <a class="" href="{% url 'detail' %}?judgment_uri={{context.judgment_uri}}">
-            {% translate "judgment.view_this_judgment" %}
-          </a>
-        {% endif %}
+        <a class="judgment-toolbar__button{% if not context.judgment %} judgment-toolbar__button-selected{% endif %}" href="{% url 'edit' %}?judgment_uri={{context.judgment_uri}}">
+          {% translate "judgment.edit_this_judgment" %}
+        </a>
+        <a class="judgment-toolbar__button{% if context.judgment %} judgment-toolbar__button-selected{% endif %}" href="{% url 'detail' %}?judgment_uri={{context.judgment_uri}}">
+          {% translate "judgment.view_this_judgment" %}
+        </a>
+      {% else %}
+        <span class="judgment-toolbar__button" aria-disabled="true">
+          {% translate "judgment.edit_this_judgment" %}
+        </span>
+        <span class="judgment-toolbar__button" aria-disabled="true">
+          {% translate "judgment.view_this_judgment" %}
+        </span>
       {% endif %}
+
       {% if context.docx_url %}
-        <a href="{{ context.docx_url }}">
+        <a class="judgment-toolbar__button" href="{{ context.docx_url }}">
           {% translate "judgment.download_docx" %}
         </a>
+      {% else %}
+        <span class="judgment-toolbar__button" aria-disabled="true">
+          {% translate "judgment.download_docx" %}
+        </span>
       {% endif %}
+
       {% if context.pdf_url %}
-        <a href="{{ context.pdf_url }}">
+        <a class="judgment-toolbar__button" href="{{ context.pdf_url }}">
           {% translate "judgment.download_pdf" %}
         </a>
+      {% else %}
+        <span class="judgment-toolbar__button" aria-disabled="true">
+          {% translate "judgment.download_pdf" %}
+        </span>
       {% endif %}
+
       {% if context.published %}
-        <a href="https://caselaw.nationalarchives.gov.uk/{{context.judgment_uri}}" target="_blank">
+        <a class="judgment-toolbar__button" href="https://caselaw.nationalarchives.gov.uk/{{context.judgment_uri}}" target="_blank">
           {% translate "judgment.view_on_public" %}
         </a>
+      {% else %}
+        <span class="judgment-toolbar__button" aria-disabled="true">
+          {% translate "judgment.view_on_public" %}
+        </span>
       {% endif %}
+
       {% if context.is_failure %}
         <form action="/delete" method="post">
           {% csrf_token %}
@@ -50,6 +71,7 @@
           />
         </form>
       {% endif %}
+
     </div>
     {% if context.version %}
       <div class="judgment-toolbar__version">

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -13,6 +13,7 @@
     {% if context.pdf_url %}
       <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
     {% endif %}
+    <a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_xml" %}</a>
   </aside>
   <div class="edit-component">
     <div class="edit-component__container">

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -18,6 +18,7 @@ def detail(request):
     try:
         judgment_xml = api_client.get_judgment_xml(judgment_uri, show_unpublished=True)
         judgment_root = get_judgment_root(judgment_xml)
+        context["published"] = api_client.get_published(judgment_uri)
         context["is_editable"] = True
         if "failures" in judgment_uri:
             context["is_failure"] = True

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-23 13:56+0000\n"
+"POT-Creation-Date: 2023-01-23 17:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,15 +58,11 @@ msgstr "Download the original judgment"
 msgid "judgment.download_pdf"
 msgstr "Download PDF"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:34
-msgid "judgment.download_xml"
-msgstr "Download XML"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:38
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:35
 msgid "judgment.view_on_public"
 msgstr "View on public site"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:52
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:49
 msgid "judgment.delete"
 msgstr "Delete judgment"
 
@@ -134,51 +130,55 @@ msgstr "Return to Find and manage case law"
 msgid "judgments.submitteremail"
 msgstr "Contact email:"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:25
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:16
+msgid "judgment.download_xml"
+msgstr "Download XML"
+
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:26
 msgid "judgment.edit_judgment"
 msgstr "Edit Judgment"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:29
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:30
 msgid "judgment.judgment_name"
 msgstr "Judgment name"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:34
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:35
 msgid "judgment.neutral_citation"
 msgstr "Neutral citation"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:39
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:40
 msgid "judgment.court"
 msgstr "Court"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:44
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:45
 msgid "judgment.judgment_date"
 msgstr "Judgment date"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:49
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:50
 msgid "judgment.published"
 msgstr "Published?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:53
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:54
 msgid "judgment.sensitive"
 msgstr "Contains sensitive information?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:57
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:58
 msgid "judgment.supplemental"
 msgstr "Has supplemental documents?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:61
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:62
 msgid "judgment.anonymised"
 msgstr "This Judgment has been anonymised"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:65
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:66
 msgid "judgment.assigned_to"
 msgstr "Assigned to"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:67
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:68
 msgid "judgments.noone"
 msgstr "No one"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:83
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:84
 msgid "judgment.previous_versions"
 msgstr "Previous versions of this Judgment"
 

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-23 17:13+0000\n"
+"POT-Creation-Date: 2023-01-23 20:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,28 +41,33 @@ msgid "judgment.back"
 msgstr "Back to search results"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:15
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:22
 msgid "judgment.edit_this_judgment"
-msgstr "Edit this Judgment"
+msgstr "Edit judgment"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:19
-msgid "judgment.view_this_judgment"
-msgstr "View this Judgment"
-
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:18
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:25
+msgid "judgment.view_this_judgment"
+msgstr "View as HTML"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:31
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:35
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:11
 msgid "judgment.download_docx"
-msgstr "Download the original judgment"
+msgstr "Download original .docx"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:30
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:41
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:45
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:14
 msgid "judgment.download_pdf"
 msgstr "Download PDF"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:35
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:51
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:55
 msgid "judgment.view_on_public"
 msgstr "View on public site"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:49
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:70
 msgid "judgment.delete"
 msgstr "Delete judgment"
 


### PR DESCRIPTION
A series of adjustments (mostly visual) to the judgment toolbar:

- Improvements to conditional wrapping to eliminate an empty (layout changing) element, fixing unbalanced whitespace and further reducing header height
- Migrate the "download XML" link to the sidebar of the judgment edit page, since it's not part of the key workflow
- Fix adding context to judgment content view, so the 'view on public site' button correctly displays
- Make all toolbar buttons display in all contexts, even if disabled, so that toolbar buttons in the same place always do the same thing
- Subtle hover effect on buttons helps highlight current interaction state
- The button for the current view is highlighted differently
- Changes to language in toolbar buttons makes intent clearer, improves consistency, reduces overall length and removes unnecessary repetition of context

## Changes in this PR:

## Screenshots of UI changes:

### Before

![localhost_3000_edit_judgment_uri=ewhc_admin_2023_81 (1)](https://user-images.githubusercontent.com/619082/214143351-b3ccab8d-64a3-438d-9d60-6eb0bc7c0370.png)

### After

![localhost_3000_edit_judgment_uri=ewhc_admin_2023_81](https://user-images.githubusercontent.com/619082/214143364-6d11a7ed-a85d-462b-9469-77a2ab3678aa.png)
