### PR TITLE
Add migration to production Django entrypoint

### DIFF
--- a/compose/production/django/entrypoint
+++ b/compose/production/django/entrypoint
@@ -39,4 +39,7 @@ until postgres_ready; do
 done
 >&2 echo 'PostgreSQL is available'
 
+>&2 echo 'Considering migrations...'
+python manage.py migrate
+
 exec "$@"


### PR DESCRIPTION
We're not 100% sure if this is the correct place to run it, but we're broadly agreed this approach is acceptable.
https://dxw.slack.com/archives/C04FQ3GFGUQ/p1675181665841469

https://trello.com/c/Q4Cu8fcv/349-ensure-django-migrations-are-run-on-deploy-of-pui-staging-and-prod