### PR TITLE
Break up large tests file

### DIFF
--- a/judgments/tests/test_converters.py
+++ b/judgments/tests/test_converters.py
@@ -1,0 +1,50 @@
+import re
+
+from judgments import converters
+
+
+class TestConverters:
+    def test_year_converter_parses_year(self):
+        converter = converters.YearConverter()
+        match = re.match(converter.regex, "1994")
+        assert isinstance(match, re.Match)
+        assert match.group(0) == "1994"
+
+    def test_year_converter_converts_to_python(self):
+        converter = converters.YearConverter()
+        assert converter.to_python("1994") == 1994
+
+    def test_year_converter_converts_to_url(self):
+        converter = converters.YearConverter()
+        assert converter.to_url(1994) == "1994"
+
+    def test_date_converter_parses_date(self):
+        converter = converters.DateConverter()
+        match = re.match(converter.regex, "2022-02-28")
+        assert isinstance(match, re.Match)
+        assert match.group(0) == "2022-02-28"
+
+    def test_date_converter_fails_to_parse_string(self):
+        converter = converters.DateConverter()
+        match = re.match(converter.regex, "202L-ab-er")
+        assert match is None
+
+    def test_court_converter_parses_court(self):
+        converter = converters.CourtConverter()
+        match = re.match(converter.regex, "ewhc")
+        assert isinstance(match, re.Match)
+        assert match.group(0) == "ewhc"
+
+    def test_court_converter_fails_to_parse(self):
+        converter = converters.CourtConverter()
+        assert re.match(converter.regex, "notacourt") is None
+
+    def test_subdivision_converter_parses_court(self):
+        converter = converters.SubdivisionConverter()
+        match = re.match(converter.regex, "comm")
+        assert isinstance(match, re.Match)
+        assert match.group(0) == "comm"
+
+    def test_subdivision_converter_fails_to_parse(self):
+        converter = converters.SubdivisionConverter()
+        assert re.match(converter.regex, "notasubdivision") is None

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -5,7 +5,11 @@ from caselawclient.Client import MarklogicAPIError
 from django.test import TestCase
 
 import judgments
-from judgments.utils import get_judgment_root, update_judgment_uri
+from judgments.utils import (
+    ensure_local_referer_url,
+    get_judgment_root,
+    update_judgment_uri,
+)
 from judgments.utils.aws import build_new_key
 from judgments.utils.paginator import paginator
 
@@ -162,3 +166,25 @@ class TestUtils(TestCase):
         old_key = "failures/TDR-2022-DNWR/image1.jpg"
         new_uri = "ukpc/2023/120"
         assert build_new_key(old_key, new_uri) == "ukpc/2023/120/image1.jpg"
