### PR TITLE
Add assignment dropdown to judgment sidebar

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_sidebar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_sidebar.scss
@@ -37,4 +37,17 @@
         font-size: 1rem;
       }
     }
+
+    &__assignment-input {
+      display: block;
+      min-width: 66%;
+    }
+
+    &__context-notification {
+      margin-top: calc(0.5 * $spacer__unit);
+    }
+
+    .loading-indicator {
+      margin-top: calc(0.5 * $spacer__unit);
+    }
   }

--- a/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
@@ -28,8 +28,15 @@
 @mixin context-notification {
     @include notification;
     display: inline-block;
+    animation: context-notification 0.5s 1;
+    animation-fill-mode: forwards;
+    animation-delay: 2s;
 }
 
+@keyframes context-notification {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}
 
 .context-notification {
     &--success {

--- a/ds_caselaw_editor_ui/static/js/src/app.js
+++ b/ds_caselaw_editor_ui/static/js/src/app.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import TabSet from "./components/tabSet";
+import JudgmentSidebar from "./components/judgmentSidebar";
 
 (function ($) {
   $.fn.manage_filters = function (options) {
@@ -79,3 +80,4 @@ $(".judgments-list__judgment-assign-form").on("submit", function (event) {
 });
 
 TabSet.init();
+JudgmentSidebar.init();

--- a/ds_caselaw_editor_ui/static/js/src/components/judgmentSidebar.js
+++ b/ds_caselaw_editor_ui/static/js/src/components/judgmentSidebar.js
@@ -1,0 +1,48 @@
+import $ from "jquery";
+
+const JudgmentSidebar = {
+  init: function () {
+    const elements = $(".judgment-sidebar");
+    elements.each(function (ix, element) {
+      JudgmentSidebar.initOne(element);
+    });
+  },
+
+  initOne: function (element) {
+    JudgmentSidebar.initAssignForm(element);
+  },
+
+  initAssignForm: function (element) {
+    const form = $(element).find(".judgment-sidebar__judgment-assign-form");
+    const select = form.find("select");
+    const submit = form.find("input[type='submit']");
+    submit.hide();
+    select.on("change", function (event) {
+      form.find(".judgment-sidebar__context-notification").remove();
+      form.trigger("submit");
+    });
+    form.on("submit", function (event) {
+      event.preventDefault();
+      const form = $(this);
+      const action = form.attr("action");
+      const loading = $(
+        "<span class='loading-indicator' role='progressbar' aria-valuetext='Loading' aria-busy='true' aria-live='polite'></span>"
+      );
+      form.append(loading);
+      $.ajax({
+        type: "POST",
+        url: action,
+        data: form.serialize(),
+        success: function (data) {
+          const successMessage = $(
+            "<div class='context-notification--success judgment-sidebar__context-notification' aria-busy='false' />"
+          );
+          successMessage.text(data["message"]);
+          loading.replaceWith(successMessage);
+        },
+      });
+    });
+  },
+};
+
+export default JudgmentSidebar;

--- a/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
@@ -46,21 +46,32 @@
     </li>
   </ul>
 </div>
-{% if feature_flag_assign_in_publish_sidebar %}
+{% if feature_flag_publish_flow %}
   <div class="judgment-sidebar__block">
     <h4>{% translate "judgments.sidebar.assigned_to" %}</h4>
-    <select class="judgment-component__assigned_to-input"
-            name="assigned_to"
-            id="assigned_to">
-      <option value="" {% if judgment.assigned_to == "" %}selected{% endif %}>
-        {% translate "judgments.noone" %}
-      </option>
-      {% for editor in editors %}
-        <option value="{{ editor.name }}"
-                {% if judgment.assigned_to == editor.name %} selected{% endif %}>
-          {{ editor.print_name }}
+    <form action="{% url "assign" %}"
+          method="post"
+          class="judgment-sidebar__judgment-assign-form">
+      {% csrf_token %}
+      <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
+      <select class="judgment-sidebar__assignment-input"
+              name="assigned_to"
+              id="assigned_to">
+        <option value="" {% if judgment.assigned_to == "" %}selected{% endif %}>
+          {% translate "judgments.noone" %}
         </option>
-      {% endfor %}
-    </select>
+        {% for editor in editors %}
+          <option value="{{ editor.name }}"
+                  {% if judgment.assigned_to == editor.name %} selected{% endif %}>
+            {{ editor.print_name }}
+          </option>
+        {% endfor %}
+      </select>
+      <input type="submit"
+             class="button-cta"
+             name="assign"
+             value
+             {% translate "judgment.assign_cta" %}/>
+    </form>
   </div>
 {% endif %}

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -100,22 +100,6 @@
              name="anonymised"
              id="anonymised"/>
     </div>
-    <div class="edit-component__panel">
-      <label for="assigned_to">{% translate "judgment.assigned_to" %}</label>
-      <select class="edit-component__assigned_to-input"
-              name="assigned_to"
-              id="assigned_to">
-        <option value="" {% if judgment.assigned_to == "" %}selected{% endif %}>
-          {% translate "judgments.noone" %}
-        </option>
-        {% for editor in editors %}
-          <option value="{{ editor.name }}"
-                  {% if judgment.assigned_to == editor.name %} selected{% endif %}>
-            {{ editor.print_name }}
-          </option>
-        {% endfor %}
-      </select>
-    </div>
     <div class="edit-component__actions">
       <input type="hidden" name="judgment_uri" value="{{ judgment_uri }}"/>
       <input type="submit" value="Save"/>

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -3,8 +3,6 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase
-from django.urls import reverse
-from factories import JudgmentFactory
 from lxml import etree
 
 from judgments.models import SearchResult, SearchResultMeta
@@ -147,23 +145,3 @@ class TestSearchResultModel(TestCase):
         self.assertEqual("ukut/lc/2022/241", search_result.uri)
         self.assertEqual(None, search_result.neutral_citation)
         self.assertEqual(None, search_result.court)
-
-
-class TestJudgmentEditor(TestCase):
-    @patch(
-        "judgments.views.judgment_edit.get_judgment_by_uri",
-    )
-    def test_assigned(self, mock_judgment):
-        judgment = JudgmentFactory.build(
-            uri="ewhc/ch/1999/1",
-            assigned_to="otheruser",
-        )
-        mock_judgment.return_value = judgment
-
-        User.objects.get_or_create(username="otheruser")[0]
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-        response = self.client.get(
-            reverse("edit-judgment", kwargs={"judgment_uri": "ewhc/ch/1999/1"})
-        )
-
-        assert_match(b"selected>(\\s*)otheruser", response.content)

--- a/judgments/views/button_handlers.py
+++ b/judgments/views/button_handlers.py
@@ -26,14 +26,21 @@ def hold_judgment_button(request):
 
 def assign_judgment_button(request):
     judgment_uri = request.POST["judgment_uri"]
-    api_client.set_property(judgment_uri, "assigned-to", request.user.username)
+    assigned_to = request.POST.get("assigned_to", request.user.username)
+    api_client.set_property(judgment_uri, "assigned-to", assigned_to)
+    if assigned_to == request.user.username:
+        msg = "Document assigned to you."
+    elif assigned_to == "":
+        msg = "Document unassigned."
+    else:
+        msg = f"Judgment assigned to {assigned_to}."
     if request.headers.get("X-Requested-With") == "XMLHttpRequest":
         return HttpResponse(
-            json.dumps({"assigned_to": request.user.username}),
+            json.dumps({"assigned_to": request.user.username, "message": msg}),
             content_type="application/json",
         )
     else:
-        messages.success(request, "Judgment assigned to you.")
+        messages.success(request, msg)
         return redirect(ensure_local_referer_url(request))
 
 

--- a/judgments/views/judgment_hold.py
+++ b/judgments/views/judgment_hold.py
@@ -7,7 +7,7 @@ from django.utils.html import escape
 from django.utils.translation import gettext
 from django.views.generic import TemplateView
 
-from judgments.utils import get_judgment_by_uri
+from judgments.utils import editors_dict, get_judgment_by_uri
 from judgments.utils.aws import invalidate_caches
 
 from .judgment_edit import build_confirmation_email_link
@@ -28,6 +28,7 @@ class HoldJudgmentView(TemplateView):
                 ),
                 "view": "hold_judgment",
                 "judgment": judgment,
+                "editors": editors_dict(),
             }
         )
 
@@ -39,8 +40,8 @@ class HoldJudgmentView(TemplateView):
             self.request, "log_minor_issues_on_publish"
         )
 
-        context["feature_flag_assign_in_publish_sidebar"] = waffle.flag_is_active(
-            self.request, "assign_in_publish_sidebar"
+        context["feature_flag_publish_flow"] = waffle.flag_is_active(
+            self.request, "publish_flow"
         )
 
         return context
@@ -64,6 +65,7 @@ class HoldJudgmentSuccessView(TemplateView):
                 "email_confirmation_link": build_confirmation_email_link(
                     self.request, judgment
                 ),
+                "editors": editors_dict(),
             }
         )
 
