### PR TITLE
Remove doubled 'context' in template parameters.

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/create_emails_block.html
+++ b/ds_caselaw_editor_ui/templates/includes/create_emails_block.html
@@ -3,11 +3,11 @@
   <h4 class="create-email-block__list-header">{% translate "judgment.email_submitter.header" %}</h4>
   <ul class="create-email-block__list">
     <li class="create-email-block__list-link">
-      <a href="{{ context.email_raise_issue_link }}">{% translate "judgment.email_submitter.issue" %}</a>
+      <a href="{{ email_raise_issue_link }}">{% translate "judgment.email_submitter.issue" %}</a>
     </li>
-    {% if context.judgment.is_published %}
+    {% if judgment.is_published %}
       <li class="create-email-block__list-link">
-        <a href="{{ context.email_confirmation_link }}">{% translate "judgment.email_submitter.confirm" %}</a>
+        <a href="{{ email_confirmation_link }}">{% translate "judgment.email_submitter.confirm" %}</a>
       </li>
     {% endif %}
   </ul>

--- a/ds_caselaw_editor_ui/templates/includes/email_confirm_hold.html
+++ b/ds_caselaw_editor_ui/templates/includes/email_confirm_hold.html
@@ -3,7 +3,7 @@
   <h4 class="email-hold-publish__list-header">{% translate "judgment.publish_email_header" %}</h4>
   <ul class="email-hold-publish__list">
     <li class="email-hold-publish__list-link">
-      <a href="{{ context.email_confirmation_link }}">{% translate "judgment.email_hold.confirm" %}</a>
+      <a href="{{ email_confirmation_link }}">{% translate "judgment.email_hold.confirm" %}</a>
     </li>
   </ul>
 </aside>

--- a/ds_caselaw_editor_ui/templates/includes/email_confirm_publication.html
+++ b/ds_caselaw_editor_ui/templates/includes/email_confirm_publication.html
@@ -3,7 +3,7 @@
   <h4 class="email-confirm-publish__list-header">{% translate "judgment.publish_email_header" %}</h4>
   <ul class="email-confirm-publish__list">
     <li class="email-confirm-publish__list-link">
-      <a href="{{ context.email_confirmation_link }}">{% translate "judgment.email_submitter.confirm" %}</a>
+      <a href="{{ email_confirmation_link }}">{% translate "judgment.email_submitter.confirm" %}</a>
     </li>
   </ul>
 </aside>

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -3,7 +3,7 @@
   <h4>{% translate "judgments.sidebar.status" %}</h4>
   <ul class="items">
     <li>
-      <span class="judgment-status-indicator judgment-status-indicator--{{ context.judgment.status | status_tag_colour }}">{{ context.judgment.status }}</span>
+      <span class="judgment-status-indicator judgment-status-indicator--{{ judgment.status | status_tag_colour }}">{{ judgment.status }}</span>
     </li>
   </ul>
   <h4>{% translate "judgments.sidebar.submission" %}</h4>
@@ -12,19 +12,19 @@
       {% translate "judgments.submitter" %}
     </dt>
     <dd>
-      {{ context.judgment.source_name }}
+      {{ judgment.source_name }}
     </dd>
     <dt class="judgment-sidebar__label">
       {% translate "judgments.submitteremail" %}
     </dt>
     <dd>
-      <a href="mailto:{{ context.judgment.source_email }}">{{ context.judgment.source_email }}</a>
+      <a href="mailto:{{ judgment.source_email }}">{{ judgment.source_email }}</a>
     </dd>
     <dt class="judgment-sidebar__label">
       {% translate "judgments.consignmentref" %}
     </dt>
     <dd>
-      {{ context.judgment.consignment_reference }}
+      {{ judgment.consignment_reference }}
     </dd>
   </dl>
 </div>
@@ -32,15 +32,15 @@
   <h4>{% translate "judgments.sidebar.tools" %}</h4>
   <ul>
     <li>
-      <a href="{{ context.jira_create_link }}"
+      <a href="{{ jira_create_link }}"
          target="_blank"
          rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a>
     </li>
     <li>
-      <a href="{% url 'unlock' %}?judgment_uri={{ context.judgment_uri }}">{% translate "judgment.unlock_judgment_title" %}</a>
+      <a href="{% url 'unlock' %}?judgment_uri={{ judgment_uri }}">{% translate "judgment.unlock_judgment_title" %}</a>
     </li>
     <li>
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSckmLdeUAEoEoBc55ybFVmOsXPEM7CG2VbN2YNwsX6kL9UZ4Q/viewform?usp=pp_url&entry.2047884653=Yes&entry.6716552=A+specific+judgment+or+decision&entry.481919886={{ request.build_absolute_uri|urlencode }}&entry.350152829={{ context.judgment.consignment_reference|urlencode }}"
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSckmLdeUAEoEoBc55ybFVmOsXPEM7CG2VbN2YNwsX6kL9UZ4Q/viewform?usp=pp_url&entry.2047884653=Yes&entry.6716552=A+specific+judgment+or+decision&entry.481919886={{ request.build_absolute_uri|urlencode }}&entry.350152829={{ judgment.consignment_reference|urlencode }}"
          target="_blank"
          rel="noopener noreferrer">{% translate "judgment.report_blocking_problem" %}</a>
     </li>
@@ -52,13 +52,12 @@
     <select class="judgment-component__assigned_to-input"
             name="assigned_to"
             id="assigned_to">
-      <option value=""
-              {% if context.judgment.assigned_to == "" %}selected{% endif %}>
+      <option value="" {% if judgment.assigned_to == "" %}selected{% endif %}>
         {% translate "judgments.noone" %}
       </option>
-      {% for user in context.users %}
+      {% for user in users %}
         <option value="{{ user.name }}"
-                {% if context.judgment.assigned_to == user.name %} selected{% endif %}>
+                {% if judgment.assigned_to == user.name %} selected{% endif %}>
           {{ user.print_name }}
         </option>
       {% endfor %}

--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -9,13 +9,13 @@
     {% endif %}
     <div class="judgment-toolbar__edit">
       {% if feature_flag_embedded_pdfs %}