+
+
+class TestReferrerUrlHelper(TestCase):
+    @patch("django.http.request.HttpRequest")
+    def test_when_referrer_is_relative(self, request):
+        request.META = {"HTTP_REFERER": "/foo/bar"}
+        assert ensure_local_referer_url(request, "/default") == "/foo/bar"
+
+    @patch("django.http.request.HttpRequest")
+    def test_when_referrer_is_absolute_and_local(self, request):
+        request.META = {"HTTP_REFERER": "https://www.example.com/foo/bar"}
+        request.get_host.return_value = "www.example.com"
+        assert (
+            ensure_local_referer_url(request, "/default")
+            == "https://www.example.com/foo/bar"
+        )
+
+    @patch("django.http.request.HttpRequest")
+    def test_when_referrer_is_absolute_and_remote(self, request):
+        request.META = {"HTTP_REFERER": "https://www.someone-nefarious.com/foo/bar"}
+        request.get_host.return_value = "www.example.com"
+        assert ensure_local_referer_url(request, "/default") == "/default"

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -1,0 +1,40 @@
+from judgments.utils.paginator import paginator
+
+
+class TestPaginator:
+    def test_paginator_2500(self):
+        expected_result = {
+            "current_page": 10,
+            "has_next_page": True,
+            "has_prev_page": True,
+            "next_page": 11,
+            "prev_page": 9,
+            "next_pages": [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+            "number_of_pages": 250,
+        }
+        assert paginator(10, 2500) == expected_result
+
+    def test_paginator_25(self):
+        # 25 items has 5 items on page 3.
+        expected_result = {
+            "current_page": 1,
+            "has_next_page": True,
+            "has_prev_page": False,
+            "next_page": 2,
+            "prev_page": 0,
+            "next_pages": [2, 3],
+            "number_of_pages": 3,
+        }
+        assert paginator(1, 25) == expected_result
+
+    def test_paginator_5(self):
+        expected_result = {
+            "current_page": 1,
+            "has_next_page": False,
+            "has_prev_page": False,
+            "next_page": 2,  # Note: remember to check has_next_page
+            "prev_page": 0,
+            "next_pages": [],
+            "number_of_pages": 1,
+        }
+        assert paginator(1, 5) == expected_result

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -1,3 +1,12 @@
+from unittest.mock import MagicMock, patch
+
+import ds_caselaw_utils
+from caselawclient.Client import MarklogicAPIError
+from django.test import TestCase
+
+import judgments
+from judgments.utils import get_judgment_root, update_judgment_uri
+from judgments.utils.aws import build_new_key
 from judgments.utils.paginator import paginator
 
 
@@ -38,3 +47,118 @@ class TestPaginator:
             "number_of_pages": 1,
         }
         assert paginator(1, 5) == expected_result
+
+
+class TestUtils(TestCase):
+    def test_get_judgment_root_error(self):
+        xml = "<error>parser.log contents</error>"
+        assert get_judgment_root(xml) == "error"
+
+    def test_get_judgment_root_akomantoso(self):
+        xml = (
+            "<akomaNtoso xmlns:uk='https://caselaw.nationalarchives.gov.uk/akn' "
+            "xmlns='http://docs.oasis-open.org/legaldocml/ns/akn/3.0'>judgment</akomaNtoso>"
+        )
+        assert (
+            get_judgment_root(xml)
+            == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
+        )
+
+    def test_get_judgment_root_malformed_xml(self):
+        # Should theoretically never happen but test anyway
+        xml = "<error>malformed xml"
+        assert get_judgment_root(xml) == "error"
+
+    @patch("judgments.utils.api_client")
+    @patch("boto3.session.Session.client")
+    def test_update_judgment_uri_success(self, fake_boto3_client, fake_api_client):
+        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
+        api_attrs = {
+            "get_judgment_xml.side_effect": MarklogicAPIError,
+            "copy_judgment.return_value": True,
+            "delete_judgment.return_value": True,
+        }
+        fake_api_client.configure_mock(**api_attrs)
+        boto_attrs: dict[str, list] = {"list_objects.return_value": []}
+        fake_boto3_client.configure_mock(**boto_attrs)
+
+        result = update_judgment_uri("old/uri", "[2002] EAT 1")
+
+        fake_api_client.copy_judgment.assert_called_with("old/uri", "new/uri")
+        fake_api_client.delete_judgment.assert_called_with("old/uri")
+        assert result == "new/uri"
+
+    @patch("judgments.utils.api_client")
+    @patch("boto3.session.Session.client")
+    def test_update_judgment_uri_strips_whitespace(
+        self, fake_boto3_client, fake_api_client
+    ):
+        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
+        api_attrs = {
+            "get_judgment_xml.side_effect": MarklogicAPIError,
+            "copy_judgment.return_value": True,
+            "delete_judgment.return_value": True,
+        }
+        fake_api_client.configure_mock(**api_attrs)
+        boto_attrs: dict[str, list] = {"list_objects.return_value": []}
+        fake_boto3_client.configure_mock(**boto_attrs)
+
+        update_judgment_uri("old/uri", " [2002] EAT 1 ")
+
+        ds_caselaw_utils.neutral_url.assert_called_with("[2002] EAT 1")
+
+    @patch("judgments.utils.api_client")
+    def test_update_judgment_uri_exception_copy(self, fake_client):
+        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
+        attrs = {
+            "copy_judgment.side_effect": MarklogicAPIError,
+            "delete_judgment.return_value": True,
+        }
+        fake_client.configure_mock(**attrs)
+
+        with self.assertRaises(judgments.utils.MoveJudgmentError):
+            update_judgment_uri("old/uri", "[2002] EAT 1")
+
+    @patch("judgments.utils.api_client")
+    def test_update_judgment_uri_exception_delete(self, fake_client):
+        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
+        attrs = {
+            "copy_judgment.return_value": True,
+            "delete_judgment.side_effect": MarklogicAPIError,
+        }
+        fake_client.configure_mock(**attrs)
+
+        with self.assertRaises(judgments.utils.MoveJudgmentError):
+            update_judgment_uri("old/uri", "[2002] EAT 1")
+
+    def test_update_judgment_uri_unparseable_citation(self):
+        ds_caselaw_utils.neutral_url = MagicMock(return_value=None)
+
+        with self.assertRaises(judgments.utils.NeutralCitationToUriError):
+            update_judgment_uri("old/uri", "Wrong neutral citation")
+
+    @patch("judgments.utils.api_client")
+    def test_update_judgment_uri_duplicate_uri(self, fake_client):
+        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
+        attrs = {
+            "get_judgment_xml.return_value": "<akomaNtoso><judgment></judgment></akomaNtoso>",
+        }
+        fake_client.configure_mock(**attrs)
+
+        with self.assertRaises(judgments.utils.MoveJudgmentError):
+            update_judgment_uri("old/uri", "[2002] EAT 1")
+
+    def test_build_new_key_docx(self):
+        old_key = "failures/TDR-2022-DNWR/failures_TDR-2022-DNWR.docx"
+        new_uri = "ukpc/2023/120"
+        assert build_new_key(old_key, new_uri) == "ukpc/2023/120/ukpc_2023_120.docx"
+
+    def test_build_new_key_pdf(self):
+        old_key = "failures/TDR-2022-DNWR/failures_TDR-2022-DNWR.pdf"
+        new_uri = "ukpc/2023/120"
+        assert build_new_key(old_key, new_uri) == "ukpc/2023/120/ukpc_2023_120.pdf"
+
+    def test_build_new_key_image(self):
+        old_key = "failures/TDR-2022-DNWR/image1.jpg"
+        new_uri = "ukpc/2023/120"
+        assert build_new_key(old_key, new_uri) == "ukpc/2023/120/image1.jpg"

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -1,11 +1,10 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase
 from lxml import etree
 
 from judgments.models import Judgment, SearchResult, SearchResultMeta
