### PR TITLE
Limit length of version strings in regex

### DIFF
--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -13,7 +13,10 @@ from django.contrib.auth.models import User
 
 from .aws import copy_assets
 
-VERSION_REGEX = r"(\d+)-(\d+|TDR)"
+VERSION_REGEX = r"xml_versions/(\d{1,10})-(\d{1,10}|TDR)"
+# Here we limit the number of digits in the version and document reference to 10 on purpose, see
+# https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS for an explanation of why.
+
 akn_namespace = {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"}
 uk_namespace = {"uk": "https://caselaw.nationalarchives.gov.uk/akn"}
 


### PR DESCRIPTION
This prevents a potential DoS attack by people passing in enormously long strings of numbers, causing the regex engine to chew up resources.