-        {% if context.judgment.is_editable %}
-          <a class="judgment-toolbar__button {% if context.view == 'judgment_metadata' %}judgment-toolbar__button-selected{% endif %}"
-             href="{% url 'edit-judgment' context.judgment.uri %}">
+        {% if judgment.is_editable %}
+          <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}judgment-toolbar__button-selected{% endif %}"
+             href="{% url 'edit-judgment' judgment.uri %}">
             {% translate "judgment.toolbar.edit_metadata" %}
           </a>
-          <a class="judgment-toolbar__button {% if context.view == 'judgment_text' %}judgment-toolbar__button-selected{% endif %}"
-             href="{% url 'full-text-html' context.judgment.uri %}">
+          <a class="judgment-toolbar__button {% if view == 'judgment_text' %}judgment-toolbar__button-selected{% endif %}"
+             href="{% url 'full-text-html' judgment.uri %}">
             {% flag "publish_flow" %}
             {% translate "judgment.toolbar.review_document" %}
           {% else %}
@@ -33,13 +33,13 @@
       </span>
     {% endif %}
   {% else %}
-    {% if context.judgment.is_editable %}
-      <a class="judgment-toolbar__button {% if context.view == 'judgment_metadata' %}judgment-toolbar__button-selected{% endif %}"
-         href="{% url 'edit-judgment' context.judgment.uri %}">
+    {% if judgment.is_editable %}
+      <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}judgment-toolbar__button-selected{% endif %}"
+         href="{% url 'edit-judgment' judgment.uri %}">
         {% translate "judgment.toolbar.edit" %}
       </a>
-      <a class="judgment-toolbar__button {% if context.view == 'judgment_text' %}judgment-toolbar__button-selected{% endif %}"
-         href="{% url 'full-text-html' context.judgment.uri %}">
+      <a class="judgment-toolbar__button {% if view == 'judgment_text' %}judgment-toolbar__button-selected{% endif %}"
+         href="{% url 'full-text-html' judgment.uri %}">
         {% translate "judgment.toolbar.view_html" %}
       </a>
     {% else %}
@@ -48,32 +48,32 @@
     {% endif %}
   {% endif %}
   {% flag "hold_flow" %}
-  {% if context.judgment.is_published %}
+  {% if judgment.is_published %}
     <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.hold" %}</span>
   {% else %}
-    {% if context.judgment.is_held %}
-      <a class="judgment-toolbar__button {% if context.view == 'hold_judgment' %}judgment-toolbar__button-selected{% endif %}"
-         href="{% url 'unhold-judgment' context.judgment.uri %}">
+    {% if judgment.is_held %}
+      <a class="judgment-toolbar__button {% if view == 'hold_judgment' %}judgment-toolbar__button-selected{% endif %}"
+         href="{% url 'unhold-judgment' judgment.uri %}">
         {% translate "judgment.toolbar.unhold" %}
       </a>
     {% else %}
-      <a class="judgment-toolbar__button {% if context.view == 'hold_judgment' %}judgment-toolbar__button-selected{% endif %}"
-         href="{% url 'hold-judgment' context.judgment.uri %}">
+      <a class="judgment-toolbar__button {% if view == 'hold_judgment' %}judgment-toolbar__button-selected{% endif %}"
+         href="{% url 'hold-judgment' judgment.uri %}">
         {% translate "judgment.toolbar.hold" %}
       </a>
     {% endif %}
   {% endif %}
 {% endflag %}
 {% flag "publish_flow" %}
-{% if context.judgment.is_published %}
-  <a class="judgment-toolbar__button {% if context.view == 'publish_judgment' %}judgment-toolbar__button-selected{% endif %}"
-     href="{% url 'unpublish-judgment' context.judgment.uri %}">
+{% if judgment.is_published %}
+  <a class="judgment-toolbar__button {% if view == 'publish_judgment' %}judgment-toolbar__button-selected{% endif %}"
+     href="{% url 'unpublish-judgment' judgment.uri %}">
     {% translate "judgment.toolbar.unpublish" %}
   </a>
 {% else %}
-  {% if context.judgment.is_publishable %}
-    <a class="judgment-toolbar__button {% if context.view == 'publish_judgment' %}judgment-toolbar__button-selected{% endif %}"
-       href="{% url 'publish-judgment' context.judgment.uri %}">
+  {% if judgment.is_publishable %}
+    <a class="judgment-toolbar__button {% if view == 'publish_judgment' %}judgment-toolbar__button-selected{% endif %}"
+       href="{% url 'publish-judgment' judgment.uri %}">
       {% translate "judgment.toolbar.publish" %}
     </a>
   {% else %}
@@ -81,27 +81,21 @@
   {% endif %}
 {% endif %}
 {% endflag %}
-{% if context.judgment.docx_url %}
-  <a class="judgment-toolbar__button"
-     href="{{ context.judgment.docx_url }}">
-    {% translate "judgment.toolbar.download_docx" %}
-  </a>
+{% if judgment.docx_url %}
+  <a class="judgment-toolbar__button" href="{{ judgment.docx_url }}">{% translate "judgment.toolbar.download_docx" %}</a>
 {% else %}
   <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.download_docx" %}</span>
 {% endif %}
 {% if not feature_flag_embedded_pdfs %}
-  {% if context.judgment.pdf_url %}
-    <a class="judgment-toolbar__button"
-       href="{{ context.judgment.pdf_url }}">
-      {% translate "judgment.toolbar.download_pdf" %}
-    </a>
+  {% if judgment.pdf_url %}
+    <a class="judgment-toolbar__button" href="{{ judgment.pdf_url }}">{% translate "judgment.toolbar.download_pdf" %}</a>
   {% else %}
     <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.download_pdf" %}</span>
   {% endif %}
 {% endif %}
-{% if context.judgment.is_published %}
+{% if judgment.is_published %}
   <a class="judgment-toolbar__button"
-     href="{{ context.judgment.public_uri }}"
+     href="{{ judgment.public_uri }}"
      target="_blank"
      rel="noopener noreferrer">
     {% translate "judgment.toolbar.view_on_public" %}
@@ -109,19 +103,19 @@
 {% else %}
   <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.view_on_public" %}</span>
 {% endif %}
-{% if context.judgment.is_failure %}
+{% if judgment.is_failure %}
   <form action="{% url "delete" %}" method="post">
     {% csrf_token %}
-    <input type="hidden" name="judgment_uri" value="{{ context.judgment.uri }}" />
+    <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
     <input type="submit"
            name="assign"
            value="{% translate "judgment.toolbar.delete" %}"/>
   </form>
 {% endif %}
 </div>
