### PR TITLE
Refactor "publish a judgment" workflow

### DIFF
--- a/judgments/models/__init__.py
+++ b/judgments/models/__init__.py
@@ -161,7 +161,9 @@ class SearchMatch(xmlmodels.XmlModel):
     class Meta:
         namespaces = {"search": "http://marklogic.com/appservices/search"}
 
-    transform_to_html = xmlmodels.XsltField(join(dirname(__file__), "search_match.xsl"))
+    transform_to_html = xmlmodels.XsltField(
+        join(dirname(__file__), "..", "search_match.xsl")
+    )
 
 
 class Judgment:

--- a/judgments/models/__init__.py
+++ b/judgments/models/__init__.py
@@ -1,20 +1,11 @@
-# from django.db import models
 import datetime
 import logging
-from functools import cached_property
 from os.path import dirname, join
-from typing import Optional
 
 import caselawclient.Client
-from caselawclient.Client import MarklogicApiClient, api_client
-from django.conf import settings
-from django.urls import reverse
+from caselawclient.Client import api_client
 from djxml import xmlmodels
 from lxml import etree
-from requests_toolbelt.multipart import decoder
-
-from judgments.utils import get_judgment_root, render_versions
-from judgments.utils.aws import generate_docx_url, generate_pdf_url, uri_for_s3
 
 
 def one(x):
@@ -164,125 +155,3 @@ class SearchMatch(xmlmodels.XmlModel):
     transform_to_html = xmlmodels.XsltField(
         join(dirname(__file__), "..", "search_match.xsl")
     )
-
-
-class Judgment:
-    def __init__(self, uri: str, api_client: Optional[MarklogicApiClient] = None):
-        self.uri = uri.strip("/")
-        if api_client:
-            self.api_client = api_client
-        else:
-            self.api_client = MarklogicApiClient(
-                host=settings.MARKLOGIC_HOST,
-                username=settings.MARKLOGIC_USER,
-                password=settings.MARKLOGIC_PASSWORD,
-                use_https=settings.MARKLOGIC_USE_HTTPS,
-            )
-
-        # As part of initialisation, we preload the NCN so we can generate a MarklogicResourceNotFoundError early
-        self.neutral_citation
-
-    @property
-    def public_uri(self) -> str:
-        return "https://caselaw.nationalarchives.gov.uk/{uri}".format(uri=self.uri)
-
-    @cached_property
-    def neutral_citation(self) -> str:
-        return self.api_client.get_judgment_citation(self.uri)
-
-    @cached_property
-    def name(self) -> str:
-        return self.api_client.get_judgment_name(self.uri)
-
-    @cached_property
-    def court(self) -> str:
-        return self.api_client.get_judgment_court(self.uri)
-
-    @cached_property
-    def judgment_date_as_string(self) -> str:
-        return self.api_client.get_judgment_work_date(self.uri)
-
-    @cached_property
-    def judgment_date_as_date(self) -> datetime.date:
-        return datetime.datetime.strptime(
-            self.judgment_date_as_string, "%Y-%m-%d"
-        ).date()
-
-    @cached_property
-    def is_published(self) -> bool:
-        return self.api_client.get_published(self.uri)
-
-    @cached_property
-    def is_sensitive(self) -> bool:
-        return self.api_client.get_sensitive(self.uri)
-
-    @cached_property
-    def is_anonymised(self) -> bool:
-        return self.api_client.get_anonymised(self.uri)
-
-    @cached_property
-    def has_supplementary_materials(self) -> bool:
-        return self.api_client.get_supplemental(self.uri)
-
-    @cached_property
-    def source_name(self) -> str:
-        return self.api_client.get_property(self.uri, "source-name")
-
-    @cached_property
-    def source_email(self) -> str:
-        return self.api_client.get_property(self.uri, "source-email")
-
-    @cached_property
-    def consignment_reference(self) -> str:
-        return self.api_client.get_property(self.uri, "transfer-consignment-reference")
-
-    @property
-    def docx_url(self) -> str:
-        return generate_docx_url(uri_for_s3(self.uri))
-
-    @property
-    def pdf_url(self) -> str:
-        return generate_pdf_url(uri_for_s3(self.uri))
-
-    @property
-    def xml_url(self) -> str:
-        return reverse("full-text-xml", kwargs={"judgment_uri": self.uri})
-
-    @cached_property
-    def assigned_to(self) -> str:
-        return self.api_client.get_property(self.uri, "assigned-to")
-
-    @cached_property
-    def versions(self) -> list:
-        versions_response = self.api_client.list_judgment_versions(self.uri)
-
-        try:
-            decoded_versions = decoder.MultipartDecoder.from_response(versions_response)
-            return render_versions(decoded_versions.parts)
-        except AttributeError:
-            return []
-
-    def content_as_xml(self) -> str:
-        return self.api_client.get_judgment_xml(self.uri, show_unpublished=True)
-
-    def content_as_html(self, version_uri: str) -> str:
-        results = self.api_client.eval_xslt(
-            self.uri, version_uri, show_unpublished=True
-        )
-        multipart_data = decoder.MultipartDecoder.from_response(results)
-        return multipart_data.parts[0].text
-
-    @cached_property
-    def is_failure(self) -> bool:
-        if "failures" in self.uri:
-            return True
-        return False
-
-    @cached_property
-    def is_editable(self) -> bool:
-        if "error" in self._get_root():
-            return False
-        return True
-
-    def _get_root(self) -> str:
-        return get_judgment_root(self.content_as_xml())

