### PR TITLE
style guide notes form component

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_global.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_global.scss
@@ -2,3 +2,9 @@ body {
   margin: 0;
   font-family: $font__open-sans;
 }
+
+textarea {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}

--- a/ds_caselaw_editor_ui/sass/includes/_note.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_note.scss
@@ -1,0 +1,14 @@
+.note-form {
+    &__label {
+        margin-bottom: 1rem;
+    }
+
+    &__text-area {
+        @include text_field;
+        display: block;
+        width: 100%;
+        font-size: 1rem;
+        line-height: 1.25rem;
+        border: 2px solid $color__almost-black;
+    }
+}

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -39,3 +39,4 @@
 @import "includes/tabs";
 @import "includes/notification_message";
 @import "includes/judgment_view_controls";
+@import "includes/note";

--- a/ds_caselaw_editor_ui/templates/includes/note-form.html
+++ b/ds_caselaw_editor_ui/templates/includes/note-form.html
@@ -1,0 +1,11 @@
+<div class="note-form">
+  <h2>
+    <label class="note-form__label" for="write-a-note">Write a note</label>
+  </h2>
+  <textarea class="note-form__text-area"
+            id="write-a-note"
+            name="write-a-note"
+            rows="8"
+            placeholder="Write your message..."
+            aria-describedby="write-a-note"></textarea>
+</div>

--- a/ds_caselaw_editor_ui/templates/includes/style_guide/note.html
+++ b/ds_caselaw_editor_ui/templates/includes/style_guide/note.html
@@ -1,0 +1,5 @@
+<h3>Note form</h3>
+<p>
+  Use with <code>include "includes/note-form.html"</code>:
+</p>
+{% include "includes/note-form.html" %}

--- a/ds_caselaw_editor_ui/templates/pages/style_guide.html
+++ b/ds_caselaw_editor_ui/templates/pages/style_guide.html
@@ -15,5 +15,6 @@
     <hr />
     {% include "includes/style_guide/summary-panels.html" %}
     <hr />
+    {% include "includes/style_guide/note.html" %}
   </div>
 {% endblock content %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
built a Note component as basic as possible to be added to an existing form. e.g. _publish_ and _put on hold_ when the checkboxes are present.

Kept the styling bear-bones with no submit button because we want to incorporate it within an existing for design a little similar to this...
https://ct3ku9.axshare.com/?id=nc19kt&p=publish-screen-desktop&c=1

## Trello card / Rollbar error (etc)
https://trello.com/c/NjqNZqsF/573-%F0%9F%8E%AB-%F0%9F%94%90-%F0%9F%93%99-%F0%9F%8E%9B%EF%B8%8F-eui-write-a-note-component-in-the-style-guide
## Screenshots of UI changes:

### Before
There is no before
### After
![Screenshot 2023-04-14 at 16 05 20](https://user-images.githubusercontent.com/102584881/232081756-779b016c-8d51-4da4-b214-7f8b1460b252.png)

- [ ] Requires env variable(s) to be updated
