### PR TITLE
styled component divider on style guide to make it look nicer

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_style_guide.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_style_guide.scss
@@ -3,7 +3,7 @@
     margin: 0 auto;
     padding: 1rem 0;
 
-    &__divider {
+    hr {
         margin: 3rem 0;
         height: 1rem;
         background-color: $color__light-grey;

--- a/ds_caselaw_editor_ui/sass/includes/_style_guide.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_style_guide.scss
@@ -2,4 +2,11 @@
     max-width: 90%;
     margin: 0 auto;
     padding: 1rem 0;
+
+    &__divider {
+        margin: 3rem 0;
+        height: 1rem;
+        background-color: $color__light-grey;
+        border: none;
+    }
 }

--- a/ds_caselaw_editor_ui/templates/pages/style_guide.html
+++ b/ds_caselaw_editor_ui/templates/pages/style_guide.html
@@ -4,17 +4,18 @@
   <div class="style-guide">
     <h2>{% translate "style_guide.title" %}</h2>
     <p>{% translate "style_guide.description" %}</p>
-    <hr />
+    <hr class="style-guide__divider" />
     {% include "includes/style_guide/buttons.html" %}
-    <hr />
+    <hr class="style-guide__divider" />
     {% include "includes/style_guide/colours.html" %}
-    <hr />
+    <hr class="style-guide__divider" />
     {% include "includes/style_guide/tabs.html" %}
-    <hr />
+    <hr class="style-guide__divider" />
     {% include "includes/style_guide/notification-messaging.html" %}
-    <hr />
+    <hr class="style-guide__divider" />
     {% include "includes/style_guide/summary-panels.html" %}
-    <hr />
+    <hr class="style-guide__divider" />
     {% include "includes/style_guide/note.html" %}
+    <hr class="style-guide__divider" />
   </div>
 {% endblock content %}

--- a/ds_caselaw_editor_ui/templates/pages/style_guide.html
+++ b/ds_caselaw_editor_ui/templates/pages/style_guide.html
@@ -4,18 +4,18 @@
   <div class="style-guide">
     <h2>{% translate "style_guide.title" %}</h2>
     <p>{% translate "style_guide.description" %}</p>
-    <hr class="style-guide__divider" />
+    <hr/>
     {% include "includes/style_guide/buttons.html" %}
-    <hr class="style-guide__divider" />
+    <hr/>
     {% include "includes/style_guide/colours.html" %}
-    <hr class="style-guide__divider" />
+    <hr/>
     {% include "includes/style_guide/tabs.html" %}
-    <hr class="style-guide__divider" />
+    <hr/>
     {% include "includes/style_guide/notification-messaging.html" %}
-    <hr class="style-guide__divider" />
+    <hr/>
     {% include "includes/style_guide/summary-panels.html" %}
-    <hr class="style-guide__divider" />
+    <hr/>
     {% include "includes/style_guide/note.html" %}
-    <hr class="style-guide__divider" />
+    <hr/>
   </div>
 {% endblock content %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Styled up the` <hr>` tag on the styke guide page to divider the components better. and to give them more space.
## Trello card / Rollbar error (etc)
no trello card for this. just me being designer
## Screenshots of UI changes:

### Before
![Screenshot 2023-04-17 at 13 58 06](https://user-images.githubusercontent.com/102584881/232491071-1aabb799-3dc6-4252-9c1c-b3b7fe18414a.png)

### After
![Screenshot 2023-04-17 at 13 58 45](https://user-images.githubusercontent.com/102584881/232491086-dde52c01-fca8-43c1-8b62-b325dcb18c09.png)

- [ ] Requires env variable(s) to be updated