--- a/judgments/models/judgments.py
+++ b/judgments/models/judgments.py
@@ -58,6 +58,10 @@ class Judgment:
         return self.api_client.get_published(self.uri)
 
     @cached_property
+    def is_held(self) -> bool:
+        return self.api_client.get_property(self.uri, "editor-hold")
+
+    @cached_property
     def is_sensitive(self) -> bool:
         return self.api_client.get_sensitive(self.uri)
 

--- a/judgments/models/judgments.py
+++ b/judgments/models/judgments.py
@@ -1,0 +1,133 @@
+import datetime
+from functools import cached_property
+from typing import Optional
+
+from caselawclient.Client import MarklogicApiClient
+from django.conf import settings
+from django.urls import reverse
+from requests_toolbelt.multipart import decoder
+
+from judgments.utils import get_judgment_root, render_versions
+from judgments.utils.aws import generate_docx_url, generate_pdf_url, uri_for_s3
+
+
+class Judgment:
+    def __init__(self, uri: str, api_client: Optional[MarklogicApiClient] = None):
+        self.uri = uri.strip("/")
+        if api_client:
+            self.api_client = api_client
+        else:
+            self.api_client = MarklogicApiClient(
+                host=settings.MARKLOGIC_HOST,
+                username=settings.MARKLOGIC_USER,
+                password=settings.MARKLOGIC_PASSWORD,
+                use_https=settings.MARKLOGIC_USE_HTTPS,
+            )
+
+        # As part of initialisation, we preload the NCN so we can generate a MarklogicResourceNotFoundError early
+        self.neutral_citation
+
+    @property
+    def public_uri(self) -> str:
+        return "https://caselaw.nationalarchives.gov.uk/{uri}".format(uri=self.uri)
+
+    @cached_property
+    def neutral_citation(self) -> str:
+        return self.api_client.get_judgment_citation(self.uri)
+
+    @cached_property
+    def name(self) -> str:
+        return self.api_client.get_judgment_name(self.uri)
+
+    @cached_property
+    def court(self) -> str:
+        return self.api_client.get_judgment_court(self.uri)
+
+    @cached_property
+    def judgment_date_as_string(self) -> str:
+        return self.api_client.get_judgment_work_date(self.uri)
+
+    @cached_property
+    def judgment_date_as_date(self) -> datetime.date:
+        return datetime.datetime.strptime(
+            self.judgment_date_as_string, "%Y-%m-%d"
+        ).date()
+
+    @cached_property
+    def is_published(self) -> bool:
+        return self.api_client.get_published(self.uri)
+
+    @cached_property
+    def is_sensitive(self) -> bool:
+        return self.api_client.get_sensitive(self.uri)
+
+    @cached_property
+    def is_anonymised(self) -> bool:
+        return self.api_client.get_anonymised(self.uri)
+
+    @cached_property
+    def has_supplementary_materials(self) -> bool:
+        return self.api_client.get_supplemental(self.uri)
+
+    @cached_property
+    def source_name(self) -> str:
+        return self.api_client.get_property(self.uri, "source-name")
+
+    @cached_property
+    def source_email(self) -> str:
+        return self.api_client.get_property(self.uri, "source-email")
+
+    @cached_property
+    def consignment_reference(self) -> str:
+        return self.api_client.get_property(self.uri, "transfer-consignment-reference")
+
+    @property
+    def docx_url(self) -> str:
+        return generate_docx_url(uri_for_s3(self.uri))
+
+    @property
+    def pdf_url(self) -> str:
+        return generate_pdf_url(uri_for_s3(self.uri))
+
+    @property
+    def xml_url(self) -> str:
+        return reverse("full-text-xml", kwargs={"judgment_uri": self.uri})
+
+    @cached_property
+    def assigned_to(self) -> str:
+        return self.api_client.get_property(self.uri, "assigned-to")
+
+    @cached_property
+    def versions(self) -> list:
+        versions_response = self.api_client.list_judgment_versions(self.uri)
+
+        try:
+            decoded_versions = decoder.MultipartDecoder.from_response(versions_response)
+            return render_versions(decoded_versions.parts)
+        except AttributeError:
+            return []
+
+    def content_as_xml(self) -> str:
+        return self.api_client.get_judgment_xml(self.uri, show_unpublished=True)
+
+    def content_as_html(self, version_uri: str) -> str:
+        results = self.api_client.eval_xslt(
+            self.uri, version_uri, show_unpublished=True
+        )
+        multipart_data = decoder.MultipartDecoder.from_response(results)
+        return multipart_data.parts[0].text
+
+    @cached_property
+    def is_failure(self) -> bool:
+        if "failures" in self.uri:
+            return True
+        return False
+
+    @cached_property
+    def is_editable(self) -> bool:
+        if "error" in self._get_root():
+            return False
+        return True
+
+    def _get_root(self) -> str:
+        return get_judgment_root(self.content_as_xml())

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -1,7 +1,7 @@
 from typing import Any
 from unittest.mock import Mock
 
