### PR TITLE
Add django-waffle

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -76,6 +76,7 @@ THIRD_PARTY_APPS = [
     "allauth.account",
     "allauth.socialaccount",
     "stronghold",
+    "waffle",
 ]
 
 LOCAL_APPS = [
@@ -142,6 +143,7 @@ MIDDLEWARE = [
     "rollbar.contrib.django.middleware.RollbarNotifierMiddleware",
     "stronghold.middleware.LoginRequiredMiddleware",
     "django.middleware.cache.FetchFromCacheMiddleware",
+    "waffle.middleware.WaffleMiddleware",
 ]
 
 # STATIC

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ django-allauth==0.50.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.14.0  # https://github.com/django-crispy-forms/django-crispy-forms
 crispy-bootstrap5==0.7  # https://github.com/django-crispy-forms/crispy-bootstrap5
 django-redis==5.2.0  # https://github.com/jazzband/django-redis
+django-waffle==3.0.0  # https://github.com/django-waffle/django-waffle
 
 requests~=2.28.1
 xmltodict~=0.13.0


### PR DESCRIPTION
django-waffle allows us to use feature flags to turn specific bits of the application on or off on a very granular basis, ideal for user testing and staged rollout.

**Heads up:** We should probably approve and merge [the ADR](https://github.com/nationalarchives/ds-find-caselaw-docs/pull/132) first.