### PR TITLE
Remove flake8-isort from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,13 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
+        args: ["--profile", "black"]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]
-        additional_dependencies: [flake8-isort]
 
   - repo: https://github.com/thibaudcolas/curlylint
     rev: v0.13.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,25 +3,25 @@ default_stages: [commit]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         args: ["--profile", "black"]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]


### PR DESCRIPTION
We already have isort running in pre-commit, so no need to run it twice.

- Remove isort from flake8
- Tell isort to use the black-compatible profile to avoid potential future conflicts
- Update versions of tools in pre-commit