### PR TITLE
Fix metadata input panel styles

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_metadata.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_metadata.scss
@@ -24,11 +24,11 @@
   }
 
   &__ncn {
-    width: 40%;
+    width: 27%;
   }
 
   &__court {
-    width: 40%;
+    width: 52%;
     left: 3rem;
   }
   &__date {
@@ -107,12 +107,17 @@
     box-sizing: border-box;
     height: calc(100% - 1.45rem);
     font-size: 1rem;
+    resize: none;
   }
 
   input[type=text] {
     box-sizing: border-box;
     width: 100%;
     min-height: 2rem;
+    font-size: 1rem;
+    $font__open-sans: 'Open Sans', sans-serif;
+    padding: 0.5rem;
+    border: 2px solid $color__dark-grey;
   }
 
   input[type=submit] {

--- a/ds_caselaw_editor_ui/sass/includes/_mixins.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_mixins.scss
@@ -113,6 +113,8 @@
   margin-top: calc($spacer__unit / 2);
   background-color: $color__white;
   width: 80%;
+  font-family: $font__open-sans;
+  font-size: 1rem;
 
   &:focus {
     @include focus-default


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Improved  metadata input text panel with... 
- consistent styling
- replaced Ariel font with open sans
- made the input text bigger to 1rem 
- increased padding to give the input text some air 
- made the borders all 2px. 
- reduced the size of NCN field to reflect likely content length.
- increased Court name field to reflect likely content length.
- fixed the Name text field from being draggable.

## Trello card / Rollbar error (etc)
https://trello.com/c/lQEnfsXZ/812-eui-refine-metadata-panel-styling
## Screenshots of UI changes:

### Before
![Screenshot 2023-04-19 at 09 38 56](https://user-images.githubusercontent.com/102584881/233020920-4ba8a285-08c6-44f4-80fc-ca29a2aa17f1.png)

### After
![Screenshot 2023-04-19 at 09 38 40](https://user-images.githubusercontent.com/102584881/233020949-02a778f4-f6c1-406d-b219-091e4a857893.png)

- [ ] 

- [ ] Requires env variable(s) to be updated