-{% if context.version %}
+{% if version %}
   <div class="judgment-toolbar__version">
-    <b>You are viewing version {{ context.version }} of this Judgment.</b>
+    <b>You are viewing version {{ version }} of this Judgment.</b>
   </div>
 {% endif %}
 </div>

--- a/ds_caselaw_editor_ui/templates/includes/judgment_view_controls.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_view_controls.html
@@ -2,12 +2,12 @@
 {% if feature_flag_embedded_pdfs %}
   <div class="judgment-toolbar__container" style="margin: 0.5rem auto">
     <a class="judgment-toolbar__button{% if view == 'html' %} judgment-toolbar__button-selected{% endif %}"
-       href="{% url 'full-text-html' context.judgment_uri %}">
+       href="{% url 'full-text-html' judgment_uri %}">
       {% translate "judgment.view_control.html" %}
     </a>
-    {% if context.judgment.pdf_url %}
+    {% if judgment.pdf_url %}
       <a class="judgment-toolbar__button{% if view == 'pdf' %} judgment-toolbar__button-selected{% endif %}"
-         href="{% url 'full-text-pdf' context.judgment.uri %}">
+         href="{% url 'full-text-pdf' judgment.uri %}">
         {% translate "judgment.view_control.pdf" %}
       </a>
     {% else %}

--- a/ds_caselaw_editor_ui/templates/includes/judgments_list_controls.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgments_list_controls.html
@@ -3,18 +3,17 @@
   <form method="get"
         action="{{ request.path }}"
         id="analytics-result-controls">
-    {% for key, value in context.query_params.items %}
+    {% for key, value in query_params.items %}
       {% if key != "order" or key != "per_page" %}<input type="hidden" name="{{ key }}" value="{{ value }}" />{% endif %}
     {% endfor %}
     <div>
       <label for="order_by" class="judgments-list-controls__label">Sort by</label>
       <select class="judgments-list-controls__select" id="order_by" name="order">
         <option value="-date"
-                {% if context.order == "-date" or context.order is None %}selected='selected'{% endif %}>
+                {% if order == "-date" or order is None %}selected='selected'{% endif %}>
           Date received &ndash; Newest
         </option>
-        <option value="date"
-                {% if context.order == "date" %}selected='selected'{% endif %}>
+        <option value="date" {% if order == "date" %}selected='selected'{% endif %}>
           Date received &ndash; Oldest
         </option>
       </select>

--- a/ds_caselaw_editor_ui/templates/includes/metadata_header.html
+++ b/ds_caselaw_editor_ui/templates/includes/metadata_header.html
@@ -4,7 +4,7 @@
   <div class="metadata-component">
     <form aria-label="Edit judgment"
           method="post"
-          action="{% url 'edit-judgment' context.judgment.uri %}">
+          action="{% url 'edit-judgment' judgment.uri %}">
       {% csrf_token %}
       <input type="hidden" name="return_to" value="{{ return_to }}" />
       <div class="metadata-component__container">
@@ -14,7 +14,7 @@
           </label>
           <input type="text"
                  class="metadata-component__neutral_citation-input"
-                 value="{{ context.judgment.neutral_citation }}"
+                 value="{{ judgment.neutral_citation }}"
                  name="neutral_citation"
                  id="neutral_citation"/>
         </div>
@@ -22,12 +22,12 @@
           <label for="court" class="metadata-component__main-labels">{% translate "judgment.court" %}</label>
           <input type="text"
                  class="metadata-component__court-input"
-                 value="{{ context.judgment.court }}"
+                 value="{{ judgment.court }}"
                  name="court"
                  id="court"
                  list="court-ids"/>
           <datalist id="court-ids">
-            {% for court in context.courts %}
+            {% for court in courts %}
               <option value="{{ court.code }}">
                 {{ court.name }}
               </option>
@@ -38,7 +38,7 @@
           <label for="judgment_date" class="metadata-component__main-labels">{% translate "judgment.judgment_date" %}</label>
           <input type="text"
                  class="metadata-component__judgment_date-input"
-                 value="{{ context.judgment.judgment_date_as_string }}"
+                 value="{{ judgment.judgment_date_as_string }}"
                  name="judgment_date"
                  id="judgment_date"/>
         </div>
@@ -49,17 +49,17 @@
           <textarea class="metadata-component__metadata_name-input"
                     name="metadata_name"
                     id="metadata_name"
-                    rows="2">{{ context.judgment.name }}</textarea>
+                    rows="2">{{ judgment.name }}</textarea>
         </div>
         <div class="metadata-component__bottom-right-column">
           <div class="metadata-component__tdr">
             <aside for="metadata_name" class="metadata-component__main-labels">
               {% translate "judgments.consignmentref" %}
             </aside>
-            <p>{{ context.judgment.consignment_reference }}</p>
+            <p>{{ judgment.consignment_reference }}</p>
           </div>
           <div class="metadata-component__actions">
-            <input type="hidden" name="judgment_uri" value="{{ context.judgment_uri }}"/>
+            <input type="hidden" name="judgment_uri" value="{{ judgment_uri }}"/>
             <input type="submit" value="Save"/>
           </div>
         </div>

--- a/ds_caselaw_editor_ui/templates/includes/pagination.html
+++ b/ds_caselaw_editor_ui/templates/includes/pagination.html
@@ -2,9 +2,9 @@
   <h3>Unpublished judgments pagination</h3>
   <ul class="pagination__list">
     <li class="pagination__list-item">
-      {% if context.paginator.has_prev_page %}
+      {% if paginator.has_prev_page %}
         <a class="pagination__page-chevron-previous"
-           href="{{ request.path }}?{% if context.query_string %}{{ context.query_string }}&{% endif %}page={{ context.paginator.prev_page }}">
+           href="{{ request.path }}?{% if query_string %}{{ query_string }}&{% endif %}page={{ paginator.prev_page }}">
           <span>Previous page</span>
         </a>
       {% else %}
@@ -17,16 +17,16 @@
       <ol>
         <li class="pagination__list-item">
           <a class="pagination__page-link-current"
