### PR TITLE
update instructions for using translations in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,74 +258,77 @@ We're using [the built-in django translation module](https://docs.djangoproject.
 
 #### Adding new translations
 
-1) Ensure that the `i18n` module is loaded at the top of the file:
+1. Ensure that the `i18n` module is loaded at the top of the file:
 
-```django
-{% extends 'layouts/base.html' %}
-{% load i18n %}
-...
-```
+  ```django
+  {% extends 'layouts/base.html' %}
+  {% load i18n %}
+  ...
+  ```
 
-2) Add the translation string to the page:
-```
-<h1>{% translate "namespace.mytranslation" %}</h1>
-```
+2. Add the translation string to the page:
 
-3) Update the locale file by running the following command  (see also 'a note on the django-admin command' below):
-```
-django-admin makemessages --no-obsolete --add-location file -l en_GB
-```
+  ```
+  <h1>{% translate "namespace.mytranslation" %}</h1>
+  ```
 
-4) In the generated `.po` file, find the generated msgid string and add the translation below it
+3. Update the locale file by running the following command in a `fab sh` shell:
 
-```
-msgid "namespace.mytranslation"
-msgstr "This is my translation"
-```
+  ```
+  python manage.py makemessages --no-obsolete --add-location file -l en_GB
+  ```
 
-5) Compile the translations to a binary file  (see also 'a note on the django-admin command' below):
-```
-  django-admin compilemessages
-```
+4. In the generated `.po` file, find the generated translation section, it will be a block like this, with the `msgid` corresponding to the key you added in the template:
 
-### Changing existing translations:
+  ```
+  #: ds_caselaw_editor_ui/templates/includes/my_template.html
+  #, fuzzy
+  #| msgid "namespace.othertranslation"
+  msgid "namespace.mytranslation"
+  msgstr "An existing translation autofilled as an example"
+  ```
 
-1) Find the translation string you want to change in the template:
+  You need to do two things here - first remove the line starting with `#, fuzzy` and any lines starting with `#|` below it, then edit the line starting with `msgstr` to include your translation string. The end result will look something like this:
 
-```django
-   <h1>{% translate "namespace.mytranslation" %}</h1>
-```
+  ```
+  #: ds_caselaw_editor_ui/templates/includes/my_template.html
+  msgid "namespace.mytranslation"
+  msgstr "This is my translation"
+  ```
 
-2) Go and look for this translation in the `django.po` file (you'll be looking for a line with `msgid` at the start and the string you saw in the template):
+5. Compile the translations to a binary file (this should also be run inside a `fab sh` shell):
+  ```
+  python manage.py compilemessages
+  ```
 
-```
-msgid "namespace.mytranslation"
-msgstr "This is my translation"
-```
+### Changing existing translations
 
-3) Change the text on the following line (begining with `msgstr` to the new translation you want):
+1. Find the translation string you want to change in the template:
+
+  ```django
+    <h1>{% translate "namespace.mytranslation" %}</h1>
+  ```
+
+2. Go and look for this translation in the `django.po` file (you'll be looking for a line with `msgid` at the start and the string you saw in the template):
+
+  ```
+  msgid "namespace.mytranslation"
+  msgstr "This is my translation"
+  ```
+
+3. Change the text on the following line (begining with `msgstr` to the new translation you want):
 
 
-```
-msgid "namespace.mytranslation"
-msgstr "This is the new tranlation text I have edited"
-```
+  ```
+  msgid "namespace.mytranslation"
+  msgstr "This is the new tranlation text I have edited"
+  ```
 
-4) Compile the translations again to make your changes show up (see also 'a note on the django-admin command' below):
+4. Compile the translations again to make your changes show up (this should be run inside a `fab sh` shell):
 
-```
-django-admin compilemessages
-```
-
-## A note on the `django-admin` command
-
-When running the django-admin command locally, there's two things to be aware of.
-The first is that this command is run within the docker container, not on your machine itself, so
-from your terminal, you will need to first run `fab sh`, which will give you a console where you can run commands within the container
-(you'll see your terminal change from saying something like `tim@Tims-Macbook` at the start of each line to `root@abcde12345`).
-You can then run the commands you need to (such as `django-admin`), and when you're done, type the command `exit` to exit back out to your own machine again (the start of each line will change back).
-
-However, that's not everything, there's also a [slightly tricky bug](https://github.com/nationalarchives/ds-caselaw-public-ui/pull/352) in the way we have django set  up, which means running the `django-admin` command will likely fail with the message `"ModuleNotFoundError: No module named 'config'"`. If you see this, the way to get around it is to run the command again, but _prefix_ it with `DJANGO_SETTINGS_MODULE=""` (those are two quote marks at the end, an empty string), like: `DJANGO_SETTINGS_MODULE="" django-admin`. This will ensure that it runs correctly.
+  ```
+  python manage.py compilemessages
+  ```
 
 ## Authentication
 


### PR DESCRIPTION
## Changes in this PR:

Little change to the README.md to make it clearer how to work with translations (ensured we're using manage.py instead of django-admin, and added extra notes on removing fuzzy strings)