-from judgments.utils import extract_version, render_versions
 
 
 class TestJudgment(TestCase):
@@ -14,35 +13,6 @@ class TestJudgment(TestCase):
         decoded_response = response.content.decode("utf-8")
         self.assertIn("Page not found", decoded_response)
         self.assertEqual(response.status_code, 404)
-
-    def test_extract_version_uri(self):
-        uri = "/ewhc/ch/2022/1178_xml_versions/2-1178.xml"
-        assert extract_version(uri) == 2
-
-    def test_extract_version_failure(self):
-        uri = "/failures/TDR-2022-DBF_xml_versions/1-TDR-2022-DBF.xml"
-        assert extract_version(uri) == 1
-
-    def test_extract_version_not_found(self):
-        uri = "some-other-string"
-        assert extract_version(uri) == 0
-
-    def test_render_versions(self):
-        version_parts = (
-            Mock(text="/ewhc/ch/2022/1178_xml_versions/3-1178.xml"),
-            Mock(text="/ewhc/ch/2022/1178_xml_versions/2-1178.xml"),
-            Mock(text="/ewhc/ch/2022/1178_xml_versions/1-1178.xml"),
-        )
-        requests_toolbelt = Mock()
-        requests_toolbelt.multipart.decoder.BodyPart.return_value = version_parts
-
-        expected_result = [
-            {"uri": "/ewhc/ch/2022/1178_xml_versions/3-1178", "version": 3},
-            {"uri": "/ewhc/ch/2022/1178_xml_versions/2-1178", "version": 2},
-            {"uri": "/ewhc/ch/2022/1178_xml_versions/1-1178", "version": 1},
-        ]
-
-        assert render_versions(version_parts) == expected_result
 
 
 class TestSearchResults(TestCase):

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -1,11 +1,9 @@
-import re
 from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase
 from lxml import etree
 