@@ -71,8 +73,8 @@ class HoldJudgmentSuccessView(TemplateView):
             self.request, "embedded_pdf_view"
         )
 
-        context["feature_flag_assign_in_publish_sidebar"] = waffle.flag_is_active(
-            self.request, "assign_in_publish_sidebar"
+        context["feature_flag_publish_flow"] = waffle.flag_is_active(
+            self.request, "publish_flow"
         )
 
         return context
@@ -116,6 +118,7 @@ class UnholdJudgmentView(TemplateView):
                 ),
                 "view": "hold_judgment",
                 "judgment": judgment,
+                "editors": editors_dict(),
             }
         )
 
@@ -141,6 +144,7 @@ class UnholdJudgmentSuccessView(TemplateView):
                     judgment=judgment.name,
                 ),
                 "judgment": judgment,
+                "editors": editors_dict(),
             }
         )
 

--- a/judgments/views/judgment_publish.py
+++ b/judgments/views/judgment_publish.py
@@ -7,7 +7,7 @@ from django.utils.html import escape
 from django.utils.translation import gettext
 from django.views.generic import TemplateView
 
-from judgments.utils import get_judgment_by_uri
+from judgments.utils import editors_dict, get_judgment_by_uri
 from judgments.utils.aws import invalidate_caches
 
 from .judgment_edit import build_confirmation_email_link
