### PR TITLE
Improve robustness of generating public URIs

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -47,7 +47,7 @@
       {% endif %}
 
       {% if context.judgment.is_published %}
-        <a class="judgment-toolbar__button" href="https://caselaw.nationalarchives.gov.uk/{{context.judgment_uri}}" target="_blank">
+        <a class="judgment-toolbar__button" href="{{ context.judgment.public_uri }}" target="_blank">
           {% translate "judgment.view_on_public" %}
         </a>
       {% else %}

--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -47,7 +47,7 @@
       {% endif %}
 
       {% if context.judgment.is_published %}
-        <a class="judgment-toolbar__button" href="{{ context.judgment.public_uri }}" target="_blank">
+        <a class="judgment-toolbar__button" href="{{ context.judgment.public_uri }}" target="_blank" rel="noopener noreferrer">
           {% translate "judgment.view_on_public" %}
         </a>
       {% else %}

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -177,6 +177,10 @@ class Judgment:
                 use_https=settings.MARKLOGIC_USE_HTTPS,
             )
 
+    @property
+    def public_uri(self) -> str:
+        return "https://caselaw.nationalarchives.gov.uk/{uri}".format(uri=self.uri)
+
     @cached_property
     def neutral_citation(self) -> str:
         return self.api_client.get_judgment_citation(self.uri)

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -166,7 +166,7 @@ class SearchMatch(xmlmodels.XmlModel):
 
 class Judgment:
     def __init__(self, uri: str, api_client: Optional[MarklogicApiClient] = None):
-        self.uri = uri
+        self.uri = uri.strip("/")
         if api_client:
             self.api_client = api_client
         else:

--- a/judgments/tests/test_models_judgment.py
+++ b/judgments/tests/test_models_judgment.py
@@ -29,6 +29,15 @@ class TestJudgment:
 
         mock_api_client_class.assert_not_called()
 
+    def test_public_uri(self, mock_api_client):
+        mock_api_client.get_judgment_citation.return_value = "2023/test/1234"
+
+        judgment = Judgment("test/1234", mock_api_client)
+
+        assert (
+            judgment.public_uri == "https://caselaw.nationalarchives.gov.uk/test/1234"
+        )
+
     def test_judgment_neutral_citation(self, mock_api_client):
         mock_api_client.get_judgment_citation.return_value = "2023/test/1234"
 

--- a/judgments/tests/test_models_judgment.py
+++ b/judgments/tests/test_models_judgment.py
@@ -35,8 +35,6 @@ class TestJudgment:
         assert judgment.uri == "test/1234"
 
     def test_public_uri(self, mock_api_client):
-        mock_api_client.get_judgment_citation.return_value = "2023/test/1234"
-
         judgment = Judgment("test/1234", mock_api_client)
 
         assert (
@@ -44,11 +42,11 @@ class TestJudgment:
         )
 
     def test_judgment_neutral_citation(self, mock_api_client):
-        mock_api_client.get_judgment_citation.return_value = "2023/test/1234"
+        mock_api_client.get_judgment_citation.return_value = "[2023] TEST 1234"
 
         judgment = Judgment("test/1234", mock_api_client)
 
-        assert judgment.neutral_citation == "2023/test/1234"
+        assert judgment.neutral_citation == "[2023] TEST 1234"
         mock_api_client.get_judgment_citation.assert_called_once_with("test/1234")
 
     def test_judgment_name(self, mock_api_client):

--- a/judgments/tests/test_models_judgment.py
+++ b/judgments/tests/test_models_judgment.py
@@ -29,6 +29,11 @@ class TestJudgment:
 
         mock_api_client_class.assert_not_called()
 
+    def test_uri_strips_slashes(self, mock_api_client):
+        judgment = Judgment("////test/1234/////", mock_api_client)
+
+        assert judgment.uri == "test/1234"
+
     def test_public_uri(self, mock_api_client):
         mock_api_client.get_judgment_citation.return_value = "2023/test/1234"
 

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -54,9 +54,7 @@ class EditJudgmentView(View):
         email_context = {
             "judgment_name": context["judgment"].name,
             "reference": context["judgment"].consignment_reference,
-            "public_judgment_url": "https://caselaw.nationalarchives.gov.uk/{uri}".format(
-                uri=context["judgment_uri"]
-            ),
+            "public_judgment_url": context["judgment"].public_uri,
             "user_signature": request.user.get_full_name() or "XXXXXX",
         }
 


### PR DESCRIPTION
It's possible to provide a judgment URI with trailing or leading slashes. This doesn't affect the behaviour of retrieving the record, but _does_ make it look unexpected when navigating around or sharing links.

This PR adds behaviour where the `Judgment` class will strip those slashes on the way in. It also centralises behaviour for rendering the public URI of a judgment into that class, so we have less to maintain.