### PR TITLE
Remove line-locations from localisation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,8 @@ We're using [the built-in django translation module](https://docs.djangoproject.
 
 3) Update the locale file by running the following command  (see also 'a note on the django-admin command' below):
 ```
-django-admin makemessages -l {langage_code}
+django-admin makemessages --no-obsolete -l en_GB
 ```
-
-where `language_code` is the ISO 3166-1 country code (e.g. en_GB)
 
 4) In the generated `.po` file, find the generated msgid string and add the translation below it
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ We're using [the built-in django translation module](https://docs.djangoproject.
 
 3) Update the locale file by running the following command  (see also 'a note on the django-admin command' below):
 ```
-django-admin makemessages --no-obsolete -l en_GB
+django-admin makemessages --no-obsolete --add-location file -l en_GB
 ```
 
 4) In the generated `.po` file, find the generated msgid string and add the translation below it

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-02 14:18+0000\n"
+"POT-Creation-Date: 2023-03-02 14:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -263,43 +263,3 @@ msgstr ""
 #: judgments/views/delete.py:14
 msgid "judgment.delete_a_judgment"
 msgstr "Delete a judgment"
-
-#~ msgid "home.useservice"
-#~ msgstr ""
-#~ "Use this service to find and manage judgments and tribunal decisions on "
-#~ "the 'Find Case Law' site"
-
-#~ msgid "common.home"
-#~ msgstr "Home"
-
-#~ msgid "openjusticelicence.title"
-#~ msgstr "Open Justice Licence"
-
-#~ msgid "judgmentsources.title"
-#~ msgstr "Judgment Sources"
-
-#~ msgid "search.title"
-#~ msgstr "Search"
-
-#~ msgid "commom.findcaselaw"
-#~ msgstr "Find and manage case law"
-
-#~ msgid "terms.title"
-#~ msgstr "Terms of use"
-
-#, fuzzy
-#~| msgid "common.findcaselaw"
-#~ msgid "findcaselaw"
-#~ msgstr "Find and manage case law"
-
-#~ msgid "judgment.downloadasxml"
-#~ msgstr "Download as XML"
-
-#~ msgid "judgment.source_by"
-#~ msgstr "This judgment has been provided to The National Archives by "
-
-#~ msgid "judgment.bailii"
-#~ msgstr "The British and Irish Legal Information Institute"
-
-#~ msgid "judgments.assignedto"
-#~ msgstr "Assigned to:"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 14:13+0000\n"
+"POT-Creation-Date: 2023-03-02 14:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,7 +32,6 @@ msgstr ""
 #: ds_caselaw_editor_ui/templates/includes/breadcrumbs.html:12
 #: ds_caselaw_editor_ui/templates/judgment/results.html:5
 #: ds_caselaw_editor_ui/templates/layouts/base.html:9
-#: ds_caselaw_editor_ui/templates/pages/home.html:13
 msgid "common.findcaselaw"
 msgstr "Find and manage case law"
 
@@ -62,42 +61,48 @@ msgstr ""
 msgid "survey.link.text"
 msgstr "Fill out our short survey"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:6
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:49
-#: judgments/views/edit_judgment.py:144
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:8
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:50
+#: judgments/views/edit_judgment.py:87
 msgid "judgments.submitter"
 msgstr "Submitter"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:7
-#: judgments/views/edit_judgment.py:146
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:9
+#: judgments/views/edit_judgment.py:89
 msgid "judgments.submitteremail"
 msgstr "Contact email"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:8
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:25
-#: judgments/views/edit_judgment.py:148
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:10
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:26
+#: judgments/views/edit_judgment.py:91
 msgid "judgments.consignmentref"
 msgstr "TDR Ref"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:14
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:20
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:31
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:35
 msgid "judgment.download_docx"
 msgstr "Download original .docx"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:17
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:23
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:41
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:45
 msgid "judgment.download_pdf"
 msgstr "Download PDF"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:19
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:25
 msgid "judgment.download_xml"
 msgstr "Download XML"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:23
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:33
 msgid "judgment.create_in_jira"
 msgstr "Create in Jira"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:34