@@ -29,6 +29,7 @@ class PublishJudgmentView(TemplateView):
                 ),
                 "view": "publish_judgment",
                 "judgment": judgment,
+                "editors": editors_dict(),
             }
         )
 
@@ -40,8 +41,8 @@ class PublishJudgmentView(TemplateView):
             self.request, "log_minor_issues_on_publish"
         )
 
-        context["feature_flag_assign_in_publish_sidebar"] = waffle.flag_is_active(
-            self.request, "assign_in_publish_sidebar"
+        context["feature_flag_publish_flow"] = waffle.flag_is_active(
+            self.request, "publish_flow"
         )
 
         return context
@@ -65,6 +66,7 @@ class PublishJudgmentSuccessView(TemplateView):
                 "email_confirmation_link": build_confirmation_email_link(
                     self.request, judgment
                 ),
+                "editors": editors_dict(),
             }
         )
 
@@ -72,8 +74,8 @@ class PublishJudgmentSuccessView(TemplateView):
             self.request, "embedded_pdf_view"
         )
 
-        context["feature_flag_assign_in_publish_sidebar"] = waffle.flag_is_active(
-            self.request, "assign_in_publish_sidebar"
+        context["feature_flag_publish_flow"] = waffle.flag_is_active(
+            self.request, "publish_flow"
         )
 
         return context
@@ -117,6 +119,7 @@ class UnpublishJudgmentView(TemplateView):
                 ),
                 "view": "publish_judgment",
                 "judgment": judgment,
+                "editors": editors_dict(),
             }
         )
 
@@ -142,6 +145,7 @@ class UnpublishJudgmentSuccessView(TemplateView):
                     judgment=judgment.name,
                 ),
                 "judgment": judgment,
+                "editors": editors_dict(),
             }
         )
 

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-28 14:47+0000\n"
+"POT-Creation-Date: 2023-04-13 12:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,9 +134,14 @@ msgid "judgments.sidebar.assigned_to"
 msgstr "Assigned to"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
-#: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgments.noone"
 msgstr "No one"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment_sidebar.html
+#, fuzzy
+#| msgid "judgment.assigned_to"
+msgid "judgment.assign_cta"
+msgstr "Assign"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.back"
@@ -193,14 +198,6 @@ msgstr "View on public site"
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.delete"
 msgstr "Delete"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment_view_controls.html
-msgid "judgment.view_control.html"
-msgstr "View HTML"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment_view_controls.html
-msgid "judgment.view_control.pdf"
-msgstr "View PDF"
 
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html
 msgid "judgments.details"
@@ -295,10 +292,6 @@ msgstr "Has supplemental documents?"
 #: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.anonymised"
 msgstr "This Judgment has been anonymised"
-
-#: ds_caselaw_editor_ui/templates/judgment/edit.html
-msgid "judgment.assigned_to"
-msgstr "Assigned to"
 
 #: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.previous_versions"
@@ -447,8 +440,8 @@ msgstr "Document unheld"
 
 #: judgments/views/judgment_publish.py
 msgid "judgment.publish.publish_success_flash_message"
-msgstr "Judgment published"
+msgstr "Document published"
 
 #: judgments/views/judgment_publish.py
 msgid "judgment.publish.unpublish_success_flash_message"
-msgstr "Judgment unpublished"
+msgstr "Document unpublished"


### PR DESCRIPTION
## Changes in this PR:

This allows editors to reassign judgments on the publish, hold and unhold pages.

It relies on javascript for the behaviour given in the axure prototypes - without JS it will gracefully degrade to a standard form with a submit button.

I've also added test coverage for the assignment button handler logic.


## Trello card / Rollbar error (etc)

https://trello.com/c/T9J35JZF/712-refinement-move-assignment-to-sidebar

## Screenshots of UI changes:


<img width="465" alt="Screenshot 2023-04-04 at 08 08 42" src="https://user-images.githubusercontent.com/4279/229702704-a68be103-3db7-4489-9f45-ddf8fc85e2f2.png">
<img width="465" alt="Screenshot 2023-04-04 at 08 08 31" src="https://user-images.githubusercontent.com/4279/229702714-feffe2f2-a3b2-410a-8521-bd14a2fd34e8.png">

