### PR TITLE
Add links to create pre-populated emails to submitter

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -1,4 +1,6 @@
-.edit-component, .list-versions-component, .judgment-info-component {
+.edit-component,
+.list-versions-component,
+.judgment-info-component {
   background-color: $color__light-grey;
   padding: $spacer__unit;
 
@@ -77,18 +79,42 @@
 }
 
 .judgment-info-component {
-  float:right;
+  float: right;
   position: sticky;
   right: 0;
   top: 0;
   width: 20vw;
+
   a {
     display: block;
   }
+
   ul {
     padding-left: 0;
   }
+
   li {
     list-style: none;
+  }
+}
+
+.create-email-block {
+  border: 2px #FFB952 solid;
+  display: inline-block;
+  padding: 0px 10px 0px 0;
+
+  &__list-header {
+    padding-left: 10px;
+    margin-top: 10px;
+  }
+
+  &__list {
+    list-style: none;
+    padding-left: 10px;
+    margin-top: 5px;
+  }
+
+  &__list-link {
+    padding-bottom: 5px;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -3,13 +3,11 @@
 .judgment-info-component {
   background-color: $color__light-grey;
   padding: $spacer__unit;
-
   &__container {
     @include container;
     text-align: left;
     padding: calc(#{$spacer__unit} * 2);
   }
-
   &__header {
     font-size: 1rem;
     line-height: 2.8rem;
@@ -19,102 +17,96 @@
     color: $color__almost-black;
     margin: 0 calc(#{$spacer__unit} * 1.5);
   }
-
   &__more-options {
     margin-top: calc($spacer__unit * 2);
   }
-
   &__success {
     background-color: $color__green;
     width: fit-content;
     padding: calc(#{$spacer__unit} / 2);
   }
-
   &__error {
     background-color: $color__red;
     width: fit-content;
     padding: calc(#{$spacer__unit} / 2);
   }
-
   &__panel {
     padding: calc(#{$spacer__unit} / 2) 0;
   }
-
   input[type=submit] {
     @include call-to-action-button;
     display: block;
     padding-left: calc(#{$spacer__unit} * 3);
     padding-right: calc(#{$spacer__unit} * 3);
   }
-
   span {
     font-weight: bold;
   }
-
   &__metadata_name-input {
     @include text_field;
     width: 80%;
     min-height: calc(#{$spacer__unit} * 3);
     font-size: 1.2rem;
-
     @media (min-width: $grid__breakpoint-small) {
       width: 20rem;
     }
-
     @media (min-width: $grid__breakpoint-medium) {
       width: 25rem;
     }
-
     @media (min-width: $grid__breakpoint-extra-large) {
       width: 35rem;
     }
   }
-
   input[type=checkbox] {
     &:focus {
       @include focus-default;
-
     }
   }
 }
-
 .judgment-info-component {
   float: right;
   position: sticky;
   right: 0;
   top: 0;
   width: 20vw;
-
   a {
     display: block;
   }
-
   ul {
     padding-left: 0;
   }
-
   li {
     list-style: none;
   }
 }
-
 .create-email-block {
   border: 2px #FFB952 solid;
   display: inline-block;
   padding: 0px 10px 0px 0;
-
+  margin-left: 15%;
   &__list-header {
     padding-left: 10px;
-    margin-top: 10px;
+    margin: 10px 0;
   }
-
   &__list {
     list-style: none;
     padding-left: 10px;
-    margin-top: 5px;
+    margin: 5px 0;
   }
-
   &__list-link {
-    padding-bottom: 5px;
+    padding-bottom: 10px;
+  }
+}
+.edit-component__actions {
+  display: inline-block;
+  width: auto;
+  padding: calc(#{$spacer__unit} / 2) 0;
+}
+@media (max-width: 800px) {
+  .edit-component__actions {
+    display: block;
+  }
+  .create-email-block {
+    margin: 20px 0;
   }
 }

--- a/ds_caselaw_editor_ui/templates/emails/confirmation_to_submitter.txt
+++ b/ds_caselaw_editor_ui/templates/emails/confirmation_to_submitter.txt
@@ -1,0 +1,7 @@
+We are pleased to inform you that your judgment reference {{ reference }} has been published on Find Case Law, and can be viewed at {{ public_judgment_url }}.
+
+Please check through the content of the published judgment for any errors.
+
+We cannot make any amendments to the content or formatting of the judgment. If you wish to supply us with an amended version of the judgment please resubmit it via TDR.
+
+If you need to contact us regarding your judgment please email judgments@nationalarchives.gov.uk quoting your case details and TDR reference "{{ reference }}".

--- a/ds_caselaw_editor_ui/templates/includes/create_emails_block.html
+++ b/ds_caselaw_editor_ui/templates/includes/create_emails_block.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <aside class="create-email-block">
-  <h3 class="create-email-block__list-header">{% translate "judgment.email_submitter.header" %}</h3>
+  <h4 class="create-email-block__list-header">{% translate "judgment.email_submitter.header" %}</h4>
   <ul class="create-email-block__list">
     <li class="create-email-block__list-link"><a href="{{ context.email_raise_issue_link }}">{% translate "judgment.email_submitter.issue" %}</a></li>
     {% if context.published %}

--- a/ds_caselaw_editor_ui/templates/includes/create_emails_block.html
+++ b/ds_caselaw_editor_ui/templates/includes/create_emails_block.html
@@ -3,6 +3,8 @@
   <h3 class="create-email-block__list-header">{% translate "judgment.email_submitter.header" %}</h3>
   <ul class="create-email-block__list">
     <li class="create-email-block__list-link"><a href="{{ context.email_raise_issue_link }}">{% translate "judgment.email_submitter.issue" %}</a></li>
-    <li class="create-email-block__list-link"><a href="{{ context.email_confirmation_link }}">{% translate "judgment.email_submitter.confirm" %}</a></li>
+    {% if context.published %}
+      <li class="create-email-block__list-link"><a href="{{ context.email_confirmation_link }}">{% translate "judgment.email_submitter.confirm" %}</a></li>
+    {% endif %}
   </ul>
 </aside>

--- a/ds_caselaw_editor_ui/templates/includes/create_emails_block.html
+++ b/ds_caselaw_editor_ui/templates/includes/create_emails_block.html
@@ -1,8 +1,8 @@
 {% load i18n %}
-<div class="create-email-block">
+<aside class="create-email-block">
   <h3 class="create-email-block__list-header">{% translate "judgment.email_submitter.header" %}</h3>
   <ul class="create-email-block__list">
     <li class="create-email-block__list-link"><a href="{{ context.email_raise_issue_link }}">{% translate "judgment.email_submitter.issue" %}</a></li>
     <li class="create-email-block__list-link"><a href="{{ context.email_confirmation_link }}">{% translate "judgment.email_submitter.confirm" %}</a></li>
   </ul>
-</div>
+</aside>

--- a/ds_caselaw_editor_ui/templates/includes/create_emails_list.html
+++ b/ds_caselaw_editor_ui/templates/includes/create_emails_list.html
@@ -1,7 +1,8 @@
+{% load i18n %}
 <div class="create-email-block">
-    <h3 class="create-email-block__list-header">Create an email to</h3>
-    <ul class="create-email-block__list">
-        <li class="create-email-block__list-link"><a href="mailto:? &subject=Issue(s) found with TDR number here &body=this is an area to add text">Raise issue(s) to submitter</a></li>
-        <li class="create-email-block__list-link"><a href="mailto:? &subject=Published ref TDR number here &body=Dear ... We are pleased to inform you judgment with consignment ...">Confirm publication</a></li>
-    </ul>
+  <h3 class="create-email-block__list-header">{% translate "judgment.email_submitter.header" %}</h3>
+  <ul class="create-email-block__list">
+    <li class="create-email-block__list-link"><a href="{{ context.email_raise_issue_link }}">{% translate "judgment.email_submitter.issue" %}</a></li>
+    <li class="create-email-block__list-link"><a href="{{ context.email_confirmation_link }}">{% translate "judgment.email_submitter.confirm" %}</a></li>
+  </ul>
 </div>

--- a/ds_caselaw_editor_ui/templates/includes/create_emails_list.html
+++ b/ds_caselaw_editor_ui/templates/includes/create_emails_list.html
@@ -1,0 +1,7 @@
+<div class="create-email-block">
+    <h3 class="create-email-block__list-header">Create an email to</h3>
+    <ul class="create-email-block__list">
+        <li class="create-email-block__list-link"><a href="mailto:? &subject=Issue(s) found with TDR number here &body=this is an area to add text">Raise issue(s) to submitter</a></li>
+        <li class="create-email-block__list-link"><a href="mailto:? &subject=Published ref TDR number here &body=Dear ... We are pleased to inform you judgment with consignment ...">Confirm publication</a></li>
+    </ul>
+</div>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -82,15 +82,14 @@
             {% endfor %}
           </select>
         </div>
-        <div class="edit-component__panel">
+
+        <div class="edit-component__actions">
           <input type="hidden" name="judgment_uri" value="{{context.judgment_uri}}"/>
           <input type="submit" value="Save"/>
         </div>
-
         {% flag "email_submitter_block" %}
         {% include 'includes/create_emails_block.html' %}
         {% endflag %}
-
       </form>
     </div>
   </div>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -85,6 +85,9 @@
           <input type="hidden" name="judgment_uri" value="{{context.judgment_uri}}"/>
           <input type="submit" value="Save"/>
         </div>
+        <aside class="create-email-block">
+          {% include 'includes/create_emails_list.html' %}
+        </aside>
       </form>
     </div>
   </div>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -85,9 +85,9 @@
           <input type="hidden" name="judgment_uri" value="{{context.judgment_uri}}"/>
           <input type="submit" value="Save"/>
         </div>
-        <aside class="create-email-block">
-          {% include 'includes/create_emails_list.html' %}
-        </aside>
+
+        {% include 'includes/create_emails_block.html' %}
+
       </form>
     </div>
   </div>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -1,4 +1,5 @@
 {% extends "layouts/judgment.html" %}
+{% load waffle_tags %}
 {% block content %}
   {% load i18n %}
   <aside class="judgment-info-component">
@@ -86,7 +87,9 @@
           <input type="submit" value="Save"/>
         </div>
 
+        {% flag "email_submitter_block" %}
         {% include 'includes/create_emails_block.html' %}
+        {% endflag %}
 
       </form>
     </div>

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -76,7 +76,7 @@ class EditJudgmentView(View):
 
     def build_email_link_with_content(self, address, subject, body=None):
 
-        params = {"subject": subject}
+        params = {"subject": "[TNA Find Caselaw] {subject}".format(subject=subject)}
 
         if body:
             params["body"] = body
@@ -87,7 +87,7 @@ class EditJudgmentView(View):
 
     def build_raise_issue_email_link(self, context):
 
-        subject_string = "[TNA Find Caselaw] Issue(s) found with {reference}".format(
+        subject_string = "Issue(s) found with {reference}".format(
             reference=context["consignment_reference"]
         )
 
@@ -97,7 +97,7 @@ class EditJudgmentView(View):
 
     def build_confirmation_email_link(self, context):
 
-        subject_string = "[TNA Find Caselaw] Your upload reference {reference} has been published".format(
+        subject_string = "Your upload reference {reference} has been published".format(
             reference=context["consignment_reference"]
         )
 

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -75,7 +75,6 @@ class EditJudgmentView(View):
             return []
 
     def build_email_link_with_content(self, address, subject, body=None):
-
         params = {"subject": "[TNA Find Caselaw] {subject}".format(subject=subject)}
 
         if body:
@@ -86,7 +85,6 @@ class EditJudgmentView(View):
         )
 
     def build_raise_issue_email_link(self, context):
-
         subject_string = "Issue(s) found with {reference}".format(
             reference=context["consignment_reference"]
         )
@@ -96,7 +94,6 @@ class EditJudgmentView(View):
         )
 
     def build_confirmation_email_link(self, context):
-
         subject_string = "Your upload reference {reference} has been published".format(
             reference=context["consignment_reference"]
         )

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -11,6 +11,7 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 from django.template import loader
 from django.urls import reverse
+from django.utils.text import wrap
 from django.utils.translation import gettext
 from django.views.generic import View
 from requests_toolbelt.multipart import decoder
@@ -100,8 +101,22 @@ class EditJudgmentView(View):
             reference=context["consignment_reference"]
         )
 
+        email_context = {
+            "reference": context["consignment_reference"],
+            "public_judgment_url": "https://caselaw.nationalarchives.gov.uk/{uri}".format(
+                uri=context["judgment_uri"]
+            ),
+        }
+
+        body_string = wrap(
+            loader.render_to_string(
+                "emails/confirmation_to_submitter.txt", email_context
+            ),
+            76,
+        )
+
         return self.build_email_link_with_content(
-            context["source_email"], subject_string
+            context["source_email"], subject_string, body_string
         )
 
     def build_jira_create_link(self, request, context):

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -38,7 +38,7 @@ msgstr "Find and manage case law"
 
 #: ds_caselaw_editor_ui/templates/includes/create_emails_list.html:3
 msgid "judgment.email_submitter.header"
-msgstr "Create an email to"
+msgstr "Create an email template"
 
 #: ds_caselaw_editor_ui/templates/includes/create_emails_list.html:5
 msgid "judgment.email_submitter.issue"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-24 11:30+0000\n"
+"POT-Creation-Date: 2023-02-03 12:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,12 +19,12 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ds_caselaw_editor_ui/templates/account/login.html:5
-#: ds_caselaw_editor_ui/templates/account/login.html:10
-#: ds_caselaw_editor_ui/templates/account/login.html:19
+#: ds_caselaw_editor_ui/templates/account/login.html:12
+#: ds_caselaw_editor_ui/templates/account/login.html:21
 msgid "Sign In"
 msgstr ""
 
-#: ds_caselaw_editor_ui/templates/account/login.html:18
+#: ds_caselaw_editor_ui/templates/account/login.html:20
 msgid "Forgot Password?"
 msgstr ""
 
@@ -35,6 +35,18 @@ msgstr ""
 #: ds_caselaw_editor_ui/templates/pages/home.html:13
 msgid "common.findcaselaw"
 msgstr "Find and manage case law"
+
+#: ds_caselaw_editor_ui/templates/includes/create_emails_list.html:3
+msgid "judgment.email_submitter.header"
+msgstr "Create an email to"
+
+#: ds_caselaw_editor_ui/templates/includes/create_emails_list.html:5
+msgid "judgment.email_submitter.issue"
+msgstr "Raise issue(s) to submitter"
+
+#: ds_caselaw_editor_ui/templates/includes/create_emails_list.html:6
+msgid "judgment.email_submitter.confirm"
+msgstr "Confirm publication"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:7
 msgid "judgment.back"
@@ -86,6 +98,7 @@ msgstr "Assigned:"
 
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:25
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:11
+#: judgments/views/edit_judgment.py:137
 msgid "judgments.consignmentref"
 msgstr "TDR Ref:"
 
@@ -99,6 +112,7 @@ msgstr "Court:"
 
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:49
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:9
+#: judgments/views/edit_judgment.py:133
 msgid "judgments.submitter"
 msgstr "Submitter:"
 
@@ -132,6 +146,7 @@ msgid "judgment.return_home"
 msgstr "Return to Find and manage case law"
 
 #: ds_caselaw_editor_ui/templates/judgment/edit.html:10
+#: judgments/views/edit_judgment.py:135
 msgid "judgments.submitteremail"
 msgstr "Contact email:"
 
@@ -187,7 +202,7 @@ msgstr "Assigned to"
 msgid "judgments.noone"
 msgstr "No one"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:94
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:97
 msgid "judgment.previous_versions"
 msgstr "Previous versions of this Judgment"
 


### PR DESCRIPTION
## Changes in this PR:

Links are added to the judgment details page which allow editors to quickly open emails to the submitter with pre-filled content.

## Screenshot

![localhost_3000_edit_judgment_uri=ukut_lc_2023_27 (2)](https://user-images.githubusercontent.com/619082/216992843-9d8ffbf4-a5a2-4f67-b4bb-1fbee446d4c5.png)

## Next steps

- [ ] This is feature-flagged behind `email_submitter_block`, create this flag for testing

