### PR TITLE
Simplify secondary button class

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_buttons.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_buttons.scss
@@ -1,0 +1,9 @@
+.button-secondary {
+        @include call-to-action-button;
+        background-color: transparent;
+        color: $color__cta-background !important;
+        border: 2px solid $color__cta-background;
+    &:visited  {
+      color: #ffffff;
+    }
+}

--- a/ds_caselaw_editor_ui/sass/includes/_how_can_this_service_be_improved.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_how_can_this_service_be_improved.scss
@@ -12,11 +12,4 @@
         font-size: 1.3rem;
       }
     }
-
-    &__cta-button {
-      @include call-to-action-button-secondary;
-      &:visited  {
-        color: #ffffff;
-      }
-    }
   }

--- a/ds_caselaw_editor_ui/sass/includes/_mixins.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_mixins.scss
@@ -66,13 +66,6 @@
   }
 }
 
-@mixin call-to-action-button-secondary {
-  @include call-to-action-button;
-  background-color: transparent;
-  color: $color__cta-background !important;
-  border: 2px solid $color__cta-background;
-}
-
 @mixin emphasised-block {
   padding: $spacer__unit;
 

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -28,5 +28,6 @@
 @import "includes/cookie_consent/ds-cookie-consent";
 @import "includes/cookie_consent/cookie-consent";
 @import "includes/metadata";
+@import "includes/buttons";
 
 @import "includes/labs";

--- a/ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html
+++ b/ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html
@@ -2,6 +2,6 @@
 <div class="sub-footer">
   <div class="sub-footer__container">
     <h2>{% translate "service.improved" %}</h2>
-    <a target="_blank" role="button" draggable="false" rel="noreferrer noopener" class="sub-footer__cta-button" href="{% translate "survey.link" %}">{% translate "survey.link.text" %}</a>
+    <a target="_blank" role="button" draggable="false" rel="noreferrer noopener" class="button-secondary" href="{% translate "survey.link" %}">{% translate "survey.link.text" %}</a>
   </div>
 </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Decided to reduce button styles on the EUI. So that we had one class for the secondary button that can be used for all secondary buttons.
## Trello card / Rollbar error (etc)
[This was](https://trello.com/c/upm0qF6y/603-eui-fix-reduce-sass-styles-of-secondary-button-to-just-one)

## Screenshots of UI changes:

### Before
This shows multiple classes for the button
![Screenshot 2023-03-13 at 15 49 40](https://user-images.githubusercontent.com/102584881/224755052-3a0dc8f7-4801-480f-a174-51dd6d89f8f9.png)


### After
This shows a single class for the button.
![Screenshot 2023-03-13 at 15 50 03](https://user-images.githubusercontent.com/102584881/224755015-4be3405c-ce54-49ce-866e-7c35c116a97d.png)


- [ ] Requires env variable(s) to be updated