-from judgments.models import Judgment
+from judgments.models.judgments import Judgment
 
 
 class JudgmentFactory:

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -20,6 +20,7 @@ class JudgmentFactory:
         "source_name": ("source_name", "Example Uploader"),
         "source_email": ("source_email", "uploader@example.com"),
         "consignment_reference": ("consignment_reference", "TDR-12345"),
+        "assigned_to": ("assigned_to", ""),
         "versions": ("versions", []),
     }
 

--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -79,7 +79,7 @@ class TestJudgmentView(TestCase):
         assert response.status_code == 200
 
     @patch(
-        "judgments.models.MarklogicApiClient.get_judgment_citation",
+        "judgments.models.judgments.MarklogicApiClient.get_judgment_citation",
         side_effect=MarklogicResourceNotFoundError(),
     )
     def test_judgment_html_view_not_found_response(self, mock_api_client):
@@ -114,7 +114,7 @@ class TestJudgmentView(TestCase):
         )
 
     @patch(
-        "judgments.models.MarklogicApiClient.get_judgment_citation",
+        "judgments.models.judgments.MarklogicApiClient.get_judgment_citation",
         side_effect=MarklogicResourceNotFoundError(),
     )
     def test_judgment_pdf_view_not_found_response(self, mock_api_client):
@@ -140,7 +140,7 @@ class TestJudgmentView(TestCase):
         self.assertEqual(response.status_code, 404)
 
     @patch(
-        "judgments.models.MarklogicApiClient.get_judgment_citation",
+        "judgments.models.judgments.MarklogicApiClient.get_judgment_citation",
         side_effect=MarklogicResourceNotFoundError(),
     )
     def test_judgment_xml_view_not_found_response(self, mock_api_client):

