### PR TITLE
Remove double header from labs template

### DIFF
--- a/ds_caselaw_editor_ui/templates/pages/labs.html
+++ b/ds_caselaw_editor_ui/templates/pages/labs.html
@@ -1,12 +1,6 @@
 {% extends "layouts/base.html" %}
 {% load i18n %}
 {% block content %}
-  <header class="page-header page-header-slim">
-
-    {% include 'includes/breadcrumbs.html' with current='Labs' title='Labs' link=request.get_full_path %}
-
-  </header>
-
   <div class="standard-text-template">
 
     <h1>Labs</h1>


### PR DESCRIPTION
This is now part of the global base template, so no need to include.