### PR TITLE
use general button styles for judgment toolbar

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_buttons.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_buttons.scss
@@ -1,13 +1,44 @@
 .button-cta {
   @include call-to-action-button;
+  border: 2px solid $color__cta-background;
+
+  &:disabled,  &[aria-disabled="true"] {
+    background-color: $color__dark-grey;
+    &:focus, &:hover {
+      outline: none;
+      background-color: $color__dark-grey;
+      color: $color__white;
+      text-decoration: none;
+      cursor: not-allowed;
+    }
+  }
 }
 
 .button-secondary {
-        @include call-to-action-button;
-        background-color: transparent;
-        color: $color__cta-background !important;
-        border: 2px solid $color__cta-background;
-    &:visited  {
-      color: #ffffff;
+  @include call-to-action-button;
+  background-color: $color__white;
+  color: $color__cta-background;
+  border: 2px solid $color__cta-background;
+
+  &:visited {
+    color: $color__cta-background;
+  }
+
+  &:focus, &:hover {
+    color: white;
+  }
+
+  &:disabled,  &[aria-disabled="true"] {
+    color: $color__dark-grey;
+    background-color: transparent;
+    border-color: $color__grey;
+    &:focus, &:hover {
+      outline: none;
+      background-color: transparent;
+      color: $color__dark-grey;
+      text-decoration: none;
+      cursor: not-allowed;
     }
+  }
+
 }

--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
@@ -2,39 +2,25 @@
 
   background-color: $color__light-grey;
   color: $color__black;
-  padding: $spacer__unit;
+  padding: calc(0.5 * $spacer__unit) $spacer__unit;
   border-bottom: 0.125rem solid $color__grey;
 
   &__button {
-    background-color: $color__aqua-blue;
-    color: $color__white;
-    padding: calc($spacer__unit / 2) calc($spacer__unit * 1.5);
     display: inline-block;
-    text-decoration: none;
-    transition: all 0.2s;
-    margin: 0.5rem 0.25rem;
+    margin: calc(0.5 * $spacer__unit) calc(0.33 * $spacer__unit) !important;
+    padding: calc($spacer__unit / 2) calc($spacer__unit * 1.5) !important;
+  }
 
-    &:hover {
-      background-color: scale-color($color__aqua-blue, $lightness: +8%);
-      color: $color__white;
-    }
-
-    &:visited {
-      color: $color__white;
-    }
-
-    &.judgment-toolbar__delete {
-      background-color: $color__red;
-    }
-
-    &-selected {
-      background-color: scale-color($color__aqua-blue, $lightness: -30%);
-    }
-
-    &[aria-disabled="true"]{
-      background-color: scale-color($color__aqua-blue, $saturation: -95%, $lightness: +55%);
+  &__delete {
+    border-color: $color__red !important;
+    color: $color__red !important;
+    &:focus, &:hover {
+      background-color: $color__red !important;
+      color: $color__white !important;
+      outline-color: $color__red !important;
     }
   }
+
 
   &__return-link {
     display: inline-block;

--- a/ds_caselaw_editor_ui/sass/includes/_mixins.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_mixins.scss
@@ -55,9 +55,13 @@
   margin-top: 1em;
   font-size: 1rem;
 
+  &:visited {
+    color: $color__white;
+  }
+
   &:focus, &:hover {
     @include focus-default;
-    color: $color__white !important;
+    color: $color__white;
     background-color: $color__cta-background-hover;
     outline-color: $color__cta-background-hover;
     border-color: $color__cta-background-hover;

--- a/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
@@ -10,11 +10,11 @@
     <div class="judgment-toolbar__edit">
       {% if feature_flag_embedded_pdfs %}
         {% if judgment.is_editable %}
-          <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}judgment-toolbar__button-selected{% endif %}"
+          <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}button-cta{% else %}button-secondary{% endif %}"
              href="{% url 'edit-judgment' judgment.uri %}">
             {% translate "judgment.toolbar.edit_metadata" %}
           </a>
-          <a class="judgment-toolbar__button {% if view == 'judgment_text' %}judgment-toolbar__button-selected{% endif %}"
+          <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
              href="{% url 'full-text-html' judgment.uri %}">
             {% flag "publish_flow" %}
             {% translate "judgment.toolbar.review_document" %}
@@ -23,8 +23,10 @@
           {% endflag %}
         </a>
       {% else %}
-        <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.edit_metadata" %}</span>
-        <span class="judgment-toolbar__button" aria-disabled="true">
+        <span class="judgment-toolbar__button button-secondary"
+              aria-disabled="true">{% translate "judgment.toolbar.edit_metadata" %}</span>
+        <span class="judgment-toolbar__button button-secondary"
+              aria-disabled="true">
           {% flag "publish_flow" %}
           {% translate "judgment.toolbar.review_document" %}
         {% else %}
@@ -34,30 +36,32 @@
     {% endif %}
   {% else %}
     {% if judgment.is_editable %}
-      <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}judgment-toolbar__button-selected{% endif %}"
+      <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}button-cta{% else %}button-secondary{% endif %}"
          href="{% url 'edit-judgment' judgment.uri %}">
         {% translate "judgment.toolbar.edit" %}
       </a>
-      <a class="judgment-toolbar__button {% if view == 'judgment_text' %}judgment-toolbar__button-selected{% endif %}"
+      <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
          href="{% url 'full-text-html' judgment.uri %}">
         {% translate "judgment.toolbar.view_html" %}
       </a>
     {% else %}
