### PR TITLE
Judgment status indicator

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/components/_tags.scss
+++ b/ds_caselaw_editor_ui/sass/includes/components/_tags.scss
@@ -1,0 +1,37 @@
+.tna-tag {
+
+  display: inline-block;
+
+  padding: 4px;
+
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+
+  color: $color__white;
+  background-color: $color__dark-blue;
+  letter-spacing: 1px;
+
+  text-decoration: none;
+  text-transform: uppercase;
+
+}
+
+.tna-tag--grey {
+  color: mix(black, $color__dark-grey, 30%);
+  background: mix(white, $color__dark-grey, 90%);
+}
+
+.tna-tag--light-blue {
+  color: mix(black, $color__highlight-blue, 30%);
+  background: mix(white, $color__highlight-blue, 90%);
+}
+
+.tna-tag--green {
+  color: mix(black, $color__green, 30%);
+  background: mix(white, $color__green, 90%);
+}
+
+.tna-tag--red {
+  color: mix(black, $color__red, 30%);
+  background: mix(white, $color__red, 90%);
+}

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -30,4 +30,6 @@
 @import "includes/metadata";
 @import "includes/buttons";
 
+@import "includes/components/tags";
+
 @import "includes/labs";

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -1,10 +1,11 @@
-{% load i18n %}
+{% load i18n status_tag_css %}
 
 <div class="judgment-sidebar__block">
 
   <h4>{% translate "judgments.sidebar.judgment" %}</h4>
 
   <ul>
+    <li><span class="tna-tag tna-tag--{{ context.judgment.status | status_tag_colour }}">{{ context.judgment.status }}</span></li>
     <li><span class="judgment-sidebar__label">{% translate "judgments.labels.uri" %}:</span> {{ context.judgment.uri }}</li>
   </ul>
 

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -2,6 +2,16 @@
 
 <div class="judgment-sidebar__block">
 
+  <h4>{% translate "judgments.sidebar.judgment" %}</h4>
+
+  <ul>
+    <li><span class="judgment-sidebar__label">{% translate "judgments.labels.uri" %}:</span> {{ context.judgment.uri }}</li>
+  </ul>
+
+</div>
+
+<div class="judgment-sidebar__block">
+
   <h4>{% translate "judgments.sidebar.submission" %}</h4>
 
   <ul>

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -2,7 +2,7 @@
 
 <div class="judgment-sidebar__block">
 
-  <h4>Submission</h4>
+  <h4>{% translate "judgments.sidebar.submission" %}</h4>
 
   <ul>
     <li><span class="judgment-sidebar__label">{% translate "judgments.submitter" %}:</span> {{ context.judgment.source_name }}</li>
@@ -13,7 +13,7 @@
 </div>
 <div class="judgment-sidebar__block">
 
-  <h4>Downloads</h4>
+  <h4>{% translate "judgments.sidebar.downloads" %}</h4>
 
   <ul>
     {% if context.judgment.docx_url %}
@@ -28,7 +28,7 @@
 </div>
 <div class="judgment-sidebar__block">
 
-  <h4>Tools</h4>
+  <h4>{% translate "judgments.sidebar.tools" %}</h4>
   <ul>
     <li><a href="{{ context.jira_create_link }}" target="_blank" rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a></li>
     <li><a href="{% url 'unlock' %}?judgment_uri={{context.judgment_uri}}">{% translate "judgment.unlock_judgment_title" %}</a></li>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -2,7 +2,6 @@
 {% load waffle_tags %}
 {% block judgment_content %}
   {% load i18n %}
-  <h2 class="edit-component__header">{% translate "judgment.edit_judgment" %} <span class="judgment-uri">{{context.judgment_uri}}</span></h2>
   <form aria-label="Edit judgment" method="post">
     {% csrf_token %}
     <div class="edit-component__panel">

--- a/judgments/models/judgments.py
+++ b/judgments/models/judgments.py
@@ -17,6 +17,10 @@ from judgments.utils.aws import (
     uri_for_s3,
 )
 
+JUDGMENT_STATUS_HOLD = "On hold"
+JUDGMENT_STATUS_PUBLISHED = "Published"
+JUDGMENT_STATUS_IN_PROGRESS = "In progress"
+
 
 class CannotPublishUnpublishableJudgment(Exception):
     pass
@@ -153,6 +157,16 @@ class Judgment:
             return False
 
         return True
+
+    @property
+    def status(self) -> str:
+        if self.is_published:
+            return JUDGMENT_STATUS_PUBLISHED
+
+        if self.is_held:
+            return JUDGMENT_STATUS_HOLD
+
+        return JUDGMENT_STATUS_IN_PROGRESS
 
     def publish(self):
         if not self.is_publishable:

--- a/judgments/templatetags/status_tag_css.py
+++ b/judgments/templatetags/status_tag_css.py
@@ -1,0 +1,22 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+from judgments.models.judgments import (
+    JUDGMENT_STATUS_HOLD,
+    JUDGMENT_STATUS_IN_PROGRESS,
+    JUDGMENT_STATUS_PUBLISHED,
+)
+
+register = template.Library()
+
+
+@register.filter
+@stringfilter
+def status_tag_colour(status):
+    if status == JUDGMENT_STATUS_IN_PROGRESS:
+        return "light-blue"
+    if status == JUDGMENT_STATUS_HOLD:
+        return "red"
+    if status == JUDGMENT_STATUS_PUBLISHED:
+        return "green"
+    return "grey"

