### PR TITLE
Remove python-slugify

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,4 @@
 pytz==2022.7.1  # https://github.com/stub42/pytz
-python-slugify==8.0.0  # https://github.com/un33k/python-slugify
 Pillow==9.4.0  # https://github.com/python-pillow/Pillow
 argon2-cffi==21.3.0  # https://github.com/hynek/argon2_cffi
 whitenoise==6.4.0  # https://github.com/evansd/whitenoise


### PR DESCRIPTION
This was a hangover from bootstrapping; we don't use it.