### PR TITLE
Update API client to 5.3.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,8 +17,8 @@ requests-toolbelt~=0.10.1
 lxml~=4.9.2
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=5.2.6
-ds-caselaw-utils~=0.5.0
+ds-caselaw-marklogic-api-client~=5.3.1
+ds-caselaw-utils~=1.0.0
 rollbar
 django-stronghold==0.4.0
-boto3==1.26.99
+boto3~=1.26.99

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,4 +22,3 @@ ds-caselaw-utils~=0.5.0
 rollbar
 django-stronghold==0.4.0
 boto3==1.26.99
-botocore==1.29.110


### PR DESCRIPTION
- Bumps API client to v5.3.1, which has the new `Judgment` class so it can be removed from EUI.
- Removes the `botocore` pinned dependency, because `boto3` has one anyway and this reduces Dependabot noise and simplifies dependency resolution.
- Bump utils to `~1.0.0`
- Loosen boto3 dependency, so it's happy with the higher requirement of v5.3.1.