### PR TITLE
Create styleguide page

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_style_guide.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_style_guide.scss
@@ -1,0 +1,5 @@
+.style-guide {
+    max-width: 90%;
+    margin: 0 auto;
+    padding: 1rem 0;
+}

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -33,3 +33,4 @@
 @import "includes/components/tags";
 
 @import "includes/labs";
+@import "includes/style_guide";

--- a/ds_caselaw_editor_ui/templates/includes/style_guide/buttons.html
+++ b/ds_caselaw_editor_ui/templates/includes/style_guide/buttons.html
@@ -1,0 +1,7 @@
+<h3>Buttons</h3>
+<h4>Call to action button</h4>
+<p> Use with <code>class="button-cta"</code>:</p>
+<button class="button-cta">This is a call to action</button>
+<h4>Secondary button</h4>
+<p> Use with <code>class="button-secondary"</code>:</p>
+<button class="button-secondary">This is a secondary button</button>

--- a/ds_caselaw_editor_ui/templates/pages/style_guide.html
+++ b/ds_caselaw_editor_ui/templates/pages/style_guide.html
@@ -1,0 +1,10 @@
+{% extends "layouts/base.html" %}
+{% load i18n %}
+{% block content %}
+  <div class="style-guide">
+    <h2>{% translate "style_guide.title" %}</h2>
+    <p>{% translate "style_guide.description" %}</p>
+    <hr />
+    {% include "includes/style_guide/buttons.html" %}
+  </div>
+{% endblock %}

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -26,6 +26,7 @@ from .views.judgment_publish import (
 from .views.labs import Labs
 from .views.results import results
 from .views.signed_asset import redirect_to_signed_asset
+from .views.style_guide import StyleGuide
 from .views.unlock import unlock
 
 urlpatterns = [
@@ -49,6 +50,7 @@ urlpatterns = [
     path("xml", xml_view_redirect),
     # Labs
     path("labs", Labs.as_view(), name="labs"),
+    path("style_guide", StyleGuide.as_view(), name="style_guide"),
     # Different views on judgments
     path("<path:judgment_uri>/edit", EditJudgmentView.as_view(), name="edit-judgment"),
     path(

--- a/judgments/views/style_guide.py
+++ b/judgments/views/style_guide.py
@@ -1,0 +1,5 @@
+from django.views.generic import TemplateView
+
+
+class StyleGuide(TemplateView):
+    template_name = "pages/style_guide.html"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-15 12:19+0000\n"
+"POT-Creation-Date: 2023-03-16 13:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -329,6 +329,18 @@ msgid "search.improvesearch"
 msgstr ""
 "Improve your search results by removing filters, double-checking your "
 "spelling, using fewer keywords or searching for something less specific."
+
+#: ds_caselaw_editor_ui/templates/pages/style_guide.html
+msgid "style_guide.title"
+msgstr "Caselaw editor UI style guide"
+
+#: ds_caselaw_editor_ui/templates/pages/style_guide.html
+msgid "style_guide.description"
+msgstr ""
+"This page serves as a sandbox for developing new UI components, "
+"as well as a repository of UI elements used on the site. Please "
+"develop new components in a seperate file under the includes/style_guide "
+"folder, and include it below following the example in the template."
 
 #: judgments/views/delete.py
 msgid "judgment.delete_a_judgment"


### PR DESCRIPTION
## Changes in this PR:

Create a styleguide and populate it with our button styles as a placeholder example (the CTA button is, ironically, unstyled, but that's because it was abstracted out as a reusable component on another branch that's pending merge - it'll magically become styled when that's done!)

This is going to offer front end devs a place to develop reusable components in isolation, as well as acting as a pallete of reusable components, breaking the dependency of front end dev on backend requirements, encouraging us to write reusable code, and documenting our work (at least in theory!)

## Trello card / Rollbar error (etc)

https://trello.com/c/o7AZSoyw/609-eui-start-creating-a-style-guide-page

## Picture (for posterity)
![Screenshot 2023-03-17 at 11 35 49](https://user-images.githubusercontent.com/4279/225893078-5784731e-7ea0-44d3-aec7-528c529577de.png)
