### PR TITLE
Assorted style/semantics improvements to edit judgment sidebar

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -70,15 +70,28 @@
   right: 0;
   top: 0;
   width: 20vw;
-  a {
-    display: block;
-  }
-  ul {
-    padding-left: 0;
-  }
-  li {
-    list-style: none;
-    margin-top: 0.4rem;
+
+  &__block {
+
+    margin-bottom: 2rem;
+
+    h4 {
+      margin-bottom: 0.6rem;
+    }
+
+    a {
+      display: block;
+    }
+
+    ul {
+      padding-left: 0;
+    }
+
+    li {
+      list-style: none;
+      margin-top: 0.4rem;
+    }
+
   }
 
   &__label {

--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -77,6 +77,17 @@
   }
   li {
     list-style: none;
+    margin-top: 0.4rem;
+  }
+
+  &__label {
+    font-size: 0.9rem;
+    font-weight: bold;
+
+    &::after{
+      content: "\a";
+      white-space: pre;
+    }
   }
 }
 .create-email-block {

--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -63,8 +63,9 @@
     }
   }
 }
-.judgment-info-component {
-  float: right;
+
+.judgment-sidebar {
+  float:right;
   position: sticky;
   right: 0;
   top: 0;

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -3,9 +3,9 @@
 <h4>Submission</h4>
 
 <ul>
-  <li>{% translate "judgments.submitter" %} {{context.source_name}}</li>
-  <li>{% translate "judgments.submitteremail" %} <a href="mailto:{{context.source_email}}">{{context.source_email}}</a></li>
-  <li>{% translate "judgments.consignmentref" %} {{context.consignment_reference}}</li>
+  <li>{% translate "judgments.submitter" %}: {{context.source_name}}</li>
+  <li>{% translate "judgments.submitteremail" %}: <a href="mailto:{{context.source_email}}">{{context.source_email}}</a></li>
+  <li>{% translate "judgments.consignmentref" %}: {{context.consignment_reference}}</li>
 </ul>
 
 <h4>Downloads</h4>

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -15,19 +15,23 @@
 
   <h4>Downloads</h4>
 
-  {% if context.docx_url %}
-    <a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a>
-  {% endif %}
-  {% if context.pdf_url %}
-    <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
-  {% endif %}
-  <a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_xml" %}</a>
+  <ul>
+    {% if context.docx_url %}
+      <li><a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a></li>
+    {% endif %}
+    {% if context.pdf_url %}
+      <li><a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a></li>
+    {% endif %}
+    <li><a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_xml" %}</a></li>
+  </ul>
 
 </div>
 <div class="judgment-sidebar__block">
 
   <h4>Tools</h4>
 
-  <p><a href="{{ context.jira_create_link }}" target="_blank" rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a></p>
+  <ul>
+    <li><a href="{{ context.jira_create_link }}" target="_blank" rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a></li>
+  </ul>
 
 </div>

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -3,9 +3,9 @@
 <h4>Submission</h4>
 
 <ul>
-  <li><span class="judgment-info-component__label">{% translate "judgments.submitter" %}:</span> {{context.source_name}}</li>
-  <li><span class="judgment-info-component__label">{% translate "judgments.submitteremail" %}:</span> <a href="mailto:{{context.source_email}}">{{context.source_email}}</a></li>
-  <li><span class="judgment-info-component__label">{% translate "judgments.consignmentref" %}:</span> {{context.consignment_reference}}</li>
+  <li><span class="judgment-sidebar__label">{% translate "judgments.submitter" %}:</span> {{context.source_name}}</li>
+  <li><span class="judgment-sidebar__label">{% translate "judgments.submitteremail" %}:</span> <a href="mailto:{{context.source_email}}">{{context.source_email}}</a></li>
+  <li><span class="judgment-sidebar__label">{% translate "judgments.consignmentref" %}:</span> {{context.consignment_reference}}</li>
 </ul>
 
 <h4>Downloads</h4>

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -1,23 +1,33 @@
 {% load i18n %}
 
-<h4>Submission</h4>
+<div class="judgment-sidebar__block">
 
-<ul>
-  <li><span class="judgment-sidebar__label">{% translate "judgments.submitter" %}:</span> {{context.source_name}}</li>
-  <li><span class="judgment-sidebar__label">{% translate "judgments.submitteremail" %}:</span> <a href="mailto:{{context.source_email}}">{{context.source_email}}</a></li>
-  <li><span class="judgment-sidebar__label">{% translate "judgments.consignmentref" %}:</span> {{context.consignment_reference}}</li>
-</ul>
+  <h4>Submission</h4>
 
-<h4>Downloads</h4>
+  <ul>
+    <li><span class="judgment-sidebar__label">{% translate "judgments.submitter" %}:</span> {{context.source_name}}</li>
+    <li><span class="judgment-sidebar__label">{% translate "judgments.submitteremail" %}:</span> <a href="mailto:{{context.source_email}}">{{context.source_email}}</a></li>
+    <li><span class="judgment-sidebar__label">{% translate "judgments.consignmentref" %}:</span> {{context.consignment_reference}}</li>
+  </ul>
 
-{% if context.docx_url %}
-  <a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a>
-{% endif %}
-{% if context.pdf_url %}
-  <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
-{% endif %}
-<a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_xml" %}</a>
+</div>
+<div class="judgment-sidebar__block">
 
-<h4>Tools</h4>
+  <h4>Downloads</h4>
 
-<p><a href="{{ context.jira_create_link }}" target="_blank" rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a></p>
+  {% if context.docx_url %}
+    <a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a>
+  {% endif %}
+  {% if context.pdf_url %}
+    <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
+  {% endif %}
+  <a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_xml" %}</a>
+
+</div>
+<div class="judgment-sidebar__block">
+
+  <h4>Tools</h4>
+
+  <p><a href="{{ context.jira_create_link }}" target="_blank" rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a></p>
+
+</div>

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -4,7 +4,7 @@
 
 <ul>
   <li>{% translate "judgments.submitter" %} {{context.source_name}}</li>
-  <li>{% translate "judgments.submitteremail" %} {{context.source_email}}</li>
+  <li>{% translate "judgments.submitteremail" %} <a href="mailto:{{context.source_email}}">{{context.source_email}}</a></li>
   <li>{% translate "judgments.consignmentref" %} {{context.consignment_reference}}</li>
 </ul>
 

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -3,9 +3,9 @@
 <h4>Submission</h4>
 
 <ul>
-  <li>{% translate "judgments.submitter" %}: {{context.source_name}}</li>
-  <li>{% translate "judgments.submitteremail" %}: <a href="mailto:{{context.source_email}}">{{context.source_email}}</a></li>
-  <li>{% translate "judgments.consignmentref" %}: {{context.consignment_reference}}</li>
+  <li><span class="judgment-info-component__label">{% translate "judgments.submitter" %}:</span> {{context.source_name}}</li>
+  <li><span class="judgment-info-component__label">{% translate "judgments.submitteremail" %}:</span> <a href="mailto:{{context.source_email}}">{{context.source_email}}</a></li>
+  <li><span class="judgment-info-component__label">{% translate "judgments.consignmentref" %}:</span> {{context.consignment_reference}}</li>
 </ul>
 
 <h4>Downloads</h4>

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+
+<h4>Submission</h4>
+
+<ul>
+  <li>{% translate "judgments.submitter" %} {{context.source_name}}</li>
+  <li>{% translate "judgments.submitteremail" %} {{context.source_email}}</li>
+  <li>{% translate "judgments.consignmentref" %} {{context.consignment_reference}}</li>
+</ul>
+
+<h4>Downloads</h4>
+
+{% if context.docx_url %}
+  <a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a>
+{% endif %}
+{% if context.pdf_url %}
+  <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
+{% endif %}
+<a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_xml" %}</a>
+
+<h4>Tools</h4>
+
+<p><a href="{{ context.jira_create_link }}" target="_blank" rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a></p>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -3,28 +3,7 @@
 {% block content %}
   {% load i18n %}
   <aside class="judgment-info-component">
-
-    <h4>Submission</h4>
-
-    <ul>
-      <li>{% translate "judgments.submitter" %} {{context.source_name}}</li>
-      <li>{% translate "judgments.submitteremail" %} {{context.source_email}}</li>
-      <li>{% translate "judgments.consignmentref" %} {{context.consignment_reference}}</li>
-    </ul>
-
-    <h4>Downloads</h4>
-
-    {% if context.docx_url %}
-      <a href="{{ context.docx_url }}">{% translate "judgment.download_docx" %}</a>
-    {% endif %}
-    {% if context.pdf_url %}
-      <a href="{{ context.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
-    {% endif %}
-    <a href="{% url 'detail_xml' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.download_xml" %}</a>
-
-    <h4>Tools</h4>
-
-    <p><a href="{{ context.jira_create_link }}" target="_blank" rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a></p>
+    {% include "includes/judgment_sidebar.html" %}
   </aside>
   <div class="edit-component">
     <div class="edit-component__container">

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -2,7 +2,7 @@
 {% load waffle_tags %}
 {% block content %}
   {% load i18n %}
-  <aside class="judgment-info-component">
+  <aside class="judgment-sidebar">
     {% include "includes/judgment_sidebar.html" %}
   </aside>
   <div class="edit-component">

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -137,9 +137,9 @@ class EditJudgmentView(View):
         description_string = "{editor_details_url}".format(
             editor_details_url="""{details_url}
 
-{source_name_label} {source_name}
-{source_email_label} {source_email}
-{consignment_ref_label} {consignment_ref}""".format(
+{source_name_label}: {source_name}
+{source_email_label}: {source_email}
+{consignment_ref_label}: {consignment_ref}""".format(
                 details_url=editor_details_url,
                 source_name_label=gettext("judgments.submitter"),
                 source_name=context["source_name"],

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:29+0000\n"
+"POT-Creation-Date: 2023-02-07 14:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,6 +48,57 @@ msgstr "Raise issue(s) to submitter"
 msgid "judgment.email_submitter.confirm"
 msgstr "Confirm publication"
 
+#: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html:4
+msgid "service.improved"
+msgstr "How can this service be improved?"
+
+#: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html:5
+msgid "survey.link"
+msgstr ""
+"https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_dp1FClbR0ZZdW4e?"
+"jfefe=new"
+
+#: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html:5
+msgid "survey.link.text"
+msgstr "Fill out our short survey"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:6
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:49
+#: judgments/views/edit_judgment.py:144
+msgid "judgments.submitter"
+msgstr "Submitter:"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:7
+#: judgments/views/edit_judgment.py:146
+msgid "judgments.submitteremail"
+msgstr "Contact email:"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:8
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:25
+#: judgments/views/edit_judgment.py:148
+msgid "judgments.consignmentref"
+msgstr "TDR Ref:"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:14
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:31
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:35
+msgid "judgment.download_docx"
+msgstr "Download original .docx"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:17
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:41
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:45
+msgid "judgment.download_pdf"
+msgstr "Download PDF"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:19
+msgid "judgment.download_xml"
+msgstr "Download XML"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:23
+msgid "judgment.create_in_jira"
+msgstr "Create in Jira"
+
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:7
 msgid "judgment.back"
 msgstr "Back to search results"
@@ -61,18 +112,6 @@ msgstr "Edit judgment"
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:25
 msgid "judgment.view_this_judgment"
 msgstr "View as HTML"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:31
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:35
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:18
-msgid "judgment.download_docx"
-msgstr "Download original .docx"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:41
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:45
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:21
-msgid "judgment.download_pdf"
-msgstr "Download PDF"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:51
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:55
@@ -96,12 +135,6 @@ msgstr "Submitted:"
 msgid "judgments.submission_assigned"
 msgstr "Assigned:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:25
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:12
-#: judgments/views/edit_judgment.py:148
-msgid "judgments.consignmentref"
-msgstr "TDR Ref:"
-
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:33
 msgid "judgments.ncn"
 msgstr "NCN:"
@@ -109,12 +142,6 @@ msgstr "NCN:"
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:41
 msgid "judgments.court"
 msgstr "Court:"
-
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:49
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:10
-#: judgments/views/edit_judgment.py:144
-msgid "judgments.submitter"
-msgstr "Submitter:"
 
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:57
 msgid "judgments.editor_priority"
@@ -145,64 +172,51 @@ msgstr "Judgment successfully deleted"
 msgid "judgment.return_home"
 msgstr "Return to Find and manage case law"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:11
-#: judgments/views/edit_judgment.py:146
-msgid "judgments.submitteremail"
-msgstr "Contact email:"
-
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:23
-msgid "judgment.download_xml"
-msgstr "Download XML"
-
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:27
-msgid "judgment.create_in_jira"
-msgstr "Create in Jira"
-
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:37
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:16
 msgid "judgment.edit_judgment"
 msgstr "Edit Judgment"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:41
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:20
 msgid "judgment.judgment_name"
 msgstr "Judgment name"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:46
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:25
 msgid "judgment.neutral_citation"
 msgstr "Neutral citation"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:51
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:30
 msgid "judgment.court"
 msgstr "Court"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:56
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:35
 msgid "judgment.judgment_date"
 msgstr "Judgment date"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:61
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:40
 msgid "judgment.published"
 msgstr "Published?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:65
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:44
 msgid "judgment.sensitive"
 msgstr "Contains sensitive information?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:69
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:48
 msgid "judgment.supplemental"
 msgstr "Has supplemental documents?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:73
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:52
 msgid "judgment.anonymised"
 msgstr "This Judgment has been anonymised"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:77
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:56
 msgid "judgment.assigned_to"
 msgstr "Assigned to"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:79
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:58
 msgid "judgments.noone"
 msgstr "No one"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:99
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:78
 msgid "judgment.previous_versions"
 msgstr "Previous versions of this Judgment"
 
@@ -240,17 +254,6 @@ msgstr ""
 #: judgments/views/delete.py:14
 msgid "judgment.delete_a_judgment"
 msgstr "Delete a judgment"
-
-#~ msgid "service.improved"
-#~ msgstr "How can this service be improved?"
-
-#~ msgid "survey.link"
-#~ msgstr ""
-#~ "https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_dp1FClbR0ZZdW4e?"
-#~ "jfefe=new"
-
-#~ msgid "survey.link.text"
-#~ msgstr "Fill out our short survey"
 
 #~ msgid "common.home"
 #~ msgstr "Home"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -66,18 +66,18 @@ msgstr "Fill out our short survey"
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:49
 #: judgments/views/edit_judgment.py:144
 msgid "judgments.submitter"
-msgstr "Submitter:"
+msgstr "Submitter"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:7
 #: judgments/views/edit_judgment.py:146
 msgid "judgments.submitteremail"
-msgstr "Contact email:"
+msgstr "Contact email"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:8
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:25
 #: judgments/views/edit_judgment.py:148
 msgid "judgments.consignmentref"
-msgstr "TDR Ref:"
+msgstr "TDR Ref"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:14
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:31


### PR DESCRIPTION
## Changes in this PR:

- Sidebar is now included as its own component
- Submitter's email address is now clickable
- Presentation tweaks to labels for submission information
- Renaming of classes from `info-component` to `sidebar` to reflect the fact it's now more than info
- Slight adjustment to vertical pacing to better distinguish individual blocks of functionality
- More consistently wrap links in `<ul>`s

## Screenshots

### Before

![localhost_3000_edit_judgment_uri=ukut_lc_2023_27](https://user-images.githubusercontent.com/619082/216985443-49e30bc2-2862-4d1c-9019-b876a2f0c55b.png)

### After

![localhost_3000_edit_judgment_uri=ukut_lc_2023_27 (1)](https://user-images.githubusercontent.com/619082/216985477-2c1346d3-2eff-4bcf-bbce-8c2ff476e915.png)