-             href="{{ request.path }}?{% if context.query_string %}{{ context.query_string }}&{% endif %}page={{ context.paginator.current_page }}"
-             aria-label="Current page, Page {{ context.paginator.current_page }}"
+             href="{{ request.path }}?{% if query_string %}{{ query_string }}&{% endif %}page={{ paginator.current_page }}"
+             aria-label="Current page, Page {{ paginator.current_page }}"
              aria-current="true">
-            <span>Current page</span>{{ context.paginator.current_page }}
+            <span>Current page</span>{{ paginator.current_page }}
           </a>
         </li>
-        {% for page in context.paginator.next_pages %}
+        {% for page in paginator.next_pages %}
           <li class="pagination__list-item">
             <a class="pagination__page-link"
-               href="{{ request.path }}?{% if context.query_string %}{{ context.query_string }}&{% endif %}page={{ page }}"
+               href="{{ request.path }}?{% if query_string %}{{ query_string }}&{% endif %}page={{ page }}"
                aria-label="Go to page {{ page }}">
               <span>Page</span>{{ page }}
             </a>
@@ -35,9 +35,9 @@
       </ol>
     </li>
     <li class="pagination__list-item">
-      {% if context.paginator.has_next_page %}
+      {% if paginator.has_next_page %}
         <a class="pagination__page-chevron-next"
-           href="{{ request.path }}?{% if context.query_string %}{{ context.query_string }}&{% endif %}&page={{ context.paginator.next_page }}">
+           href="{{ request.path }}?{% if query_string %}{{ query_string }}&{% endif %}&page={{ paginator.next_page }}">
           <span>Next page</span>
         </a>
       {% else %}

--- a/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
+++ b/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
@@ -3,16 +3,14 @@
   <div class="judgments-list__container">
     <div class="judgments-list__judgments-list-controls-container">
       <div class="results__result-header">
-        <p id="recently-published-judgments" class="judgments-list__header">
-          {% translate "home.recent" %}: {{ context.total }}
-        </p>
+        <p id="recently-published-judgments" class="judgments-list__header">{% translate "home.recent" %}: {{ total }}</p>
       </div>
       {% include "includes/judgments_list_controls.html" %}
     </div>
     <div class="judgments-list__table">
       {% include "includes/judgments_list_header.html" %}
       <ul class="judgments-list__list">
-        {% for item in context.judgments %}
+        {% for item in judgments %}
           {% include "includes/judgments_list_item.html" %}
         {% endfor %}
       </ul>

--- a/ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
+++ b/ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
@@ -2,13 +2,13 @@
 {% load static i18n %}
 {% block content %}
   <div class="unlock-judgment">
-    <p>{{ context.judgment_uri }}</p>
+    <p>{{ judgment_uri }}</p>
     <p class="unlock-judgment__confirmation">{% translate "judgment.confirm_unlock" %}</p>
     <form method="post">
       {% csrf_token %}
-      <input type="hidden" name="judgment_uri" value="{{ context.judgment_uri }}" />
+      <input type="hidden" name="judgment_uri" value="{{ judgment_uri }}" />
       <button type="submit">{% translate "judgment.unlock_judgment_title" %}</button>
     </form>
-    <a href="{% url 'full-text-html' context.judgment_uri %}">{% translate "judgment.back_to_judgment" %}</a>
+    <a href="{% url 'full-text-html' judgment_uri %}">{% translate "judgment.back_to_judgment" %}</a>
   </div>
 {% endblock content %}

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -5,18 +5,18 @@
   <div class="judgment-sidebar__block">
     <h4>{% translate "judgments.sidebar.downloads" %}</h4>
     <ul>
-      {% if context.judgment.docx_url %}
+      {% if judgment.docx_url %}
         <li>
-          <a href="{{ context.judgment.docx_url }}">{% translate "judgment.download_docx" %}</a>
+          <a href="{{ judgment.docx_url }}">{% translate "judgment.download_docx" %}</a>
         </li>
       {% endif %}
-      {% if context.judgment.pdf_url %}
+      {% if judgment.pdf_url %}
         <li>
-          <a href="{{ context.judgment.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
+          <a href="{{ judgment.pdf_url }}">{% translate "judgment.download_pdf" %}</a>
         </li>
       {% endif %}
       <li>
-        <a href="{{ context.judgment.xml_url }}">{% translate "judgment.download_xml" %}</a>
+        <a href="{{ judgment.xml_url }}">{% translate "judgment.download_xml" %}</a>
       </li>
     </ul>
   </div>
@@ -28,7 +28,7 @@
       <label for="metadata_name">{% translate "judgment.judgment_name" %}</label>
       <input type="text"
              class="edit-component__metadata_name-input"
-             value="{{ context.judgment.name }}"
+             value="{{ judgment.name }}"
              name="metadata_name"
              id="metadata_name"/>
     </div>
@@ -36,7 +36,7 @@
       <label for="neutral_citation">{% translate "judgment.neutral_citation" %}</label>
       <input type="text"
              class="edit-component__neutral_citation-input"
-             value="{{ context.judgment.neutral_citation }}"
+             value="{{ judgment.neutral_citation }}"
              name="neutral_citation"
              id="neutral_citation"
              size="30"/>
@@ -45,13 +45,13 @@
       <label for="court">{% translate "judgment.court" %}</label>
       <input type="text"
              class="edit-component__court-input"
-             value="{{ context.judgment.court }}"
+             value="{{ judgment.court }}"
              name="court"
              id="court"
              list="court-ids"
              size="40"/>
       <datalist id="court-ids">
-        {% for court in context.courts %}
+        {% for court in courts %}
           <option value="{{ court.code }}">
             {{ court.name }}
           </option>
@@ -62,7 +62,7 @@
       <label for="judgment_date">{% translate "judgment.judgment_date" %}</label>
       <input type="text"
              class="edit-component__judgment_date-input"
-             value="{{ context.judgment.judgment_date_as_string }}"
+             value="{{ judgment.judgment_date_as_string }}"
              name="judgment_date"
              id="judgment_date"/>
     </div>
@@ -71,7 +71,7 @@
         <label for="published">{% translate "judgment.published" %}</label>
         <input type="checkbox"
                class="edit-component__published-input"
-               {% if context.judgment.is_published %}checked{% endif %}
+               {% if judgment.is_published %}checked{% endif %}
                name="published"
                id="published"/>
       </div>