+#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html:17
+#: judgments/views/unlock.py:31
+msgid "judgment.unlock_judgment_title"
+msgstr "Unlock judgment"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:7
 msgid "judgment.back"
@@ -122,21 +127,12 @@ msgstr "View on public site"
 msgid "judgment.delete"
 msgstr "Delete judgment"
 
-msgid "judgment.unlock_judgment_title"
-msgstr "Unlock judgment"
-
-msgid "judgment.confirm_unlock"
-msgstr "Forcibly unlock this judgment? This will make any enrichment processes on the judgment fail."
-
-msgid "judgment.back_to_judgment"
-msgstr "Back to judgment"
-
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html:4
 msgid "judgments.details"
 msgstr "Judgment details:"
 
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html:7
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:17
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:18
 msgid "judgments.submission_datetime"
 msgstr "Submitted:"
 
@@ -144,23 +140,23 @@ msgstr "Submitted:"
 msgid "judgments.submission_assigned"
 msgstr "Assigned:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:33
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:34
 msgid "judgments.ncn"
 msgstr "NCN:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:41
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:42
 msgid "judgments.court"
 msgstr "Court:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:57
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:59
 msgid "judgments.editor_priority"
 msgstr "Priority:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:74
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:78
 msgid "judgments.editor_status"
 msgstr "Status:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:90
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:94
 msgid "judgments.assigned_to"
 msgstr "Assigned to:"
 
@@ -173,6 +169,16 @@ msgstr "Unpublished judgments"
 msgid "judgments.allrecent"
 msgstr "See all recent judgments"
 
+#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html:13
+msgid "judgment.confirm_unlock"
+msgstr ""
+"Forcibly unlock this judgment? This will make any enrichment processes on "
+"the judgment fail."
+
+#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html:19
+msgid "judgment.back_to_judgment"
+msgstr "Back to judgment"
+
 #: ds_caselaw_editor_ui/templates/judgment/deleted.html:12
 msgid "judgment.deleted"
 msgstr "Judgment successfully deleted"
@@ -181,51 +187,51 @@ msgstr "Judgment successfully deleted"
 msgid "judgment.return_home"
 msgstr "Return to Find and manage case law"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:16
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:10
 msgid "judgment.edit_judgment"
 msgstr "Edit Judgment"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:20
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:14
 msgid "judgment.judgment_name"
 msgstr "Judgment name"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:25
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:19
 msgid "judgment.neutral_citation"
 msgstr "Neutral citation"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:30
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:24
 msgid "judgment.court"
 msgstr "Court"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:35
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:29
 msgid "judgment.judgment_date"
 msgstr "Judgment date"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:40
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:34
 msgid "judgment.published"
 msgstr "Published?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:44
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:38
 msgid "judgment.sensitive"
 msgstr "Contains sensitive information?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:48
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:42
 msgid "judgment.supplemental"
 msgstr "Has supplemental documents?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:52
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:46
 msgid "judgment.anonymised"
 msgstr "This Judgment has been anonymised"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:56
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:50
 msgid "judgment.assigned_to"
 msgstr "Assigned to"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:58
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:52
 msgid "judgments.noone"
 msgstr "No one"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:78
+#: ds_caselaw_editor_ui/templates/judgment/edit.html:72
 msgid "judgment.previous_versions"
 msgstr "Previous versions of this Judgment"
 
@@ -238,12 +244,6 @@ msgstr "Search results"
 #: ds_caselaw_editor_ui/templates/layouts/base.html:39
 msgid "skiplink"
 msgstr "Skip to Main Content"
-
-#: ds_caselaw_editor_ui/templates/pages/home.html:15
-msgid "home.useservice"
-msgstr ""
-"Use this service to find and manage judgments and tribunal decisions on the "
-"'Find Case Law' site"
 
 #: ds_caselaw_editor_ui/templates/pages/no_results.html:5
 #, python-format
@@ -263,6 +263,11 @@ msgstr ""
 #: judgments/views/delete.py:14
 msgid "judgment.delete_a_judgment"
 msgstr "Delete a judgment"
