### PR TITLE
Revert unwanted changes to judgments_list_item.html

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -1,3 +1,4 @@
+{% load waffle_tags %}
 {% load static i18n %}
 
 <li class="judgments-list__judgment">
@@ -54,7 +55,9 @@
       </li>
       <li>
         <span class="judgments-list__judgment-details-meta-key">
+          {% flag "editor_priority_filter" %}
           {% translate "judgments.editor_priority" %}
+
         </span>
         <span class="judgments-list__judgment-details-meta-value">
           <form action="/prioritise" method="post">
@@ -68,6 +71,7 @@
             <input type="submit" name="submit" value="set priority">
           </form>
         </span>
+        {% endflag %}
       </li>
       <li>
         <span class="judgments-list__judgment-details-meta-key">
@@ -91,7 +95,7 @@
         </span>
         <span class="judgments-list__judgment-details-meta-value">
           {% if item.meta.assigned_to %}
-            <a href="{% url 'edit' %}?judgment_uri={{item.uri}}#assigned_to">{{ item.meta.assigned_to }}</a>
+            <a href="{% url 'edit-judgment' item.uri%}#assigned_to">{{ item.meta.assigned_to }}</a>
           {% else %}
             <form action="/assign" method="post" class="judgments-list__judgment-assign-form">
               {% csrf_token %}
@@ -110,7 +114,7 @@
   </div>
   <div class="judgments-list__judgment-assigned">
     {% if item.meta.assigned_to %}
-      <a href="{% url 'edit' %}?judgment_uri={{item.uri}}#assigned_to">{{ item.meta.assigned_to }}</a>
+      <a href="{% url 'edit-judgment' item.uri %}#assigned_to">{{ item.meta.assigned_to }}</a>
     {% else %}
       <form action="/assign" method="post" class="judgments-list__judgment-assign-form">
         {% csrf_token %}


### PR DESCRIPTION
This fixes a regression where list items in the home page were trying to use legacy URL names.