### PR TITLE
updated metadata form styles and consistency

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -2,6 +2,7 @@
 .list-versions-component,
 .judgment-info-component {
   padding: 0 $spacer__unit;
+
   &__container {
     @include container;
     text-align: left;
@@ -18,6 +19,7 @@
     color: $color__almost-black;
     margin: 0 calc(#{$spacer__unit} * 1.5);
   }
+
   &__more-options {
     margin-top: calc($spacer__unit * 2);
   }
@@ -25,6 +27,15 @@
   &__panel {
     padding: calc(#{$spacer__unit} / 2) 0;
   }
+
+  label {
+    padding-left: 0;
+  }
+
+  &__text-field-label {
+    display: block;
+  }
+
   input[type=submit] {
     @include call-to-action-button;
     display: block;
@@ -33,22 +44,27 @@
   &__metadata_name-input {
     @include text_field;
     width: 80%;
-    min-height: calc(#{$spacer__unit} * 3);
     font-size: 1.2rem;
+
     @media (min-width: $grid__breakpoint-small) {
       width: 20rem;
     }
+
     @media (min-width: $grid__breakpoint-medium) {
       width: 25rem;
     }
+
     @media (min-width: $grid__breakpoint-extra-large) {
       width: 35rem;
     }
   }
+
+  input[type=text] {
+    @include text_field;
+  }
+
   input[type=checkbox] {
-    &:focus {
-      @include focus-default;
-    }
+    @include checkbox;
   }
 }
 
@@ -57,28 +73,34 @@
   display: inline-block;
   padding: 0px 10px 0px 0;
   margin-left: 15%;
+
   &__list-header {
     padding-left: 10px;
     margin: 10px 0;
   }
+
   &__list {
     list-style: none;
     padding-left: 10px;
     margin: 5px 0;
   }
+
   &__list-link {
     padding-bottom: 10px;
   }
 }
+
 .edit-component__actions {
   display: inline-block;
   width: auto;
   padding: calc(#{$spacer__unit} / 2) 0;
 }
+
 @media (max-width: 800px) {
   .edit-component__actions {
     display: block;
   }
+
   .create-email-block {
     margin: 20px 0;
   }

--- a/ds_caselaw_editor_ui/sass/includes/_metadata.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_metadata.scss
@@ -111,6 +111,7 @@
   }
 
   input[type=text] {
+    @include text_field;
     box-sizing: border-box;
     width: 100%;
     min-height: 2rem;
@@ -118,6 +119,7 @@
     $font__open-sans: 'Open Sans', sans-serif;
     padding: 0.5rem;
     border: 2px solid $color__dark-grey;
+    margin: 0;
   }
 
   input[type=submit] {

--- a/ds_caselaw_editor_ui/sass/includes/_mixins.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_mixins.scss
@@ -109,7 +109,6 @@
 @mixin text_field {
   border: 2px solid $color__dark-grey;
   padding: calc($spacer__unit / 2);
-  margin-bottom: $spacer__unit;
   margin-top: calc($spacer__unit / 2);
   background-color: $color__white;
   width: 80%;

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -25,7 +25,7 @@
   <form aria-label="Edit judgment" method="post">
     {% csrf_token %}
     <div class="edit-component__panel">
-      <label for="metadata_name">{% translate "judgment.judgment_name" %}</label>
+      <label class="edit-component__text-field-label" for="metadata_name">{% translate "judgment.judgment_name" %}</label>
       <input type="text"
              class="edit-component__metadata_name-input"
              value="{{ judgment.name }}"
@@ -33,7 +33,9 @@
              id="metadata_name"/>
     </div>
     <div class="edit-component__panel">
-      <label for="neutral_citation">{% translate "judgment.neutral_citation" %}</label>
+      <label class="edit-component__text-field-label" for="neutral_citation">
+        {% translate "judgment.neutral_citation" %}
+      </label>
       <input type="text"
              class="edit-component__neutral_citation-input"
              value="{{ judgment.neutral_citation }}"
@@ -42,7 +44,7 @@
              size="30"/>
     </div>
     <div class="edit-component__panel">
-      <label for="court">{% translate "judgment.court" %}</label>
+      <label class="edit-component__text-field-label" for="court">{% translate "judgment.court" %}</label>
       <input type="text"
              class="edit-component__court-input"
              value="{{ judgment.court }}"
@@ -59,7 +61,10 @@
       </datalist>
     </div>
     <div class="edit-component__panel">
-      <label for="judgment_date">{% translate "judgment.judgment_date" %}</label>
+      <label class="edit-component__text-field-label"
+             for="judgment_date__text-field-label">
+        {% translate "judgment.judgment_date" %}
+      </label>
       <input type="text"
              class="edit-component__judgment_date-input"
              value="{{ judgment.judgment_date_as_string }}"
@@ -68,7 +73,7 @@
     </div>
     {% if not feature_flag_publish_flow %}
       <div class="edit-component__panel">
-        <label for="published">{% translate "judgment.published" %}</label>
+        <label class="edit-component__checkbox-label" for="published">{% translate "judgment.published" %}</label>
         <input type="checkbox"
                class="edit-component__published-input"
                {% if judgment.is_published %}checked{% endif %}
@@ -77,7 +82,7 @@
       </div>
     {% endif %}
     <div class="edit-component__panel">
-      <label for="sensitive">{% translate "judgment.sensitive" %}</label>
+      <label class="edit-component__checkbox-label" for="sensitive">{% translate "judgment.sensitive" %}</label>
       <input type="checkbox"
              class="edit-component__sensitive-input"
              {% if judgment.is_sensitive %}checked{% endif %}
@@ -85,7 +90,7 @@
              id="sensitive"/>
     </div>
     <div class="edit-component__panel">
-      <label for="supplemental">{% translate "judgment.supplemental" %}</label>
+      <label class="edit-component__checkbox-label" for="supplemental">{% translate "judgment.supplemental" %}</label>
       <input type="checkbox"
              class="edit-component__supplemental-input"
              {% if judgment.has_supplementary_materials %}checked{% endif %}
@@ -93,7 +98,7 @@
              id="supplemental"/>
     </div>
     <div class="edit-component__panel">
-      <label for="anonymised">{% translate "judgment.anonymised" %}</label>
+      <label class="edit-component__checkbox-label" for="anonymised">{% translate "judgment.anonymised" %}</label>
       <input type="checkbox"
              class="edit-component__anonymised-input"
              {% if judgment.is_anonymised %}checked{% endif %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Update basic text-inputs to include the styles to match those on PUI.
Please note checkboxes were not part of this card.
## Trello card / Rollbar error (etc)
https://trello.com/c/zo5171tT/810-eui-fix-text-input-style-to-match-pui
## Screenshots of UI changes:

### Before
![Screenshot 2023-04-20 at 16 52 10](https://user-images.githubusercontent.com/102584881/233420467-0bd89b02-fb74-4795-8257-c95bf227b9f9.png)

### After
![Screenshot 2023-04-20 at 16 51 40](https://user-images.githubusercontent.com/102584881/233420532-5f240a2f-33f0-4239-9f25-95410cda1319.png)

- [ ] Requires env variable(s) to be updated
