### PR TITLE
Improve coverage of mypy checks, and add mypy to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,29 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
 
+  static-analysis:
+    runs-on: ubuntu-latest
+    needs: linter
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v3
+
+      - name: Copy .env.example file
+        uses: canastro/copy-file-action@master
+        with:
+          source: ".env.example"
+          target: ".env"
+
+      - name: Build the Stack
+        run: docker-compose build django postgres
+
+      - name: Run mypy
+        run: docker-compose run django mypy ds_caselaw_editor_ui judgments
+
   # With no caching at all the entire ci process takes 4m 30s to complete!
   pytest:
     runs-on: ubuntu-latest
-
+    needs: linter
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v3

--- a/fabfile.py
+++ b/fabfile.py
@@ -138,6 +138,7 @@ def test(c):
             "django",
             "mypy",
             "ds_caselaw_editor_ui",
+            "judgments",
         ]
     )
     # Pytest

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -1,5 +1,4 @@
 import re
-from unittest import skip
 from unittest.mock import MagicMock, Mock, patch
 
 import ds_caselaw_utils
@@ -23,13 +22,6 @@ from judgments.utils.paginator import paginator
 
 
 class TestJudgment(TestCase):
-    @skip("TODO: Fix")
-    def test_valid_content(self):
-        response = self.client.get("/judgments/ewca/civ/2004/632")
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn("[2004] EWCA Civ 632", decoded_response)
-        self.assertEqual(response.status_code, 200)
-
     def test_404_response(self):
         response = self.client.get("/judgments/ewca/civ/2004/63X")
         decoded_response = response.content.decode("utf-8")

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -23,18 +23,17 @@ from judgments.utils.paginator import paginator
 
 
 class TestJudgment(TestCase):
-    @skip
+    @skip("TODO: Fix")
     def test_valid_content(self):
         response = self.client.get("/judgments/ewca/civ/2004/632")
         decoded_response = response.content.decode("utf-8")
         self.assertIn("[2004] EWCA Civ 632", decoded_response)
         self.assertEqual(response.status_code, 200)
 
-    @skip
     def test_404_response(self):
         response = self.client.get("/judgments/ewca/civ/2004/63X")
         decoded_response = response.content.decode("utf-8")
-        self.assertIn("Judgment was not found", decoded_response)
+        self.assertIn("Page not found", decoded_response)
         self.assertEqual(response.status_code, 404)
 
     def test_extract_version_uri(self):

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -230,7 +230,7 @@ class TestConverters(TestCase):
     def test_year_converter_parses_year(self):
         converter = converters.YearConverter()
         match = re.match(converter.regex, "1994")
-
+        assert isinstance(match, re.Match)
         self.assertEqual(match.group(0), "1994")
 
     def test_year_converter_converts_to_python(self):
@@ -244,6 +244,7 @@ class TestConverters(TestCase):
     def test_date_converter_parses_date(self):
         converter = converters.DateConverter()
         match = re.match(converter.regex, "2022-02-28")
+        assert isinstance(match, re.Match)
         self.assertEqual(match.group(0), "2022-02-28")
 
     def test_date_converter_fails_to_parse_string(self):
@@ -254,6 +255,7 @@ class TestConverters(TestCase):
     def test_court_converter_parses_court(self):
         converter = converters.CourtConverter()
         match = re.match(converter.regex, "ewhc")
+        assert isinstance(match, re.Match)
         self.assertEqual(match.group(0), "ewhc")
 
     def test_court_converter_fails_to_parse(self):
@@ -263,6 +265,7 @@ class TestConverters(TestCase):
     def test_subdivision_converter_parses_court(self):
         converter = converters.SubdivisionConverter()
         match = re.match(converter.regex, "comm")
+        assert isinstance(match, re.Match)
         self.assertEqual(match.group(0), "comm")
 
     def test_subdivision_converter_fails_to_parse(self):

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -309,7 +309,7 @@ class TestUtils(TestCase):
             "delete_judgment.return_value": True,
         }
         fake_api_client.configure_mock(**api_attrs)
-        boto_attrs = {"list_objects.return_value": []}
+        boto_attrs: dict[str, list] = {"list_objects.return_value": []}
         fake_boto3_client.configure_mock(**boto_attrs)
 
         result = update_judgment_uri("old/uri", "[2002] EAT 1")
@@ -330,7 +330,7 @@ class TestUtils(TestCase):
             "delete_judgment.return_value": True,
         }
         fake_api_client.configure_mock(**api_attrs)
-        boto_attrs = {"list_objects.return_value": []}
+        boto_attrs: dict[str, list] = {"list_objects.return_value": []}
         fake_boto3_client.configure_mock(**boto_attrs)
 
         update_judgment_uri("old/uri", " [2002] EAT 1 ")

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -134,10 +134,8 @@ def render_versions(decoded_versions):
 
 
 def extract_version(version_string: str) -> int:
-    try:
-        return int(re.search(VERSION_REGEX, version_string).group(1))
-    except AttributeError:
-        return 0
+    result = re.search(VERSION_REGEX, version_string)
+    return int(result.group(1)) if result else 0
 
 
 def users_dict():

--- a/judgments/views/button_handlers.py
+++ b/judgments/views/button_handlers.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Union
+from typing import Optional
 
 from caselawclient.Client import api_client
 from django.contrib import messages
@@ -40,7 +40,7 @@ def assign_judgment_button(request):
 def prioritise_judgment_button(request):
     """Editors can let other editors know that some judgments are more important than others."""
 
-    def parse_priority(priority: Union[str, int]) -> Optional[str]:
+    def parse_priority(priority: str) -> Optional[str]:
         # note: use 09 if using numbers less than 10.
         priorities = {"low": "10", "medium": "20", "high": "30"}
         priority_string = priority.lower().strip()

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -1,11 +1,9 @@
-import re
-
 from caselawclient.Client import MarklogicResourceNotFoundError, api_client
 from django.http import Http404, HttpResponse
 from django.template import loader
 from requests_toolbelt.multipart import decoder
 
-from judgments.utils import VERSION_REGEX, get_judgment_root
+from judgments.utils import extract_version, get_judgment_root
 from judgments.utils.aws import generate_docx_url, generate_pdf_url, uri_for_s3
 
 
@@ -41,11 +39,7 @@ def detail(request):
         context["pdf_url"] = generate_pdf_url(uri_for_s3(judgment_uri))
 
         if version_uri:
-            try:
-                version = re.search(VERSION_REGEX, version_uri).group(1)
-            except AttributeError:
-                version = None
-            context["version"] = version
+            context["version"] = extract_version(version_uri)
     except MarklogicResourceNotFoundError as e:
         raise Http404(f"Judgment was not found at uri {judgment_uri}, {e}")
     template = loader.get_template("judgment/detail.html")


### PR DESCRIPTION
At the moment mypy under `fab test` is only checking the `ds_caselaw_editor_ui` folder, but we also implement a lot of stuff in the `judgments` folder and this isn't being analysed.

In addition, mypy isn't being run at all in CI. Add a new task to the workflow to run it.