-      <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.edit" %}</span>
+      <span class="judgment-toolbar__button button-secondary"
+            aria-disabled="true">{% translate "judgment.toolbar.edit" %}</span>
       <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.view_html" %}</span>
     {% endif %}
   {% endif %}
   {% flag "hold_flow" %}
   {% if judgment.is_published %}
-    <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.hold" %}</span>
+    <span class="judgment-toolbar__button button-secondary"
+          aria-disabled="true">{% translate "judgment.toolbar.hold" %}</span>
   {% else %}
     {% if judgment.is_held %}
-      <a class="judgment-toolbar__button {% if view == 'hold_judgment' %}judgment-toolbar__button-selected{% endif %}"
+      <a class="judgment-toolbar__button {% if view == 'hold_judgment' %}button-cta{% else %}button-secondary{% endif %}"
          href="{% url 'unhold-judgment' judgment.uri %}">
         {% translate "judgment.toolbar.unhold" %}
       </a>
     {% else %}
-      <a class="judgment-toolbar__button {% if view == 'hold_judgment' %}judgment-toolbar__button-selected{% endif %}"
+      <a class="judgment-toolbar__button {% if view == 'hold_judgment' %}button-cta{% else %}button-secondary{% endif %}"
          href="{% url 'hold-judgment' judgment.uri %}">
         {% translate "judgment.toolbar.hold" %}
       </a>
@@ -66,42 +70,48 @@
 {% endflag %}
 {% flag "publish_flow" %}
 {% if judgment.is_published %}
-  <a class="judgment-toolbar__button {% if view == 'publish_judgment' %}judgment-toolbar__button-selected{% endif %}"
+  <a class="judgment-toolbar__button {% if view == 'publish_judgment' %}button-cta{% else %}button-secondary{% endif %}"
      href="{% url 'unpublish-judgment' judgment.uri %}">
     {% translate "judgment.toolbar.unpublish" %}
   </a>
 {% else %}
   {% if judgment.is_publishable %}
-    <a class="judgment-toolbar__button {% if view == 'publish_judgment' %}judgment-toolbar__button-selected{% endif %}"
+    <a class="judgment-toolbar__button {% if view == 'publish_judgment' %}button-cta{% else %}button-secondary{% endif %}"
        href="{% url 'publish-judgment' judgment.uri %}">
       {% translate "judgment.toolbar.publish" %}
     </a>
   {% else %}
-    <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.publish" %}</span>
+    <span class="judgment-toolbar__button button-secondary"
+          aria-disabled="true">{% translate "judgment.toolbar.publish" %}</span>
   {% endif %}
 {% endif %}
 {% endflag %}
 {% if judgment.docx_url %}
-  <a class="judgment-toolbar__button" href="{{ judgment.docx_url }}">{% translate "judgment.toolbar.download_docx" %}</a>
+  <a class="judgment-toolbar__button button-secondary"
+     href="{{ judgment.docx_url }}">{% translate "judgment.toolbar.download_docx" %}</a>
 {% else %}
-  <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.download_docx" %}</span>
+  <span class="judgment-toolbar__button button-secondary"
+        aria-disabled="true">{% translate "judgment.toolbar.download_docx" %}</span>
 {% endif %}
 {% if not feature_flag_embedded_pdfs %}
   {% if judgment.pdf_url %}
-    <a class="judgment-toolbar__button" href="{{ judgment.pdf_url }}">{% translate "judgment.toolbar.download_pdf" %}</a>
+    <a class="judgment-toolbar__button button-secondary"
+       href="{{ judgment.pdf_url }}">{% translate "judgment.toolbar.download_pdf" %}</a>
   {% else %}
-    <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.download_pdf" %}</span>
+    <span class="judgment-toolbar__button button-secondary"
+          aria-disabled="true">{% translate "judgment.toolbar.download_pdf" %}</span>
   {% endif %}
 {% endif %}
 {% if judgment.is_published %}
-  <a class="judgment-toolbar__button"
+  <a class="judgment-toolbar__button button-secondary"
      href="{{ judgment.public_uri }}"
      target="_blank"
      rel="noopener noreferrer">
     {% translate "judgment.toolbar.view_on_public" %}
   </a>
 {% else %}
-  <span class="judgment-toolbar__button" aria-disabled="true">{% translate "judgment.toolbar.view_on_public" %}</span>
+  <span class="judgment-toolbar__button button-secondary"
+        aria-disabled="true">{% translate "judgment.toolbar.view_on_public" %}</span>
 {% endif %}
 {% if judgment.is_failure %}
   <form action="{% url "delete" %}" method="post">
@@ -109,6 +119,7 @@
     <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
     <input type="submit"
            name="assign"
+           class="button-secondary judgment-toolbar__delete"
            value="{% translate "judgment.toolbar.delete" %}"/>
   </form>
 {% endif %}


### PR DESCRIPTION
## Changes in this PR:

Use the existing site-wide button styles for the judgment header toolbar (and adapt them where needed - in particualar we've now added a 'disabled button' style globally.


## Trello card / Rollbar error (etc)

https://trello.com/c/GccWXdAq/713-eui-ensure-toolbar-buttons-are-underlined-with-correct-double-boarder-on-hover-etc

## Screenshots of UI changes:

<img width="1545" alt="imagen" src="https://user-images.githubusercontent.com/4279/229753437-e3f82763-ea32-4a2e-81d1-ad67993603fc.png">

