### PR TITLE
Remove last Redis dependencies

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 volumes:
   production_postgres_data: {}
@@ -13,7 +13,6 @@ services:
     image: ds_caselaw_editor_ui_production_django
     depends_on:
       - postgres
-      - redis
     env_file:
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,8 +3,6 @@ python-slugify==7.0.0  # https://github.com/un33k/python-slugify
 Pillow==9.4.0  # https://github.com/python-pillow/Pillow
 argon2-cffi==21.3.0  # https://github.com/hynek/argon2_cffi
 whitenoise==6.3.0  # https://github.com/evansd/whitenoise
-redis==4.4.0  # https://github.com/redis/redis-py
-hiredis==2.1.1  # https://github.com/redis/hiredis-py
 
 # Django
 # ------------------------------------------------------------------------------
@@ -14,7 +12,6 @@ django-model-utils==4.3.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.50.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.14.0  # https://github.com/django-crispy-forms/django-crispy-forms
 crispy-bootstrap5==0.7  # https://github.com/django-crispy-forms/crispy-bootstrap5
-django-redis==5.2.0  # https://github.com/jazzband/django-redis
 django-waffle==3.0.0  # https://github.com/django-waffle/django-waffle
 
 requests~=2.28.1


### PR DESCRIPTION
Redis seems to be included in dependencies, but we don't actually make use of any redis functionality. Remove the dependencies to keep things leaner and meaner.