@@ -80,7 +80,7 @@
       <label for="sensitive">{% translate "judgment.sensitive" %}</label>
       <input type="checkbox"
              class="edit-component__sensitive-input"
-             {% if context.judgment.is_sensitive %}checked{% endif %}
+             {% if judgment.is_sensitive %}checked{% endif %}
              name="sensitive"
              id="sensitive"/>
     </div>
@@ -88,7 +88,7 @@
       <label for="supplemental">{% translate "judgment.supplemental" %}</label>
       <input type="checkbox"
              class="edit-component__supplemental-input"
-             {% if context.judgment.has_supplementary_materials %}checked{% endif %}
+             {% if judgment.has_supplementary_materials %}checked{% endif %}
              name="supplemental"
              id="supplemental"/>
     </div>
@@ -96,7 +96,7 @@
       <label for="anonymised">{% translate "judgment.anonymised" %}</label>
       <input type="checkbox"
              class="edit-component__anonymised-input"
-             {% if context.judgment.is_anonymised %}checked{% endif %}
+             {% if judgment.is_anonymised %}checked{% endif %}
              name="anonymised"
              id="anonymised"/>
     </div>
@@ -105,35 +105,34 @@
       <select class="edit-component__assigned_to-input"
               name="assigned_to"
               id="assigned_to">
-        <option value=""
-                {% if context.judgment.assigned_to == "" %}selected{% endif %}>
+        <option value="" {% if judgment.assigned_to == "" %}selected{% endif %}>
           {% translate "judgments.noone" %}
         </option>
-        {% for user in context.users %}
+        {% for user in users %}
           <option value="{{ user.name }}"
-                  {% if context.judgment.assigned_to == user.name %} selected{% endif %}>
+                  {% if judgment.assigned_to == user.name %} selected{% endif %}>
             {{ user.print_name }}
           </option>
         {% endfor %}
       </select>
     </div>
     <div class="edit-component__actions">
-      <input type="hidden" name="judgment_uri" value="{{ context.judgment_uri }}"/>
+      <input type="hidden" name="judgment_uri" value="{{ judgment_uri }}"/>
       <input type="submit" value="Save"/>
     </div>
     {% flag "email_submitter_block" %}
     {% include "includes/create_emails_block.html" %}
   {% endflag %}
 </form>
-{% if context.judgment.versions %}
+{% if judgment.versions %}
   <div class="list-versions-component">
     <div class="list-versions-component__container">
       <h2 class="list-versions-component__header">{% translate "judgment.previous_versions" %}</h2>
       <ul>
-        {% for version in context.judgment.versions %}
+        {% for version in judgment.versions %}
           <li>
             <a class="list-versions__version-title"
-               href="{% url 'full-text-html' context.judgment_uri %}?version_uri={{ version.uri }}">
+               href="{% url 'full-text-html' judgment_uri %}?version_uri={{ version.uri }}">
               v{{ version.version }} ( {{ version.uri }} )
             </a>
           </li>

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
@@ -3,14 +3,14 @@
 {% block content %}
   {% include "includes/metadata_header.html" with return_to="html" %}
   {% include "includes/judgment_view_controls.html" with view="html" %}
-  {% if context.judgment_content %}
-    {% if context.judgment.is_failure %}
+  {% if judgment_content %}
+    {% if judgment.is_failure %}
       <pre>
-        {{ context.judgment_content }}
+        {{ judgment_content }}
       </pre>
     {% else %}
       {% autoescape off %}
-        {{ context.judgment_content }}
+        {{ judgment_content }}
       {% endautoescape %}
     {% endif %}
   {% else %}

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_pdf.html
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_pdf.html
@@ -3,10 +3,10 @@
 {% block content %}
   {% include "includes/metadata_header.html" with return_to="pdf" %}
   {% include "includes/judgment_view_controls.html" with view="pdf" %}
-  <object data="{{ context.judgment.pdf_url }}"
+  <object data="{{ judgment.pdf_url }}"
           type="application/pdf"
           width="100%"
           height="800px">
-    Your browser cannot display this embedded PDF. <a href="{{ context.judgment.pdf_url }}">Download it here</a>.
+    Your browser cannot display this embedded PDF. <a href="{{ judgment.pdf_url }}">Download it here</a>.
   </object>
 {% endblock content %}

--- a/ds_caselaw_editor_ui/templates/judgment/hold-success.html
+++ b/ds_caselaw_editor_ui/templates/judgment/hold-success.html
@@ -2,7 +2,7 @@
 {% load waffle_tags %}
 {% load i18n %}
 {% block judgment_header %}
-  {% include "includes/judgment_metadata_panel.html" with judgment=context.judgment %}
+  {% include "includes/judgment_metadata_panel.html" with judgment=judgment %}
 {% endblock judgment_header %}
 {% block judgment_content %}
   <h2>{% translate "judgment.hold.success" %}</h2>

--- a/ds_caselaw_editor_ui/templates/judgment/hold.html
+++ b/ds_caselaw_editor_ui/templates/judgment/hold.html
@@ -2,14 +2,14 @@
 {% load waffle_tags %}
 {% load i18n %}
 {% block judgment_header %}
-  {% include "includes/judgment_metadata_panel.html" with judgment=context.judgment %}
+  {% include "includes/judgment_metadata_panel.html" with judgment=judgment %}
 {% endblock judgment_header %}
 {% block judgment_content %}
   <h2>{% translate "judgment.put.on.hold" %}</h2>
   <form action="{% url 'hold' %}" method="post">
     {% csrf_token %}
     <div class="judgment-component__actions">
-      <input type="hidden" name="judgment_uri" value="{{ context.judgment.uri }}" />
+      <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
       <input type="hidden" name="hold" value="true" />
       <input class="button-cta"
              type="submit"

--- a/ds_caselaw_editor_ui/templates/judgment/publish-success.html
+++ b/ds_caselaw_editor_ui/templates/judgment/publish-success.html
@@ -2,14 +2,14 @@
 {% load waffle_tags %}
 {% load i18n %}
 {% block judgment_header %}
-  {% include "includes/judgment_metadata_panel.html" with judgment=context.judgment %}
+  {% include "includes/judgment_metadata_panel.html" with judgment=judgment %}
 {% endblock judgment_header %}
 {% block judgment_content %}
   <h2>Success - this document has been published</h2>
   <p class="judgment-component__live-link">
