### PR TITLE
Allow assigned-to to be unset

### DIFF
--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -172,7 +172,7 @@ class EditJudgmentView(View):
 
                 # Assignment
                 # TODO consider validating assigned_to is a user?
-                if new_assignment := request.POST["assigned_to"]:
+                if new_assignment := request.POST.get("assigned_to", False):
                     api_client.set_property(judgment_uri, "assigned-to", new_assignment)
 
                 published = bool(request.POST.get("published", False))


### PR DESCRIPTION
https://dxw.slack.com/archives/C02TP2L2Z0F/p1681996208950269

MultiValueDictKeyError 'assigned_to'
at
post(/app/judgments/views/judgment_edit.py:175)
assigned_to can be empty if it's never been assigned, instead of
if new_assignment := request.POST["assigned_to"]:
we can use .get() with a default value