### PR TITLE
Wrap login form in a text container

### DIFF
--- a/ds_caselaw_editor_ui/templates/account/login.html
+++ b/ds_caselaw_editor_ui/templates/account/login.html
@@ -7,16 +7,20 @@
 
 {% block content %}
 
-  <h1>{% trans "Sign In" %}</h1>
+  <div class="standard-text-template">
 
-  <form class="login" method="POST" action="{% url 'account_login' %}">
-    {% csrf_token %}
-    {{ form.as_p }}
-    {% if redirect_field_value %}
-      <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-    {% endif %}
-    <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
-    <button class="primaryAction" type="submit">{% trans "Sign In" %}</button>
-  </form>
+    <h1>{% trans "Sign In" %}</h1>
+
+    <form class="login" method="POST" action="{% url 'account_login' %}">
+      {% csrf_token %}
+      {{ form.as_p }}
+      {% if redirect_field_value %}
+        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+      {% endif %}
+      <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+      <button class="primaryAction" type="submit">{% trans "Sign In" %}</button>
+    </form>
+
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
The login form was not properly wrapped in a container, meaning it had no padding applied. This was visually not great.

## Changes in this PR:

Wrap the login form in a text container

## Screenshots of UI changes:

### Before

![localhost_3000_accounts_login__next=_admin_ (1)](https://user-images.githubusercontent.com/619082/216363719-65f7fba3-a716-4b1e-b23b-d54e7769fca3.png)

### After

![localhost_3000_accounts_login__next=_admin_](https://user-images.githubusercontent.com/619082/216363669-db27d605-2be3-401c-9aba-fbe6c5d3bce3.png)