-    <a href="{{ context.judgment.public_uri }}"
+    <a href="{{ judgment.public_uri }}"
        target="_blank"
-       rel="noopener noreferrer">{{ context.judgment.name }}</a>
+       rel="noopener noreferrer">{{ judgment.name }}</a>
   </p>
   <div class="judgment-component__actions">
     <p>{% include "includes/email_confirm_publication.html" %}</p>

--- a/ds_caselaw_editor_ui/templates/judgment/publish.html
+++ b/ds_caselaw_editor_ui/templates/judgment/publish.html
@@ -2,14 +2,14 @@
 {% load waffle_tags %}
 {% load i18n %}
 {% block judgment_header %}
-  {% include "includes/judgment_metadata_panel.html" with judgment=context.judgment %}
+  {% include "includes/judgment_metadata_panel.html" with judgment=judgment %}
 {% endblock judgment_header %}
 {% block judgment_content %}
   <h2>Publish this document</h2>
   {% if feature_flag_log_minor_issues_on_publish %}
     <p>
       {% translate "judgment.confirm" %}
-      <span class="judgment-uri">{{ context.judgment_uri }}</span>
+      <span class="judgment-uri">{{ judgment_uri }}</span>
     </p>
   {% endif %}
   <form aria-label="publish judgment"
@@ -20,7 +20,7 @@
       <div class="judgment-component__panel judgment-component__minor-issues-options">
         <input type="checkbox"
                class="judgment-component__center-input"
-               {% if context.judgment.is_centered %}checked{% endif %}
+               {% if judgment.is_centered %}checked{% endif %}
                name="center"
                id="center"/>
         <label for="center">{% translate "judgment.center" %}</label>
@@ -28,7 +28,7 @@
       <div class="judgment-component__panel">
         <input type="checkbox"
                class="judgment-component__indentation-input"
-               {% if context.judgment.is_indentation %}checked{% endif %}
+               {% if judgment.is_indentation %}checked{% endif %}
                name="indentation"
                id="indentation"/>
         <label for="indentation">{% translate "judgment.indentation" %}</label>
@@ -36,7 +36,7 @@
       <div class="judgment-component__panel">
         <input type="checkbox"
                class="judgment-component__images-input"
-               {% if context.judgment.is_images %}checked{% endif %}
+               {% if judgment.is_images %}checked{% endif %}
                name="images"
                id="images"/>
         <label for="images">{% translate "judgment.images" %}</label>
@@ -44,7 +44,7 @@
       <div class="judgment-component__panel">
         <input type="checkbox"
                class="judgment-component__headings-input"
-               {% if context.judgment.is_headings %}checked{% endif %}
+               {% if judgment.is_headings %}checked{% endif %}
                name="headings"
                id="headings"/>
         <label for="headings">{% translate "judgment.headings" %}</label>
@@ -52,7 +52,7 @@
       <div class="judgment-component__panel">
         <input type="checkbox"
                class="judgment-component__barriers-input"
-               {% if context.judgment.is_barriers %}checked{% endif %}
+               {% if judgment.is_barriers %}checked{% endif %}
                name="barriers"
                id="barriers"/>
         <label for="barriers">{% translate "judgment.barriers" %}</label>
@@ -60,14 +60,14 @@
       <div class="judgment-component__panel">
         <input type="checkbox"
                class="judgment-component__problems-input"
-               {% if context.judgment.no_problems %}checked{% endif %}
+               {% if judgment.no_problems %}checked{% endif %}
                name="problems"
                id="barriers"/>
         <label for="problems">{% translate "judgment.problems" %}</label>
       </div>
     {% endif %}
     <div class="judgment-component__actions">
-      <input type="hidden" name="judgment_uri" value="{{ context.judgment.uri }}" />
+      <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
       <input class="button-cta"
              type="submit"
              value="{% translate "judgment.publish_this_judgment" %}"/>

--- a/ds_caselaw_editor_ui/templates/judgment/results.html
+++ b/ds_caselaw_editor_ui/templates/judgment/results.html
@@ -12,14 +12,14 @@
       <div class="judgments-list__container">
         <div class="judgments-list__judgments-list-controls-container">
           <div class="results__result-header">
-            <p id="recently-published-judgments" class="judgments-list__header">We found {{ context.total }} judgments:</p>
+            <p id="recently-published-judgments" class="judgments-list__header">We found {{ total }} judgments:</p>
           </div>
         </div>
         <div class="judgments-list__table">
           {% include "includes/judgments_list_header.html" %}
           <ul class="judgments-list__list">
-            {% for item in context.judgments %}
-              {% include "includes/judgments_list_item.html" %}
+            {% for item in judgments %}
+              {% include "includes/judgments_list_item.html" with item=item %}
             {% endfor %}
           </ul>
           {% include "includes/pagination.html" %}

--- a/ds_caselaw_editor_ui/templates/judgment/unhold-success.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold-success.html
@@ -5,7 +5,7 @@
   <h2>
     {% translate "judgment.hold.unhold_success_title" %}
     <br />
-    {{ context.judgment.name }}
+    {{ judgment.name }}
   </h2>
   <p>{% translate "judgment.unhold.success" %}</p>
 {% endblock judgment_content %}

--- a/ds_caselaw_editor_ui/templates/judgment/unhold.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold.html
@@ -4,12 +4,12 @@
   <h2>
     {% translate "judgment.hold.unhold_title" %}
     <br />
-    {{ context.judgment.name }}
+    {{ judgment.name }}
   </h2>
   <form action="{% url 'unhold' %}" method="post">
     {% csrf_token %}
     <div class="judgment-component__actions">
-      <input type="hidden" name="judgment_uri" value="{{ context.judgment.uri }}" />
+      <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
       <input type="hidden" name="unhold" value="false" />
       <input class="button-cta"
              type="submit"

--- a/ds_caselaw_editor_ui/templates/judgment/unpublish-success.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unpublish-success.html
@@ -5,7 +5,7 @@
   <h2>
     {% translate "judgment.publish.unpublish_success_title" %}
     <br />
-    {{ context.judgment.name }}
+    {{ judgment.name }}
   </h2>
   <p>This judgment is now unpublished.</p>
 {% endblock judgment_content %}

--- a/ds_caselaw_editor_ui/templates/judgment/unpublish.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unpublish.html
@@ -4,11 +4,11 @@
   <h2>
     {% translate "judgment.publish.unpublish_title" %}
     <br />