--- a/judgments/tests/test_models_judgment.py
+++ b/judgments/tests/test_models_judgment.py
@@ -213,13 +213,29 @@ class TestJudgmentPublication:
             judgment.publish()
             mock_api_client.set_published.assert_not_called()
 
-    def test_publish(self, mock_api_client):
+    @patch("judgments.models.judgments.notify_changed")
+    @patch("judgments.models.judgments.publish_documents")
+    def test_publish(
+        self, mock_publish_documents, mock_notify_changed, mock_api_client
+    ):
         judgment = Judgment("test/1234", mock_api_client)
         judgment.is_publishable = True
         judgment.publish()
+        mock_publish_documents.assert_called_once_with("test/1234")
         mock_api_client.set_published.assert_called_once_with("test/1234", True)
+        mock_notify_changed.assert_called_once_with(
+            uri="test/1234", status="published", enrich=True
+        )
 
-    def test_unpublish(self, mock_api_client):
+    @patch("judgments.models.judgments.notify_changed")
+    @patch("judgments.models.judgments.unpublish_documents")
+    def test_unpublish(
+        self, mock_unpublish_documents, mock_notify_changed, mock_api_client
+    ):
         judgment = Judgment("test/1234", mock_api_client)
         judgment.unpublish()
+        mock_unpublish_documents.assert_called_once_with("test/1234")
         mock_api_client.set_published.assert_called_once_with("test/1234", False)
+        mock_notify_changed.assert_called_once_with(
+            uri="test/1234", status="not published", enrich=False
+        )

--- a/judgments/tests/test_models_judgment.py
+++ b/judgments/tests/test_models_judgment.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, Mock, patch
 import pytest
 from caselawclient.Client import MarklogicApiClient
 
-from judgments.models import Judgment
+from judgments.models.judgments import Judgment
 
 
 @pytest.fixture
@@ -13,7 +13,7 @@ def mock_api_client():
 
 
 class TestJudgment:
-    @patch("judgments.models.MarklogicApiClient")
+    @patch("judgments.models.judgments.MarklogicApiClient")
     def test_judgment_uses_default_api_client(self, mock_api_client_class):
         Judgment("test/1234")
 
@@ -21,7 +21,7 @@ class TestJudgment:
             host=ANY, username=ANY, password=ANY, use_https=ANY
         )
 
-    @patch("judgments.models.MarklogicApiClient")
+    @patch("judgments.models.judgments.MarklogicApiClient")
     def test_judgment_doesnt_use_default_api_client_if_provided(
         self, mock_api_client_class, mock_api_client
     ):
@@ -136,7 +136,7 @@ class TestJudgment:
             "test/1234", "transfer-consignment-reference"
         )
 
-    @patch("judgments.models.generate_docx_url")
+    @patch("judgments.models.judgments.generate_docx_url")
     def test_judgment_docx_url(self, mock_url_generator, mock_api_client):
         mock_url_generator.return_value = "https://example.com/mock.docx"
 
@@ -145,7 +145,7 @@ class TestJudgment:
         assert judgment.docx_url == "https://example.com/mock.docx"
         mock_url_generator.assert_called_once
 
-    @patch("judgments.models.generate_pdf_url")
+    @patch("judgments.models.judgments.generate_pdf_url")
     def test_judgment_pdf_url(self, mock_url_generator, mock_api_client):
         mock_url_generator.return_value = "https://example.com/mock.pdf"
 

--- a/judgments/tests/test_models_judgment.py
+++ b/judgments/tests/test_models_judgment.py
@@ -84,6 +84,14 @@ class TestJudgment:
         assert judgment.is_published is True
         mock_api_client.get_published.assert_called_once_with("test/1234")
 
+    def test_judgment_is_held(self, mock_api_client):
+        mock_api_client.get_property.return_value = False
+
+        judgment = Judgment("test/1234", mock_api_client)
+
+        assert judgment.is_held is False
+        mock_api_client.get_property.assert_called_once_with("test/1234", "editor-hold")
+
     def test_judgment_is_sensitive(self, mock_api_client):
         mock_api_client.get_sensitive.return_value = True
 

