### PR TITLE
Autofill court codes

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/metadata_header.html
+++ b/ds_caselaw_editor_ui/templates/includes/metadata_header.html
@@ -14,7 +14,12 @@
         </div>
         <div class="metadata-component__court">
           <label for="court" class="metadata-component__main-labels">{% translate "judgment.court" %}</label>
-          <input type="text" class="metadata-component__court-input" value="{{ context.judgment.court }}" name="court" id="court" />
+          <input type="text" class="metadata-component__court-input" value="{{ context.judgment.court }}" name="court" id="court" list="court-ids"/>
+          <datalist id="court-ids">
+            {% for court in context.courts %}
+              <option value="{{ court.code }}">{{court.name}}</option>
+            {% endfor %}
+          </datalist>
         </div>
         <div class="metadata-component__date">
           <label for="judgment_date" class="metadata-component__main-labels">{% translate "judgment.judgment_date" %}</label>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -12,12 +12,17 @@
     <div class="edit-component__panel">
       <label for="neutral_citation">{% translate "judgment.neutral_citation" %}</label>
       <input type="text" class="edit-component__neutral_citation-input" value="{{ context.judgment.neutral_citation }}"
-             name="neutral_citation" id="neutral_citation" />
+             name="neutral_citation" id="neutral_citation" size="30"/>
     </div>
     <div class="edit-component__panel">
       <label for="court">{% translate "judgment.court" %}</label>
       <input type="text" class="edit-component__court-input" value="{{ context.judgment.court }}"
-             name="court" id="court" />
+             name="court" id="court" list="court-ids" size="40"/>
+      <datalist id="court-ids">
+        {% for court in context.courts %}
+          <option value="{{ court.code }}">{{ court.code }}: {{court.name}}</option>
+        {% endfor %}
+      </datalist>
     </div>
     <div class="edit-component__panel">
       <label for="judgment_date">{% translate "judgment.judgment_date" %}</label>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -20,7 +20,7 @@
              name="court" id="court" list="court-ids" size="40"/>
       <datalist id="court-ids">
         {% for court in context.courts %}
-          <option value="{{ court.code }}">{{ court.code }}: {{court.name}}</option>
+          <option value="{{ court.code }}">{{court.name}}</option>
         {% endfor %}
       </datalist>
     </div>

--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -32,6 +32,10 @@ class TestJudgmentEdit(TestCase):
         decoded_response = response.content.decode("utf-8")
         self.assertIn("Test v Tested", decoded_response)
         assert response.status_code == 200
+        assert (
+            '<option value="UKSC">United Kingdom Supreme Court</option>'
+            in decoded_response
+        )
 
     @patch("judgments.views.judgment_edit.invalidate_caches")
     @patch("judgments.views.judgment_edit.api_client")

--- a/judgments/views/full_text.py
+++ b/judgments/views/full_text.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlencode
 
+import ds_caselaw_utils as caselawutils
 import waffle
 from caselawclient.Client import MarklogicResourceNotFoundError
 from django.http import Http404, HttpResponse, HttpResponseRedirect
@@ -16,7 +17,11 @@ def html_view(request, judgment_uri):
 
     try:
         judgment = Judgment(judgment_uri)
-        context = {"judgment_uri": judgment_uri, "judgment": judgment}
+        context = {
+            "judgment_uri": judgment_uri,
+            "judgment": judgment,
+            "courts": caselawutils.courts.get_all(),
+        }
 
         if not judgment.is_editable:
             judgment_content = judgment.content_as_xml()

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -1,5 +1,6 @@
 from urllib.parse import quote, urlencode
 
+import ds_caselaw_utils as caselawutils
 import waffle
 from caselawclient.Client import MarklogicAPIError, api_client
 from django.conf import settings
@@ -110,6 +111,7 @@ class EditJudgmentView(View):
         context["judgment"] = judgment
         context["page_title"] = judgment.name
         context["view"] = "judgment_metadata"
+        context["courts"] = caselawutils.courts.get_all()
 
         context.update({"users": users_dict()})
 


### PR DESCRIPTION
Uses a datalist to show a drop-down list of options; we include codename and ID to facilitate multiple types of search.

Changes width of court and neutral citation fields to be a little wider by default.

Should fall back gracefully if the datalist is not supported.

Strange bug on my system where "A-COURT" comes up as an option -- it's not in the HTML, so I assume it's my browser.

Do we want a feature flag on this?

<img width="949" alt="image" src="https://user-images.githubusercontent.com/85497046/224075980-fbb16ecb-b36a-49b8-a835-88cff3f5f8b3.png">