-    {{ context.judgment.name }}
+    {{ judgment.name }}
   </h2>
   <form action="{% url 'unpublish' %}" method="post">
     {% csrf_token %}
-    <input type="hidden" name="judgment_uri" value="{{ context.judgment.uri }}" />
+    <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
     <input type="submit"
            value="{% translate "judgment.unpublish.unpublish_button" %}"/>
   </form>

--- a/ds_caselaw_editor_ui/templates/layouts/base.html
+++ b/ds_caselaw_editor_ui/templates/layouts/base.html
@@ -7,7 +7,7 @@
     <meta name="robots" content="noindex,nofollow" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>
-      {% if context.page_title %}{{ context.page_title }} -{% endif %}
+      {% if page_title %}{{ page_title }} -{% endif %}
     {% translate "common.findcaselaw" %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="{% static 'images/favicons/favicon.png' %}" />
@@ -32,7 +32,7 @@
     {% endif %}
     <a id="skip-to-main-content" href="#main-content">{% translate "skiplink" %}</a>
     <header class="page-header page-header-slim">
-      {% include "includes/breadcrumbs.html" with current=context.page_title title=context.page_title link=request.get_full_path %}
+      {% include "includes/breadcrumbs.html" with current=page_title title=page_title link=request.get_full_path %}
     </header>
     {% block precontent %}
     {% endblock precontent %}

--- a/judgments/views/delete.py
+++ b/judgments/views/delete.py
@@ -23,4 +23,4 @@ def delete(request):
     template = loader.get_template("judgment/deleted.html")
 
     messages.success(request, "Judgment deleted.")
-    return HttpResponse(template.render({"context": context}, request))
+    return HttpResponse(template.render(context, request))

--- a/judgments/views/full_text.py
+++ b/judgments/views/full_text.py
@@ -33,23 +33,16 @@ def html_view(request, judgment_uri):
         context["judgment_content"] = judgment_content
         context["page_title"] = metadata_name
         context["view"] = "judgment_text"
+        context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
+            request, "embedded_pdf_view"
+        )
 
         if version_uri:
             context["version"] = extract_version(version_uri)
     except MarklogicResourceNotFoundError as e:
         raise Http404(f"Judgment was not found at uri {judgment_uri}, {e}")
     template = loader.get_template("judgment/full_text_html.html")
-    return HttpResponse(
-        template.render(
-            {
-                "context": context,
-                "feature_flag_embedded_pdfs": waffle.flag_is_active(
-                    request, "embedded_pdf_view"
-                ),
-            },
-            request,
-        )
-    )
+    return HttpResponse(template.render(context, request))
 
 
 def pdf_view(request, judgment_uri):
@@ -69,6 +62,9 @@ def pdf_view(request, judgment_uri):
         "judgment": judgment,
         "page_title": judgment.name,
         "view": "judgment_text",
+        "feature_flag_embedded_pdfs": waffle.flag_is_active(
+            request, "embedded_pdf_view"
+        ),
     }
 
     if version_uri:
@@ -77,12 +73,7 @@ def pdf_view(request, judgment_uri):
     template = loader.get_template("judgment/full_text_pdf.html")
     return HttpResponse(
         template.render(
-            {
-                "context": context,
-                "feature_flag_embedded_pdfs": waffle.flag_is_active(
-                    request, "embedded_pdf_view"
-                ),
-            },
+            context,
             request,
         )
     )

--- a/judgments/views/index.py
+++ b/judgments/views/index.py
@@ -14,4 +14,4 @@ def index(request):
             f"Search results not found, {e}"
         )  # TODO: This should be something else!
     template = loader.get_template("pages/home.html")
-    return HttpResponse(template.render({"context": context}, request))
+    return HttpResponse(template.render(context, request))

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -121,21 +121,15 @@ class EditJudgmentView(View):
         )
         context["jira_create_link"] = self.build_jira_create_link(request, context)
 
-        template = loader.get_template("judgment/edit.html")
-        return HttpResponse(
-            template.render(
-                {
-                    "context": context,
-                    "feature_flag_embedded_pdfs": waffle.flag_is_active(
-                        request, "embedded_pdf_view"
-                    ),
-                    "feature_flag_publish_flow": waffle.flag_is_active(
-                        request, "publish_flow"
-                    ),
-                },
-                request,
-            )
+        context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
+            request, "embedded_pdf_view"
         )
+        context["feature_flag_publish_flow"] = waffle.flag_is_active(
+            request, "publish_flow"
+        )
+
+        template = loader.get_template("judgment/edit.html")
+        return HttpResponse(template.render(context, request))
 
     def post(self, request, *args, **kwargs):
         judgment_uri = request.POST["judgment_uri"]

--- a/judgments/views/judgment_hold.py
+++ b/judgments/views/judgment_hold.py
@@ -21,13 +21,15 @@ class HoldJudgmentView(TemplateView):
 
         judgment = Judgment(kwargs["judgment_uri"])
 
-        context["context"] = {
-            "page_title": '{title}: "{judgment}"'.format(
-                title=gettext("judgment.hold.hold_title"), judgment=judgment.name
-            ),
-            "view": "hold_judgment",
-            "judgment": judgment,
-        }
+        context.update(
+            {
+                "page_title": '{title}: "{judgment}"'.format(
+                    title=gettext("judgment.hold.hold_title"), judgment=judgment.name
+                ),
+                "view": "hold_judgment",
+                "judgment": judgment,
+            }
+        )
 
         context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
             self.request, "embedded_pdf_view"
@@ -52,16 +54,18 @@ class HoldJudgmentSuccessView(TemplateView):
 
         judgment = Judgment(kwargs["judgment_uri"])
 
-        context["context"] = {
-            "page_title": '{title}: "{judgment}"'.format(
-                title=gettext("judgment.hold.hold_success_title"),
-                judgment=judgment.name,
-            ),
-            "judgment": judgment,
-            "email_confirmation_link": build_confirmation_email_link(
-                self.request, judgment
-            ),
-        }
+        context.update(
+            {
+                "page_title": '{title}: "{judgment}"'.format(
+                    title=gettext("judgment.hold.hold_success_title"),
+                    judgment=judgment.name,
+                ),
+                "judgment": judgment,
+                "email_confirmation_link": build_confirmation_email_link(
+                    self.request, judgment
+                ),
+            }
+        )
 
         context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
             self.request, "embedded_pdf_view"
