### PR TITLE
Fix: Images now display in the editor interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,4 +25,6 @@ PRIVATE_ASSET_BUCKET_REGION=us-east-1
 S3_REGION=eu-west-2
 SNS_TOPIC=arn:aws:sns:us-east-1:000000000000:caselaw-stg-judgment-updated
 
+XSLT_IMAGE_LOCATION=/signed-asset/
+
 JIRA_INSTANCE=INSERT_YOUR_JIRA_DOMAIN_HERE.atlassian.net

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -11,6 +11,7 @@ from .views.detail_xml import detail_xml
 from .views.edit_judgment import EditJudgmentView
 from .views.index import index
 from .views.results import results
+from .views.signed_asset import redirect_to_signed_asset
 
 urlpatterns = [
     path("edit", EditJudgmentView.as_view(), name="edit"),
@@ -22,5 +23,7 @@ urlpatterns = [
     path("assign", assign_judgment_button, name="assign"),
     path("prioritise", prioritise_judgment_button, name="prioritise"),
     path("hold", hold_judgment_button, name="hold"),
+    # redirect to signed asset URLs
+    path("signed-asset/<path:key>", redirect_to_signed_asset, name="signed-asset"),
     path("", index, name="home"),
 ]

--- a/judgments/utils/aws.py
+++ b/judgments/utils/aws.py
@@ -62,7 +62,7 @@ def uri_for_s3(uri: str):
     return uri.lstrip("/")
 
 
-def generate_docx_url(uri: str):
+def generate_signed_asset_url(key: str):
     # If there isn't a PRIVATE_ASSET_BUCKET, don't try to get the bucket.
     # This helps local environment setup where we don't use S3.
     bucket = env("PRIVATE_ASSET_BUCKET", None)
@@ -71,25 +71,21 @@ def generate_docx_url(uri: str):
 
     client = create_s3_client()
 
-    key = f'{uri}/{uri.replace("/", "_")}.docx'
-
     return client.generate_presigned_url(
         "get_object", Params={"Bucket": bucket, "Key": key}
     )
+
+
+def generate_docx_url(uri: str):
+    key = f'{uri}/{uri.replace("/", "_")}.docx'
+
+    return generate_signed_asset_url(key)
 
 
 def generate_pdf_url(uri: str):
-    bucket = env("PRIVATE_ASSET_BUCKET", None)
-    if not bucket:
-        return ""
-
-    client = create_s3_client()
-
     key = f'{uri}/{uri.replace("/", "_")}.pdf'
 
-    return client.generate_presigned_url(
-        "get_object", Params={"Bucket": bucket, "Key": key}
-    )
+    return generate_signed_asset_url(key)
 
 
 def delete_from_bucket(uri: str, bucket: str) -> None:

--- a/judgments/views/signed_asset.py
+++ b/judgments/views/signed_asset.py
@@ -1,0 +1,7 @@
+from django.shortcuts import redirect
+
+from judgments.utils.aws import generate_signed_asset_url
+
+
+def redirect_to_signed_asset(request, key):
+    return redirect(generate_signed_asset_url(key))


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes

Editors can now see images in the editor UI.
![image](https://user-images.githubusercontent.com/85497046/217614636-b4f21512-73c2-4a5c-82da-a723bbddf30c.png)


## Before

- [ ] Update the value of `XSLT_IMAGE_LOCATION` on editor deployments to be `/signed-asset/`.
