### PR TITLE
Use new flash notification messages site-wide

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -4,7 +4,6 @@ Base settings to build other settings files upon.
 from pathlib import Path
 
 import environ
-from django.contrib.messages import constants as message_constants
 
 ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 # ds_judgments_editor_ui/
@@ -292,8 +291,3 @@ STRONGHOLD_PUBLIC_URLS = (
 )
 
 JIRA_INSTANCE = env("JIRA_INSTANCE")
-
-MESSAGE_TAGS = {
-    message_constants.SUCCESS: "edit-component__success",
-    message_constants.ERROR: "edit-component__error",
-}

--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -8,6 +8,7 @@
     margin: 0 auto;
     padding: 0 calc(#{$spacer__unit} * 2);
   }
+
   &__header {
     font-size: 1rem;
     line-height: 2.8rem;
@@ -20,16 +21,7 @@
   &__more-options {
     margin-top: calc($spacer__unit * 2);
   }
-  &__success {
-    background-color: $color__green;
-    width: fit-content;
-    padding: calc(#{$spacer__unit} / 2);
-  }
-  &__error {
-    background-color: $color__red;
-    width: fit-content;
-    padding: calc(#{$spacer__unit} / 2);
-  }
+
   &__panel {
     padding: calc(#{$spacer__unit} / 2) 0;
   }

--- a/ds_caselaw_editor_ui/sass/includes/_global.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_global.scss
@@ -2,8 +2,3 @@ body {
   margin: 0;
   font-family: $font__open-sans;
 }
-
-.messages {
-  list-style-type: none;
-  padding-left: 0
-}

--- a/ds_caselaw_editor_ui/sass/includes/_global.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_global.scss
@@ -2,3 +2,8 @@ body {
   margin: 0;
   font-family: $font__open-sans;
 }
+
+.messages {
+  list-style-type: none;
+  padding-left: 0
+}

--- a/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
@@ -1,10 +1,11 @@
-@mixin message {
+@mixin notification {
     color: $color__white;
     padding: .5rem 1rem;
 }
 
 @mixin page-notification {
-    margin: auto 15%;
+    @include notification;
+    margin: $spacer__unit 15% calc(0.5 * $spacer__unit) 15%;
 
     @media (max-width: $grid__breakpoint-medium) {
         margin: auto 0;
@@ -14,46 +15,30 @@
 .page-notification {
     &--success {
         @include page-notification;
-
-        p {
-            background-color: $color__success;
-            @include message;
-        }
+        background-color: $color__success;
     }
 
     &--failure {
         @include page-notification;
-
-        p {
-            background-color: $color__failure;
-            @include message;
-        }
+        background-color: $color__failure;
     }
 
 }
 
 @mixin context-notification {
+    @include notification;
     display: inline-block;
 }
 
 
 .context-notification {
-
     &--success {
         @include context-notification;
-
-        p {
-            background-color: $color__success;
-            @include message;
-        }
+        background-color: $color__success;
     }
 
     &--failure {
         @include context-notification;
-
-        p {
-            background-color: $color__failure;
-            @include message;
-        }
+        background-color: $color__failure;
     }
 }

--- a/ds_caselaw_editor_ui/templates/includes/context_notification.html
+++ b/ds_caselaw_editor_ui/templates/includes/context_notification.html
@@ -1,5 +1,0 @@
-{% spaceless %}
-  <div class="context-notification--{% if failure %}failure{% else %}success{% endif %}">
-    <p>{{ message }}</p>
-  </div>
-{% endspaceless %}

--- a/ds_caselaw_editor_ui/templates/includes/notifications.html
+++ b/ds_caselaw_editor_ui/templates/includes/notifications.html
@@ -1,0 +1,7 @@
+{% if messages %}
+  {% for message in messages %}
+    {% spaceless %}
+      <div class="page-notification--{% if message.tags %}{{ message.tags }}{% else %}success{% endif %}">{{ message }}</div>
+    {% endspaceless %}
+  {% endfor %}
+{% endif %}

--- a/ds_caselaw_editor_ui/templates/includes/page_notification.html
+++ b/ds_caselaw_editor_ui/templates/includes/page_notification.html
@@ -1,5 +1,0 @@
-{% spaceless %}
-  <div class="page-notification--{% if failure %}failure{% else %}success{% endif %}">
-    <p>{{ message }}</p>
-  </div>
-{% endspaceless %}

--- a/ds_caselaw_editor_ui/templates/includes/style_guide/notification-messaging.html
+++ b/ds_caselaw_editor_ui/templates/includes/style_guide/notification-messaging.html
@@ -4,14 +4,16 @@
   Used for page reload events &ndash; the message will stay on the screen until the user interacts with something else.
 </p>
 <p>
-  Use with <code>include "includes/page_notification.html" with message="Successfully signed in as Crispin." failure=False</code>
+  Use with class names <code>page-notification--success</code> or <code>page-notification--failure</code>:
 </p>
-{% include "includes/page_notification.html" with message="Successfully signed in as Crispin." %}
-{% include "includes/page_notification.html" with message="The username and/or password you specified are not correct." failure=True %}
+<div class="page-notification--success">Successfully signed in as Crispin.</div>
+<div class="page-notification--failure">The username and/or password you specified are not correct.</div>
 <h4>Context notification</h4>
-<p>Used for individual interactive elements such as forms &ndash; these messages rely on JavaScript.</p>
 <p>
-  Use with <code>include "includes/context_notification.html" with message="Please select at least one checkbox." failure=True</code>
+  Used for individual interactive elements such as forms which submit data via AJAX, when the message should be incorporated within the element itself, or placed nearby.
 </p>
-{% include "includes/context_notification.html" with message="Metadata has been saved successfully." %}
-{% include "includes/context_notification.html" with message="Please select at least one checkbox." failure=True %}
+<p>
+  Use with class names <code>context-notification--success</code> or <code>context-notification--failure</code>:
+</p>
+<div class="context-notification--success">Metadata has been saved successfully.</div>
+<div class="context-notification--failure">Please select at least one checkbox.</div>

--- a/ds_caselaw_editor_ui/templates/judgment/unhold-success.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold-success.html
@@ -1,5 +1,8 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
 {% load waffle_tags %}
+{% block judgment_header %}
+  {% include "includes/judgment_metadata_panel.html" with judgment=judgment %}
+{% endblock judgment_header %}
 {% block judgment_content %}
   {% load i18n %}
   <h2>

--- a/ds_caselaw_editor_ui/templates/judgment/unhold.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold.html
@@ -1,4 +1,7 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
+{% block judgment_header %}
+  {% include "includes/judgment_metadata_panel.html" with judgment=judgment %}
+{% endblock judgment_header %}
 {% block judgment_content %}
   {% load i18n %}
   <h2>

--- a/ds_caselaw_editor_ui/templates/layouts/base.html
+++ b/ds_caselaw_editor_ui/templates/layouts/base.html
@@ -26,7 +26,13 @@
     {% if messages %}
       <ul class="messages">
         {% for message in messages %}
-          <li {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+          <li>
+            {% if message.tags == "failure" %}
+              {% include "includes/page_notification.html" with message=message failure=True %}
+            {% else %}
+              {% include "includes/page_notification.html" with message=message failure=False %}
+            {% endif %}
+          </li>
         {% endfor %}
       </ul>
     {% endif %}

--- a/ds_caselaw_editor_ui/templates/layouts/base.html
+++ b/ds_caselaw_editor_ui/templates/layouts/base.html
@@ -23,25 +23,13 @@
   <body>
     {% include "includes/cookie_consent/cookie_banner.html" %}
     {% include "includes/gtm/gtm_body.html" %}
-    {% if messages %}
-      <ul class="messages">
-        {% for message in messages %}
-          <li>
-            {% if message.tags == "failure" %}
-              {% include "includes/page_notification.html" with message=message failure=True %}
-            {% else %}
-              {% include "includes/page_notification.html" with message=message failure=False %}
-            {% endif %}
-          </li>
-        {% endfor %}
-      </ul>
-    {% endif %}
     <a id="skip-to-main-content" href="#main-content">{% translate "skiplink" %}</a>
     <header class="page-header page-header-slim">
       {% include "includes/breadcrumbs.html" with current=page_title title=page_title link=request.get_full_path %}
     </header>
     {% block precontent %}
     {% endblock precontent %}
+    {% include "includes/notifications.html" %}
     <main id="main-content">
       {% block content %}
       {% endblock content %}


### PR DESCRIPTION
This commit uses terry's new notification component for flash messages, and removes some stray additional styling from before.

## Screenshots of UI changes:
<img width="1494" alt="Screenshot 2023-03-30 at 12 56 38" src="https://user-images.githubusercontent.com/4279/228815295-291a5473-1ac8-4a08-ae45-6a6ac79a41ac.png">