@@ -104,14 +108,16 @@ class UnholdJudgmentView(TemplateView):
 
         judgment = Judgment(kwargs["judgment_uri"])
 
-        context["context"] = {
-            "page_title": '{title}: "{judgment}"'.format(
-                title=gettext("judgment.hold.unhold_title"),
-                judgment=judgment.name,
-            ),
-            "view": "hold_judgment",
-            "judgment": judgment,
-        }
+        context.update(
+            {
+                "page_title": '{title}: "{judgment}"'.format(
+                    title=gettext("judgment.hold.unhold_title"),
+                    judgment=judgment.name,
+                ),
+                "view": "hold_judgment",
+                "judgment": judgment,
+            }
+        )
 
         context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
             self.request, "embedded_pdf_view"
@@ -128,13 +134,15 @@ class UnholdJudgmentSuccessView(TemplateView):
 
         judgment = Judgment(kwargs["judgment_uri"])
 
-        context["context"] = {
-            "page_title": '{title}: "{judgment}"'.format(
-                title=gettext("judgment.hold.unhold_success_title"),
-                judgment=judgment.name,
-            ),
-            "judgment": judgment,
-        }
+        context.update(
+            {
+                "page_title": '{title}: "{judgment}"'.format(
+                    title=gettext("judgment.hold.unhold_success_title"),
+                    judgment=judgment.name,
+                ),
+                "judgment": judgment,
+            }
+        )
 
         context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
             self.request, "embedded_pdf_view"

--- a/judgments/views/judgment_publish.py
+++ b/judgments/views/judgment_publish.py
@@ -21,13 +21,16 @@ class PublishJudgmentView(TemplateView):
 
         judgment = Judgment(kwargs["judgment_uri"])
 
-        context["context"] = {
-            "page_title": '{title}: "{judgment}"'.format(
-                title=gettext("judgment.publish.publish_title"), judgment=judgment.name
-            ),
-            "view": "publish_judgment",
-            "judgment": judgment,
-        }
+        context.update(
+            {
+                "page_title": '{title}: "{judgment}"'.format(
+                    title=gettext("judgment.publish.publish_title"),
+                    judgment=judgment.name,
+                ),
+                "view": "publish_judgment",
+                "judgment": judgment,
+            }
+        )
 
         context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
             self.request, "embedded_pdf_view"
@@ -52,16 +55,18 @@ class PublishJudgmentSuccessView(TemplateView):
 
         judgment = Judgment(kwargs["judgment_uri"])
 
-        context["context"] = {
-            "page_title": '{title}: "{judgment}"'.format(
-                title=gettext("judgment.publish.publish_success_title"),
-                judgment=judgment.name,
-            ),
-            "judgment": judgment,
-            "email_confirmation_link": build_confirmation_email_link(
-                self.request, judgment
-            ),
-        }
+        context.update(
+            {
+                "page_title": '{title}: "{judgment}"'.format(
+                    title=gettext("judgment.publish.publish_success_title"),
+                    judgment=judgment.name,
+                ),
+                "judgment": judgment,
+                "email_confirmation_link": build_confirmation_email_link(
+                    self.request, judgment
+                ),
+            }
+        )
 
         context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
             self.request, "embedded_pdf_view"
@@ -104,14 +109,16 @@ class UnpublishJudgmentView(TemplateView):
 
         judgment = Judgment(kwargs["judgment_uri"])
 
-        context["context"] = {
-            "page_title": '{title}: "{judgment}"'.format(
-                title=gettext("judgment.publish.unpublish_title"),
-                judgment=judgment.name,
-            ),
-            "view": "publish_judgment",
-            "judgment": judgment,
-        }
+        context.update(
+            {
+                "page_title": '{title}: "{judgment}"'.format(
+                    title=gettext("judgment.publish.unpublish_title"),
+                    judgment=judgment.name,
+                ),
+                "view": "publish_judgment",
+                "judgment": judgment,
+            }
+        )
 
         context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
             self.request, "embedded_pdf_view"
@@ -128,13 +135,15 @@ class UnpublishJudgmentSuccessView(TemplateView):
 
         judgment = Judgment(kwargs["judgment_uri"])
 
-        context["context"] = {
-            "page_title": '{title}: "{judgment}"'.format(
-                title=gettext("judgment.publish.unpublish_success_title"),
-                judgment=judgment.name,
-            ),
-            "judgment": judgment,
-        }
+        context.update(
+            {
+                "page_title": '{title}: "{judgment}"'.format(
+                    title=gettext("judgment.publish.unpublish_success_title"),
+                    judgment=judgment.name,
+                ),
+                "judgment": judgment,
+            }
+        )
 
         context["feature_flag_embedded_pdfs"] = waffle.flag_is_active(
             self.request, "embedded_pdf_view"

--- a/judgments/views/labs.py
+++ b/judgments/views/labs.py
@@ -19,7 +19,7 @@ class Labs(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(Labs, self).get_context_data(**kwargs)
 
-        context["context"] = {"page_title": "Labs"}
+        context = {"page_title": "Labs"}
 
         context["experiments"] = []
 

--- a/judgments/views/results.py
+++ b/judgments/views/results.py
@@ -17,4 +17,4 @@ def results(request):
     except MarklogicAPIError as e:
         raise Http404(f"Search error, {e}")  # TODO: This should be something else!
     template = loader.get_template("judgment/results.html")
-    return HttpResponse(template.render({"context": context}, request))
+    return HttpResponse(template.render(context, request))

--- a/judgments/views/unlock.py
+++ b/judgments/views/unlock.py
@@ -31,7 +31,7 @@ def unlock_get(request):
         "page_title": gettext("judgment.unlock_judgment_title"),
     }
     template = loader.get_template("judgment/confirm-unlock.html")
-    return HttpResponse(template.render({"context": context}, request))
+    return HttpResponse(template.render(context, request))
 
 
 def unlock_post(request):


### PR DESCRIPTION
## Changes in this PR:

As well as being confusing this was causing problems for template re-use, where an include was used in two places - one with the extra 'context' variable on the context, and another without. This removes the extra 'context' everywhere it's used for consistency - further refactoring to come to tidy up the views and remove duplication.
