### PR TITLE
removed download xml view in eui

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -30,9 +30,6 @@
           {% translate "judgment.download_pdf" %}
         </a>
       {% endif %}
-      <a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">
-        {% translate "judgment.download_xml" %}
-      </a>
       {% if context.published %}
         <a href="https://caselaw.nationalarchives.gov.uk/{{context.judgment_uri}}" target="_blank">
           {% translate "judgment.view_on_public" %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
If we remove view download as xml then Editors will be able to find the tools they need faster


## Trello card / Rollbar error (etc)
https://trello.com/c/bSJ1UPj0/356-eui-experiment-remove-view-as-xml-option-on-eui
## Screenshots of UI changes:

### Before
View
![Trello-356-view-judgment-xml](https://user-images.githubusercontent.com/75584408/214147029-2ce8c263-1455-4c78-93f1-e6d78942f1c1.png)
Edit
![Trello-356-edit-judgment-xml](https://user-images.githubusercontent.com/75584408/214147125-221cf8f2-d3ce-4c38-ac8e-c8d859870816.png)
### After
View
![Trello-356-view-xml-removed](https://user-images.githubusercontent.com/75584408/214147498-9d170622-f771-4647-b9af-ec3fd99aa29c.png)
Edit
![Trello-356-edit-view-xml-removed](https://user-images.githubusercontent.com/75584408/214147472-d198c684-53f1-4e56-95ac-6fec4837e889.png)

- [ ] Requires env variable(s) to be updated