--- a/judgments/tests/test_models_judgment.py
+++ b/judgments/tests/test_models_judgment.py
@@ -4,7 +4,13 @@ from unittest.mock import ANY, Mock, patch
 import pytest
 from caselawclient.Client import MarklogicApiClient
 
-from judgments.models.judgments import CannotPublishUnpublishableJudgment, Judgment
+from judgments.models.judgments import (
+    JUDGMENT_STATUS_HOLD,
+    JUDGMENT_STATUS_IN_PROGRESS,
+    JUDGMENT_STATUS_PUBLISHED,
+    CannotPublishUnpublishableJudgment,
+    Judgment,
+)
 
 
 @pytest.fixture
@@ -191,6 +197,22 @@ class TestJudgment:
 
         assert successful_judgment.is_failure is False
         assert failing_judgment.is_failure is True
+
+    def test_judgment_status(self, mock_api_client):
+        in_progress_judgment = Judgment("test/1234", mock_api_client)
+        in_progress_judgment.is_held = False
+        in_progress_judgment.is_published = False
+        assert in_progress_judgment.status == JUDGMENT_STATUS_IN_PROGRESS
+
+        on_hold_judgment = Judgment("test/1234", mock_api_client)
+        on_hold_judgment.is_held = True
+        on_hold_judgment.is_published = False
+        assert on_hold_judgment.status == JUDGMENT_STATUS_HOLD
+
+        published_judgment = Judgment("test/1234", mock_api_client)
+        on_hold_judgment.is_held = False
+        published_judgment.is_published = True
+        assert published_judgment.status == JUDGMENT_STATUS_PUBLISHED
 
 
 class TestJudgmentPublication:

--- a/judgments/tests/test_templatetags.py
+++ b/judgments/tests/test_templatetags.py
@@ -1,0 +1,20 @@
+from judgments.models.judgments import (
+    JUDGMENT_STATUS_HOLD,
+    JUDGMENT_STATUS_IN_PROGRESS,
+    JUDGMENT_STATUS_PUBLISHED,
+)
+from judgments.templatetags.status_tag_css import status_tag_colour
+
+
+class TestStatusTagColour:
+    def test_colour_in_progress(self):
+        assert status_tag_colour(JUDGMENT_STATUS_IN_PROGRESS) == "light-blue"
+
+    def test_colour_published(self):
+        assert status_tag_colour(JUDGMENT_STATUS_PUBLISHED) == "green"
+
+    def test_colour_hold(self):
+        assert status_tag_colour(JUDGMENT_STATUS_HOLD) == "red"
+
+    def test_colour_undefined(self):
+        assert status_tag_colour("undefined") == "grey"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-15 12:03+0000\n"
+"POT-Creation-Date: 2023-03-15 12:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,6 +57,14 @@ msgstr ""
 #: ds_caselaw_editor_ui/templates/includes/how_can_this_service_be_improved.html
 msgid "survey.link.text"
 msgstr "Fill out our short survey"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+msgid "judgments.sidebar.judgment"
+msgstr "Judgment"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+msgid "judgments.labels.uri"
+msgstr "Internal ID"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
 msgid "judgments.sidebar.submission"
@@ -241,10 +249,6 @@ msgstr "Judgment successfully deleted"
 #: ds_caselaw_editor_ui/templates/judgment/deleted.html
 msgid "judgment.return_home"
 msgstr "Return to Find and manage case law"
-
-#: ds_caselaw_editor_ui/templates/judgment/edit.html
-msgid "judgment.edit_judgment"
-msgstr "Edit Judgment"
 
 #: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.published"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 15:53+0000\n"
+"POT-Creation-Date: 2023-03-15 12:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,6 +59,10 @@ msgid "survey.link.text"
 msgstr "Fill out our short survey"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+msgid "judgments.sidebar.submission"
+msgstr "Submission"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 #: judgments/views/judgment_edit.py
 msgid "judgments.submitter"
@@ -77,6 +81,10 @@ msgid "judgments.consignmentref"
 msgstr "TDR Reference"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+msgid "judgments.sidebar.downloads"
+msgstr "Downloads"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
 msgid "judgment.download_docx"
 msgstr "Download original .docx"
 
@@ -87,6 +95,10 @@ msgstr "Download PDF"
 #: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
 msgid "judgment.download_xml"
 msgstr "Download XML"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+msgid "judgments.sidebar.tools"
+msgstr "Tools"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
 msgid "judgment.create_in_jira"


### PR DESCRIPTION
Add a status indicator for a judgment to the sidebar, showing one of "in progress", "published" or "on hold".

The tag formatting is based on the GOV.UK Design System.

## Judgment states

### Published

A judgment is "published" if its published flag is set _regardless of if it is on hold or not_.

### On hold

A judgment is "on hold" if its hold flag is set _and_ it is not published.

### In progress

A judgment is "in progress" if it has neither published or hold flags set.