+
+#~ msgid "home.useservice"
+#~ msgstr ""
+#~ "Use this service to find and manage judgments and tribunal decisions on "
+#~ "the 'Find Case Law' site"
 
 #~ msgid "common.home"
 #~ msgstr "Home"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-02 14:19+0000\n"
+"POT-Creation-Date: 2023-03-02 14:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,248 +18,239 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ds_caselaw_editor_ui/templates/account/login.html:5
-#: ds_caselaw_editor_ui/templates/account/login.html:12
-#: ds_caselaw_editor_ui/templates/account/login.html:21
+#: ds_caselaw_editor_ui/templates/account/login.html
 msgid "Sign In"
 msgstr ""
 
-#: ds_caselaw_editor_ui/templates/account/login.html:20
+#: ds_caselaw_editor_ui/templates/account/login.html
 msgid "Forgot Password?"
 msgstr ""
 
-#: ds_caselaw_editor_ui/templates/includes/breadcrumbs.html:9
-#: ds_caselaw_editor_ui/templates/includes/breadcrumbs.html:12
-#: ds_caselaw_editor_ui/templates/judgment/results.html:5
-#: ds_caselaw_editor_ui/templates/layouts/base.html:9
+#: ds_caselaw_editor_ui/templates/includes/breadcrumbs.html
+#: ds_caselaw_editor_ui/templates/judgment/results.html
+#: ds_caselaw_editor_ui/templates/layouts/base.html
 msgid "common.findcaselaw"
 msgstr "Find and manage case law"
 
-#: ds_caselaw_editor_ui/templates/includes/create_emails_block.html:3
+#: ds_caselaw_editor_ui/templates/includes/create_emails_block.html
 msgid "judgment.email_submitter.header"
 msgstr "Create an email template"
 
-#: ds_caselaw_editor_ui/templates/includes/create_emails_block.html:5
+#: ds_caselaw_editor_ui/templates/includes/create_emails_block.html
 msgid "judgment.email_submitter.issue"
 msgstr "Raise issue(s) to submitter"
 
-#: ds_caselaw_editor_ui/templates/includes/create_emails_block.html:7
+#: ds_caselaw_editor_ui/templates/includes/create_emails_block.html
 msgid "judgment.email_submitter.confirm"
 msgstr "Confirm publication"
 
-#: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html:4
+#: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html
 msgid "service.improved"
 msgstr "How can this service be improved?"
 
-#: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html:5
+#: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html
 msgid "survey.link"
 msgstr ""
 "https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_dp1FClbR0ZZdW4e?"
 "jfefe=new"
 
-#: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html:5
+#: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html
 msgid "survey.link.text"
 msgstr "Fill out our short survey"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:8
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:50
-#: judgments/views/edit_judgment.py:87
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
+#: judgments/views/edit_judgment.py
 msgid "judgments.submitter"
 msgstr "Submitter"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:9
-#: judgments/views/edit_judgment.py:89
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+#: judgments/views/edit_judgment.py
 msgid "judgments.submitteremail"
 msgstr "Contact email"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:10
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:26
-#: judgments/views/edit_judgment.py:91
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
+#: judgments/views/edit_judgment.py
 msgid "judgments.consignmentref"
 msgstr "TDR Ref"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:20
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:31
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:35
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.download_docx"
 msgstr "Download original .docx"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:23
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:41
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:45
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.download_pdf"
 msgstr "Download PDF"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:25
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
 msgid "judgment.download_xml"
 msgstr "Download XML"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:33
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
 msgid "judgment.create_in_jira"
 msgstr "Create in Jira"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html:34
-#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html:17
-#: judgments/views/unlock.py:31
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
+#: judgments/views/unlock.py
 msgid "judgment.unlock_judgment_title"
 msgstr "Unlock judgment"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:7
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.back"
 msgstr "Back to search results"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:15
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:22
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.edit_this_judgment"
 msgstr "Edit judgment"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:18
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:25
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.view_this_judgment"
 msgstr "View as HTML"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:51
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:55
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.view_on_public"
 msgstr "View on public site"
 