-from judgments import converters
 from judgments.models import Judgment, SearchResult, SearchResultMeta
 from judgments.utils import extract_version, render_versions
 
@@ -174,53 +172,6 @@ class TestSearchResultModel(TestCase):
         self.assertEqual("ukut/lc/2022/241", search_result.uri)
         self.assertEqual(None, search_result.neutral_citation)
         self.assertEqual(None, search_result.court)
-
-
-class TestConverters(TestCase):
-    def test_year_converter_parses_year(self):
-        converter = converters.YearConverter()
-        match = re.match(converter.regex, "1994")
-        assert isinstance(match, re.Match)
-        self.assertEqual(match.group(0), "1994")
-
-    def test_year_converter_converts_to_python(self):
-        converter = converters.YearConverter()
-        self.assertEqual(converter.to_python("1994"), 1994)
-
-    def test_year_converter_converts_to_url(self):
-        converter = converters.YearConverter()
-        self.assertEqual(converter.to_url(1994), "1994")
-
-    def test_date_converter_parses_date(self):
-        converter = converters.DateConverter()
-        match = re.match(converter.regex, "2022-02-28")
-        assert isinstance(match, re.Match)
-        self.assertEqual(match.group(0), "2022-02-28")
-
-    def test_date_converter_fails_to_parse_string(self):
-        converter = converters.DateConverter()
-        match = re.match(converter.regex, "202L-ab-er")
-        self.assertIsNone(match)
-
-    def test_court_converter_parses_court(self):
-        converter = converters.CourtConverter()
-        match = re.match(converter.regex, "ewhc")
-        assert isinstance(match, re.Match)
-        self.assertEqual(match.group(0), "ewhc")
-
-    def test_court_converter_fails_to_parse(self):
-        converter = converters.CourtConverter()
-        self.assertIsNone(re.match(converter.regex, "notacourt"))
-
-    def test_subdivision_converter_parses_court(self):
-        converter = converters.SubdivisionConverter()
-        match = re.match(converter.regex, "comm")
-        assert isinstance(match, re.Match)
-        self.assertEqual(match.group(0), "comm")
-
-    def test_subdivision_converter_fails_to_parse(self):
-        converter = converters.SubdivisionConverter()
-        self.assertIsNone(re.match(converter.regex, "notasubdivision"))
 
 
 class TestJudgmentEditor(TestCase):

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -7,7 +7,7 @@ from lxml import etree
 
 from judgments import converters
 from judgments.models import Judgment, SearchResult, SearchResultMeta
-from judgments.utils import ensure_local_referer_url, extract_version, render_versions
+from judgments.utils import extract_version, render_versions
 
 
 class TestJudgment(TestCase):
@@ -237,25 +237,3 @@ class TestJudgmentEditor(TestCase):
         response = self.client.get("/edit?judgment_uri=ewhc/ch/1999/1")
 
         assert b"selected>otheruser" in response.content
-
-
-class TestReferrerUrlHelper(TestCase):
-    @patch("django.http.request.HttpRequest")
-    def test_when_referrer_is_relative(self, request):
-        request.META = {"HTTP_REFERER": "/foo/bar"}
-        assert ensure_local_referer_url(request, "/default") == "/foo/bar"
-
-    @patch("django.http.request.HttpRequest")
-    def test_when_referrer_is_absolute_and_local(self, request):
-        request.META = {"HTTP_REFERER": "https://www.example.com/foo/bar"}
-        request.get_host.return_value = "www.example.com"
-        assert (
-            ensure_local_referer_url(request, "/default")
-            == "https://www.example.com/foo/bar"
-        )
-
-    @patch("django.http.request.HttpRequest")
-    def test_when_referrer_is_absolute_and_remote(self, request):
-        request.META = {"HTTP_REFERER": "https://www.someone-nefarious.com/foo/bar"}
-        request.get_host.return_value = "www.example.com"
-        assert ensure_local_referer_url(request, "/default") == "/default"

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -18,7 +18,6 @@ from judgments.utils import (
     update_judgment_uri,
 )
 from judgments.utils.aws import build_new_key
