### PR TITLE
Use new tabs site wide

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_view_controls.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_view_controls.scss
@@ -1,0 +1,7 @@
+.judgment-view-controls{
+
+  @media (min-width: 1400px) {
+    width: 67.5%;
+    margin: 0 auto;
+ }
+}

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -36,4 +36,5 @@
 @import "includes/labs";
 @import "includes/style_guide";
 @import "includes/tabs";
-@import "includes/notification_message"
+@import "includes/notification_message";
+@import "includes/judgment_view_controls";

--- a/ds_caselaw_editor_ui/static/js/src/components/tabSet.js
+++ b/ds_caselaw_editor_ui/static/js/src/components/tabSet.js
@@ -2,7 +2,7 @@ import $ from "jquery";
 
 const TabSet = {
   init: function () {
-    const elements = $(".tabs-set");
+    const elements = $(".tabs-set.with-js");
     elements.each(function (ix, element) {
       TabSet.initOne(element);
     });

--- a/ds_caselaw_editor_ui/templates/includes/judgment_view_controls.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_view_controls.html
@@ -1,17 +1,7 @@
-{% load i18n %}
 {% if feature_flag_embedded_pdfs %}
-  <div class="judgment-toolbar__container" style="margin: 0.5rem auto">
-    <a class="judgment-toolbar__button{% if view == 'html' %} judgment-toolbar__button-selected{% endif %}"
-       href="{% url 'full-text-html' judgment_uri %}">
-      {% translate "judgment.view_control.html" %}
-    </a>
-    {% if judgment.pdf_url %}
-      <a class="judgment-toolbar__button{% if view == 'pdf' %} judgment-toolbar__button-selected{% endif %}"
-         href="{% url 'full-text-pdf' judgment.uri %}">
-        {% translate "judgment.view_control.pdf" %}
-      </a>
-    {% else %}
-      <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.view_control.pdf" %}</span>
-    {% endif %}
+  <div class="judgment-view-controls">
+    {% url 'full-text-html' judgment.uri as url1 %}
+    {% url 'full-text-pdf' judgment.uri as url2 %}
+    {% include "includes/tabs.html" with label1="HTML view" label2="PDF view" url1=url1 url2=url2 selected=selected_tab %}
   </div>
 {% endif %}

--- a/ds_caselaw_editor_ui/templates/includes/style_guide/tabs.html
+++ b/ds_caselaw_editor_ui/templates/includes/style_guide/tabs.html
@@ -1,5 +1,5 @@
 <h4>Tabs</h4>
 <p>
-  Use with <code>include "includes/tabs.html" with label1="HTML view" label2="PDF view" url1="#first-tab" url2="#second-tab" selected=1</code>:
+  Use with <code>include "includes/tabs.html" with label1="HTML view" label2="PDF view" url1="#first-tab" url2="#second-tab" selected=1 javascript_enabled=True</code>:
 </p>
-{% include "includes/tabs.html" with label1="HTML view" label2="PDF view" url1="#first-tab" url2="#second-tab" selected=1 %}
+{% include "includes/tabs.html" with label1="HTML view" label2="PDF view" url1="#first-tab" url2="#second-tab" selected=1 javascript_enabled=True %}

--- a/ds_caselaw_editor_ui/templates/includes/tabs.html
+++ b/ds_caselaw_editor_ui/templates/includes/tabs.html
@@ -1,4 +1,4 @@
-<div class="tabs-set">
+<div class="tabs-set {% if javascript_enabled %}with-js{% endif %}">
   <div class="tabs-set__item">
     <input type="radio"
            id="tab1"

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
@@ -2,7 +2,7 @@
 {% load waffle_tags %}
 {% block content %}
   {% include "includes/metadata_header.html" with return_to="html" %}
-  {% include "includes/judgment_view_controls.html" with view="html" %}
+  {% include "includes/judgment_view_controls.html" with selected_tab=1 %}
   {% if judgment_content %}
     {% if judgment.is_failure %}
       <pre>

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_pdf.html
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_pdf.html
@@ -2,7 +2,7 @@
 {% load waffle_tags %}
 {% block content %}
   {% include "includes/metadata_header.html" with return_to="pdf" %}
-  {% include "includes/judgment_view_controls.html" with view="pdf" %}
+  {% include "includes/judgment_view_controls.html" with selected_tab=2 %}
   <object data="{{ judgment.pdf_url }}"
           type="application/pdf"
           width="100%"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Add the new tab from style guide so it is available site wide -put behind the embedded pdf flag 
## Trello card / Rollbar error (etc)
https://trello.com/c/AIJddSdz/740-eui-style-tab-switcher-for-html-pdf-view
## Screenshots of UI changes:

### Before
![button-tab](https://user-images.githubusercontent.com/75584408/229161266-c9725847-7676-471b-8c03-6ce035981e1c.png)

### After
[tab-toggle.webm](https://user-images.githubusercontent.com/75584408/229161384-0b9bbab6-6ca3-4020-95c5-35de1a2168bb.webm)

- [ ] Requires env variable(s) to be updated
