### PR TITLE
added padding to judgment toolbar buttons so theynlook good on mobile

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
@@ -12,6 +12,7 @@
     display: inline-block;
     text-decoration: none;
     transition: all 0.2s;
+    margin: 0.5rem 0.25rem;
 
     &:hover {
       background-color: scale-color($color__aqua-blue, $lightness: +8%);


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Added margin to judgement toolbar buttons so they looked good on mobile.
## Trello card / Rollbar error (etc)
https://trello.com/c/ScjTj7z2/450-da-%E2%9C%8F%EF%B8%8F-eui-judgment-toolbar-buttons

## Screenshots of UI changes:

### Before
![Screenshot 2023-02-23 at 17 22 37](https://user-images.githubusercontent.com/102584881/220982937-51b39fe0-98d7-4b3c-affe-125ddf881dd6.png)

### After
![Screenshot 2023-02-23 at 17 23 23](https://user-images.githubusercontent.com/102584881/220982869-bde137d3-ebc7-415b-951f-c51172cb49eb.png)
![Screenshot 2023-02-23 at 17 23 09](https://user-images.githubusercontent.com/102584881/220982922-088df722-3f4d-4dbe-9c37-48edfbcf1176.png)

- [ ] Requires env variable(s) to be updated