-from judgments.utils.paginator import paginator
 
 
 class TestJudgment(TestCase):
@@ -185,45 +184,6 @@ class TestSearchResultModel(TestCase):
         self.assertEqual("ukut/lc/2022/241", search_result.uri)
         self.assertEqual(None, search_result.neutral_citation)
         self.assertEqual(None, search_result.court)
-
-
-class TestPaginator(TestCase):
-    def test_paginator_2500(self):
-        expected_result = {
-            "current_page": 10,
-            "has_next_page": True,
-            "has_prev_page": True,
-            "next_page": 11,
-            "prev_page": 9,
-            "next_pages": [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
-            "number_of_pages": 250,
-        }
-        self.assertEqual(paginator(10, 2500), expected_result)
-
-    def test_paginator_25(self):
-        # 25 items has 5 items on page 3.
-        expected_result = {
-            "current_page": 1,
-            "has_next_page": True,
-            "has_prev_page": False,
-            "next_page": 2,
-            "prev_page": 0,
-            "next_pages": [2, 3],
-            "number_of_pages": 3,
-        }
-        self.assertEqual(paginator(1, 25), expected_result)
-
-    def test_paginator_5(self):
-        expected_result = {
-            "current_page": 1,
-            "has_next_page": False,
-            "has_prev_page": False,
-            "next_page": 2,  # Note: remember to check has_next_page
-            "prev_page": 0,
-            "next_pages": [],
-            "number_of_pages": 1,
-        }
-        self.assertEqual(paginator(1, 5), expected_result)
 
 
 class TestConverters(TestCase):

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -1,23 +1,13 @@
 import re
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
-import ds_caselaw_utils
-from caselawclient.Client import MarklogicAPIError
 from django.contrib.auth.models import User
 from django.test import TestCase
 from lxml import etree
 
-import judgments
 from judgments import converters
 from judgments.models import Judgment, SearchResult, SearchResultMeta
-from judgments.utils import (
-    ensure_local_referer_url,
-    extract_version,
-    get_judgment_root,
-    render_versions,
-    update_judgment_uri,
-)
-from judgments.utils.aws import build_new_key
+from judgments.utils import ensure_local_referer_url, extract_version, render_versions
 
 
 class TestJudgment(TestCase):
@@ -231,121 +221,6 @@ class TestConverters(TestCase):
     def test_subdivision_converter_fails_to_parse(self):
         converter = converters.SubdivisionConverter()
         self.assertIsNone(re.match(converter.regex, "notasubdivision"))
-
-
-class TestUtils(TestCase):
-    def test_get_judgment_root_error(self):
-        xml = "<error>parser.log contents</error>"
-        assert get_judgment_root(xml) == "error"
-
-    def test_get_judgment_root_akomantoso(self):
-        xml = (
-            "<akomaNtoso xmlns:uk='https://caselaw.nationalarchives.gov.uk/akn' "
-            "xmlns='http://docs.oasis-open.org/legaldocml/ns/akn/3.0'>judgment</akomaNtoso>"
-        )
-        assert (
-            get_judgment_root(xml)
-            == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
-        )
-
-    def test_get_judgment_root_malformed_xml(self):
-        # Should theoretically never happen but test anyway
-        xml = "<error>malformed xml"
-        assert get_judgment_root(xml) == "error"
-
-    @patch("judgments.utils.api_client")
-    @patch("boto3.session.Session.client")
-    def test_update_judgment_uri_success(self, fake_boto3_client, fake_api_client):
-        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        api_attrs = {
-            "get_judgment_xml.side_effect": MarklogicAPIError,
-            "copy_judgment.return_value": True,
-            "delete_judgment.return_value": True,
-        }
-        fake_api_client.configure_mock(**api_attrs)
-        boto_attrs: dict[str, list] = {"list_objects.return_value": []}
-        fake_boto3_client.configure_mock(**boto_attrs)
-
-        result = update_judgment_uri("old/uri", "[2002] EAT 1")
-
-        fake_api_client.copy_judgment.assert_called_with("old/uri", "new/uri")
-        fake_api_client.delete_judgment.assert_called_with("old/uri")
-        assert result == "new/uri"
-
-    @patch("judgments.utils.api_client")
-    @patch("boto3.session.Session.client")
-    def test_update_judgment_uri_strips_whitespace(
-        self, fake_boto3_client, fake_api_client
-    ):
-        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        api_attrs = {
-            "get_judgment_xml.side_effect": MarklogicAPIError,
-            "copy_judgment.return_value": True,
-            "delete_judgment.return_value": True,
-        }
-        fake_api_client.configure_mock(**api_attrs)
-        boto_attrs: dict[str, list] = {"list_objects.return_value": []}
-        fake_boto3_client.configure_mock(**boto_attrs)
-
-        update_judgment_uri("old/uri", " [2002] EAT 1 ")
-
-        ds_caselaw_utils.neutral_url.assert_called_with("[2002] EAT 1")
-
-    @patch("judgments.utils.api_client")
-    def test_update_judgment_uri_exception_copy(self, fake_client):
-        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        attrs = {
-            "copy_judgment.side_effect": MarklogicAPIError,
-            "delete_judgment.return_value": True,
-        }
-        fake_client.configure_mock(**attrs)
-
-        with self.assertRaises(judgments.utils.MoveJudgmentError):
-            update_judgment_uri("old/uri", "[2002] EAT 1")
-
-    @patch("judgments.utils.api_client")
-    def test_update_judgment_uri_exception_delete(self, fake_client):
-        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        attrs = {
-            "copy_judgment.return_value": True,
-            "delete_judgment.side_effect": MarklogicAPIError,
-        }
-        fake_client.configure_mock(**attrs)
-
-        with self.assertRaises(judgments.utils.MoveJudgmentError):
-            update_judgment_uri("old/uri", "[2002] EAT 1")
-
-    def test_update_judgment_uri_unparseable_citation(self):
-        ds_caselaw_utils.neutral_url = MagicMock(return_value=None)
-
-        with self.assertRaises(judgments.utils.NeutralCitationToUriError):
-            update_judgment_uri("old/uri", "Wrong neutral citation")
-
-    @patch("judgments.utils.api_client")
-    def test_update_judgment_uri_duplicate_uri(self, fake_client):
-        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        attrs = {
-            "get_judgment_xml.return_value": "<akomaNtoso><judgment></judgment></akomaNtoso>",
-        }
-        fake_client.configure_mock(**attrs)
-
-        with self.assertRaises(judgments.utils.MoveJudgmentError):
-            update_judgment_uri("old/uri", "[2002] EAT 1")
-
-    def test_build_new_key_docx(self):
-        old_key = "failures/TDR-2022-DNWR/failures_TDR-2022-DNWR.docx"
-        new_uri = "ukpc/2023/120"
-        assert build_new_key(old_key, new_uri) == "ukpc/2023/120/ukpc_2023_120.docx"
-
-    def test_build_new_key_pdf(self):
-        old_key = "failures/TDR-2022-DNWR/failures_TDR-2022-DNWR.pdf"
-        new_uri = "ukpc/2023/120"
-        assert build_new_key(old_key, new_uri) == "ukpc/2023/120/ukpc_2023_120.pdf"
-
-    def test_build_new_key_image(self):
-        old_key = "failures/TDR-2022-DNWR/image1.jpg"
-        new_uri = "ukpc/2023/120"
-        assert build_new_key(old_key, new_uri) == "ukpc/2023/120/image1.jpg"
 
 
 class TestJudgmentEditor(TestCase):


### PR DESCRIPTION
Historically, all our tests have been in a single `tests.py`. Now we're starting to write more tests (yay), break this file down slightly so that test files are smaller, more focussed, easier to understand and find what you're working on.