--- a/judgments/tests/test_unlock.py
+++ b/judgments/tests/test_unlock.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.test import Client
 from django.urls import reverse
 
-from judgments.models import Judgment
+from judgments.models.judgments import Judgment
 
 
 @pytest.mark.django_db

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -5,7 +5,8 @@ from django.test import TestCase
 from django.urls import reverse
 from lxml import etree
 
-from judgments.models import Judgment, SearchResult, SearchResultMeta
+from judgments.models import SearchResult, SearchResultMeta
+from judgments.models.judgments import Judgment
 
 
 class TestSearchResults(TestCase):

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -18,13 +18,7 @@ from judgments.utils import (
     update_judgment_uri,
     users_dict,
 )
-from judgments.utils.aws import (
-    invalidate_caches,
-    notify_changed,
-    publish_documents,
-    unpublish_documents,
-    uri_for_s3,
-)
+from judgments.utils.aws import invalidate_caches
 
 
 class EditJudgmentView(View):
@@ -167,35 +161,25 @@ class EditJudgmentView(View):
             api_client.set_judgment_date(judgment_uri, new_date)
 
             if not subset:
-                published = bool(request.POST.get("published", False))
                 sensitive = bool(request.POST.get("sensitive", False))
                 supplemental = bool(request.POST.get("supplemental", False))
                 anonymised = bool(request.POST.get("anonymised", False))
 
-                api_client.set_published(judgment_uri, published)
                 api_client.set_sensitive(judgment_uri, sensitive)
                 api_client.set_supplemental(judgment_uri, supplemental)
                 api_client.set_anonymised(judgment_uri, anonymised)
-
-                if published:
-                    publish_documents(uri_for_s3(judgment_uri))
-                else:
-                    unpublish_documents(uri_for_s3(judgment_uri))
 
                 # Assignment
                 # TODO consider validating assigned_to is a user?
                 if new_assignment := request.POST["assigned_to"]:
                     api_client.set_property(judgment_uri, "assigned-to", new_assignment)
 
+                published = bool(request.POST.get("published", False))
+
                 if published:
-                    notify_status = "published"
+                    judgment.publish()
                 else:
-                    notify_status = "not published"
-                notify_changed(
-                    uri=judgment_uri,
-                    status=notify_status,
-                    enrich=published,  # placeholder for now, should perhaps be "has this become published"
-                )
+                    judgment.unpublish()
 
             # If judgment_uri is a `failure` URI, amend it to match new neutral citation and redirect
             if "failures" in judgment_uri and new_citation is not None:

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from django.utils.translation import gettext
 from django.views.generic import View
 
-from judgments.models import Judgment
+from judgments.models.judgments import Judgment
 from judgments.utils import (
     MoveJudgmentError,
     NeutralCitationToUriError,

--- a/judgments/views/edit_judgment.py
+++ b/judgments/views/edit_judgment.py
@@ -176,9 +176,9 @@ class EditJudgmentView(View):
 
                 published = bool(request.POST.get("published", False))
 
-                if published:
+                if published and not judgment.is_published:
                     judgment.publish()
-                else:
+                elif not published and judgment.is_published:
                     judgment.unpublish()
 
             # If judgment_uri is a `failure` URI, amend it to match new neutral citation and redirect

--- a/judgments/views/full_text.py
+++ b/judgments/views/full_text.py
@@ -6,7 +6,7 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.template import loader
 from django.urls import reverse
 
-from judgments.models import Judgment
+from judgments.models.judgments import Judgment
 from judgments.utils import extract_version
 
 

--- a/judgments/views/unlock.py
+++ b/judgments/views/unlock.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from django.utils.translation import gettext
 from django.views.decorators.http import require_http_methods
 
-from judgments.models import Judgment
+from judgments.models.judgments import Judgment
 
 
 @require_http_methods(["POST", "GET", "HEAD"])


### PR DESCRIPTION
At the moment, the process of (un)publishing a judgment is handled by `edit_judgment.py` making API calls.

Since we now have the `Judgment` object, we can implement new `publish()` and `unpublish()` functions which do the same thing in a more contained and testable way.