-#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html:70
+#: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.delete"
 msgstr "Delete judgment"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html:4
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html
 msgid "judgments.details"
 msgstr "Judgment details:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html:7
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:18
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 msgid "judgments.submission_datetime"
 msgstr "Submitted:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html:10
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html
 msgid "judgments.submission_assigned"
 msgstr "Assigned:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:34
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 msgid "judgments.ncn"
 msgstr "NCN:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:42
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 msgid "judgments.court"
 msgstr "Court:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:59
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 msgid "judgments.editor_priority"
 msgstr "Priority:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:78
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 msgid "judgments.editor_status"
 msgstr "Status:"
 
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html:94
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 msgid "judgments.assigned_to"
 msgstr "Assigned to:"
 
-#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:8
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
 msgid "home.recent"
 msgstr "Unpublished judgments"
 
-#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html:20
-#: ds_caselaw_editor_ui/templates/judgment/results.html:36
+#: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
+#: ds_caselaw_editor_ui/templates/judgment/results.html
 msgid "judgments.allrecent"
 msgstr "See all recent judgments"
 
-#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html:13
+#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
 msgid "judgment.confirm_unlock"
 msgstr ""
 "Forcibly unlock this judgment? This will make any enrichment processes on "
 "the judgment fail."
 
-#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html:19
+#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
 msgid "judgment.back_to_judgment"
 msgstr "Back to judgment"
 
-#: ds_caselaw_editor_ui/templates/judgment/deleted.html:12
+#: ds_caselaw_editor_ui/templates/judgment/deleted.html
 msgid "judgment.deleted"
 msgstr "Judgment successfully deleted"
 
-#: ds_caselaw_editor_ui/templates/judgment/deleted.html:13
+#: ds_caselaw_editor_ui/templates/judgment/deleted.html
 msgid "judgment.return_home"
 msgstr "Return to Find and manage case law"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:10
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.edit_judgment"
 msgstr "Edit Judgment"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:14
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.judgment_name"
 msgstr "Judgment name"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:19
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.neutral_citation"
 msgstr "Neutral citation"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:24
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.court"
 msgstr "Court"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:29
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.judgment_date"
 msgstr "Judgment date"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:34
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.published"
 msgstr "Published?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:38
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.sensitive"
 msgstr "Contains sensitive information?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:42
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.supplemental"
 msgstr "Has supplemental documents?"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:46
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.anonymised"
 msgstr "This Judgment has been anonymised"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:50
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.assigned_to"
 msgstr "Assigned to"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:52
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgments.noone"
 msgstr "No one"
 
-#: ds_caselaw_editor_ui/templates/judgment/edit.html:72
+#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.previous_versions"
 msgstr "Previous versions of this Judgment"
 
-#: ds_caselaw_editor_ui/templates/judgment/results.html:5
-#: ds_caselaw_editor_ui/templates/judgment/results.html:9
-#: judgments/views/results.py:14
+#: ds_caselaw_editor_ui/templates/judgment/results.html
+#: judgments/views/results.py
 msgid "results.search.title"
 msgstr "Search results"
 
-#: ds_caselaw_editor_ui/templates/layouts/base.html:39
+#: ds_caselaw_editor_ui/templates/layouts/base.html
 msgid "skiplink"
 msgstr "Skip to Main Content"
 
-#: ds_caselaw_editor_ui/templates/pages/no_results.html:5
+#: ds_caselaw_editor_ui/templates/pages/no_results.html
 #, python-format
 msgid "No results for '%(data)s'"
 msgstr ""
 
-#: ds_caselaw_editor_ui/templates/pages/no_results.html:11
+#: ds_caselaw_editor_ui/templates/pages/no_results.html
 msgid "search.noresults"
 msgstr "There are no results for your search"
 
-#: ds_caselaw_editor_ui/templates/pages/no_results.html:12
+#: ds_caselaw_editor_ui/templates/pages/no_results.html
 msgid "search.improvesearch"
 msgstr ""
 "Improve your search results by removing filters, double-checking your "
 "spelling, using fewer keywords or searching for something less specific."
 
-#: judgments/views/delete.py:14
+#: judgments/views/delete.py
 msgid "judgment.delete_a_judgment"
 msgstr "Delete a judgment"


### PR DESCRIPTION
Remove obsolete localisations and line locations from the localisation file.

This will help reduce the overall size of changesets in future.