### PR TITLE
Swap editing a judgment's metadata to use POST-Redirect-GET pattern

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -4,6 +4,7 @@ Base settings to build other settings files upon.
 from pathlib import Path
 
 import environ
+from django.contrib.messages import constants as message_constants
 
 ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 # ds_judgments_editor_ui/
@@ -291,3 +292,8 @@ STRONGHOLD_PUBLIC_URLS = (
 )
 
 JIRA_INSTANCE = env("JIRA_INSTANCE")
+
+MESSAGE_TAGS = {
+    message_constants.SUCCESS: "edit-component__success",
+    message_constants.ERROR: "edit-component__error",
+}

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -7,12 +7,6 @@
   </aside>
   <div class="edit-component">
     <div class="edit-component__container">
-      {% if context.success %}
-        <div class="edit-component__success">{{ context.success }}</div>
-      {% endif %}
-      {% if context.error %}
-        <div class="edit-component__error">{{ context.error }}</div>
-      {% endif %}
       <h2 class="edit-component__header">{% translate "judgment.edit_judgment" %} <span class="judgment-uri">{{context.judgment_uri}}</span></h2>
       <form aria-label="Edit judgment" method="post">
         {% csrf_token %}

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -2,6 +2,7 @@ from urllib.parse import quote, urlencode
 
 from caselawclient.Client import MarklogicAPIError, api_client
 from django.conf import settings
+from django.contrib import messages
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.template import loader
@@ -191,15 +192,16 @@ class EditJudgmentView(View):
                 enrich=published,  # placeholder for now, should perhaps be "has this become published"
             )
 
-            context["success"] = "Judgment successfully updated"
+            messages.success(request, "Judgment successfully updated")
 
         except (MoveJudgmentError, NeutralCitationToUriError) as e:
-            context[
-                "error"
-            ] = f"There was an error updating the Judgment's neutral citation: {e}"
+            messages.error(
+                request,
+                f"There was an error updating the Judgment's neutral citation: {e}",
+            )
 
         except MarklogicAPIError as e:
-            context["error"] = f"There was an error saving the Judgment: {e}"
+            messages.error(request, f"There was an error saving the Judgment: {e}")
 
         judgment = Judgment(judgment_uri)
 

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -3,7 +3,7 @@ from urllib.parse import quote, urlencode
 from caselawclient.Client import MarklogicAPIError, api_client
 from django.conf import settings
 from django.contrib import messages
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.template import loader
 from django.urls import reverse
@@ -144,7 +144,6 @@ class EditJudgmentView(View):
         supplemental = bool(request.POST.get("supplemental", False))
         anonymised = bool(request.POST.get("anonymised", False))
 
-        context = {"judgment_uri": judgment_uri}
         try:
             api_client.set_published(judgment_uri, published)
             api_client.set_sensitive(judgment_uri, sensitive)
@@ -203,13 +202,6 @@ class EditJudgmentView(View):
         except MarklogicAPIError as e:
             messages.error(request, f"There was an error saving the Judgment: {e}")
 
-        judgment = Judgment(judgment_uri)
-
-        context["judgment"] = judgment
-        context["page_title"] = judgment.name
-
         invalidate_caches(judgment_uri)
 
-        context.update({"users": users_dict()})
-
-        return self.render(request, context)
+        return HttpResponseRedirect(reverse("edit") + "?judgment_uri=" + judgment_uri)


### PR DESCRIPTION
At the moment, whenever changes are made to a judgment the view will perform the changes and then directly return a `HTTP 200` with the edit form. This has led to some problems with missing template context, eg judgment details being unavailable for magic links.

By swapping to a [POST-Redirect-GET](https://en.wikipedia.org/wiki/Post/Redirect/Get) pattern, this view will perform the changes and then redirect the user back to the usual GET form view.