### PR TITLE
Consistency of headings in judgment publish/hold workflow

### DIFF
--- a/ds_caselaw_editor_ui/templates/judgment/unhold-success.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold-success.html
@@ -5,10 +5,6 @@
 {% endblock judgment_header %}
 {% block judgment_content %}
   {% load i18n %}
-  <h2>
-    {% translate "judgment.hold.unhold_success_title" %}
-    <br />
-    {{ judgment.name }}
-  </h2>
+  <h2>{% translate "judgment.hold.unhold_success_title" %}</h2>
   <p>{% translate "judgment.unhold.success" %}</p>
 {% endblock judgment_content %}

--- a/ds_caselaw_editor_ui/templates/judgment/unhold.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold.html
@@ -4,11 +4,7 @@
 {% endblock judgment_header %}
 {% block judgment_content %}
   {% load i18n %}
-  <h2>
-    {% translate "judgment.hold.unhold_title" %}
-    <br />
-    {{ judgment.name }}
-  </h2>
+  <h2>{% translate "judgment.hold.unhold_title" %}</h2>
   <form action="{% url 'unhold' %}" method="post">
     {% csrf_token %}
     <div class="judgment-component__actions">

--- a/ds_caselaw_editor_ui/templates/judgment/unpublish-success.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unpublish-success.html
@@ -1,11 +1,10 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
 {% load waffle_tags %}
+{% block judgment_header %}
+  {% include "includes/judgment_metadata_panel.html" with judgment=judgment %}
+{% endblock judgment_header %}
 {% block judgment_content %}
   {% load i18n %}
-  <h2>
-    {% translate "judgment.publish.unpublish_success_title" %}
-    <br />
-    {{ judgment.name }}
-  </h2>
+  <h2>{% translate "judgment.publish.unpublish_success_title" %}</h2>
   <p>This judgment is now unpublished.</p>
 {% endblock judgment_content %}

--- a/ds_caselaw_editor_ui/templates/judgment/unpublish.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unpublish.html
@@ -1,11 +1,10 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
+{% load i18n %}
+{% block judgment_header %}
+  {% include "includes/judgment_metadata_panel.html" with judgment=judgment %}
+{% endblock judgment_header %}
 {% block judgment_content %}
-  {% load i18n %}
-  <h2>
-    {% translate "judgment.publish.unpublish_title" %}
-    <br />
-    {{ judgment.name }}
-  </h2>
+  <h2>{% translate "judgment.publish.unpublish_title" %}</h2>
   <form action="{% url 'unpublish' %}" method="post">
     {% csrf_token %}
     <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -144,11 +144,11 @@ msgstr "Back to search results"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.edit_metadata"
-msgstr "Edit metadata"
+msgstr "Edit"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.review_document"
-msgstr "Review document"
+msgstr "Review"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.view_judgment"
@@ -156,7 +156,7 @@ msgstr "View full text"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.edit"
-msgstr "Edit judgment"
+msgstr "Edit"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.view_html"
@@ -168,15 +168,15 @@ msgstr "Put on hold"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.unhold"
-msgstr "Unhold"
+msgstr "Take off hold"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.unpublish"
-msgstr "Unpublish judgment"
+msgstr "Unpublish"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.publish"
-msgstr "Publish judgment"
+msgstr "Publish"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.download_docx"
@@ -192,7 +192,7 @@ msgstr "View on public site"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.toolbar.delete"
-msgstr "Delete judgment"
+msgstr "Delete"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment_view_controls.html
 msgid "judgment.view_control.html"
@@ -357,7 +357,7 @@ msgstr "Search results"
 #: ds_caselaw_editor_ui/templates/judgment/unhold-success.html
 #: judgments/tests/test_judgments.py judgments/views/judgment_hold.py
 msgid "judgment.hold.unhold_success_title"
-msgstr "Document not on hold"
+msgstr "This document has been taken off hold"
 
 #: ds_caselaw_editor_ui/templates/judgment/unhold-success.html
 msgid "judgment.unhold.success"
@@ -366,7 +366,7 @@ msgstr "This document is no longer on hold."
 #: ds_caselaw_editor_ui/templates/judgment/unhold.html
 #: judgments/tests/test_judgments.py judgments/views/judgment_hold.py
 msgid "judgment.hold.unhold_title"
-msgstr "Unhold document"
+msgstr "Take this document off hold"
 
 #: ds_caselaw_editor_ui/templates/judgment/unhold.html
 msgid "judgment.unhold.unhold_button"
@@ -375,16 +375,16 @@ msgstr "Unhold document"
 #: ds_caselaw_editor_ui/templates/judgment/unpublish-success.html
 #: judgments/tests/test_judgments.py judgments/views/judgment_publish.py
 msgid "judgment.publish.unpublish_success_title"
-msgstr "Unpublished judgment"
+msgstr "This document is no longer published"
 
 #: ds_caselaw_editor_ui/templates/judgment/unpublish.html
 #: judgments/tests/test_judgments.py judgments/views/judgment_publish.py
 msgid "judgment.publish.unpublish_title"
-msgstr "Unpublish judgment"
+msgstr "Unpublish this document"
 
 #: ds_caselaw_editor_ui/templates/judgment/unpublish.html
 msgid "judgment.unpublish.unpublish_button"
-msgstr "Unpublish judgment"
+msgstr "Unpublish document"
 
 #: ds_caselaw_editor_ui/templates/layouts/base.html
 msgid "skiplink"


### PR DESCRIPTION


## Changes in this PR:
A few copy and markup changes to make sure the design and language we use are consistent. I've favoured 'document' over 'judgment' too to prepare us for the arrival of press summaries.

## Trello card / Rollbar error (etc)
https://trello.com/c/t3PcSpFI/753-eui-headings-on-publish-unpublish-hold-unhold-pages-should-show-the-judgment-name
## Screenshots of UI changes:

![Screenshot 2023-04-17 at 17 49 10](https://user-images.githubusercontent.com/4279/232545603-1eb9e6eb-4ca4-4eb2-b0d1-331b4756a427.png)

