### PR TITLE
Improve move document workflow

### DIFF
--- a/ds_caselaw_editor_ui/templates/judgment/move.html
+++ b/ds_caselaw_editor_ui/templates/judgment/move.html
@@ -1,0 +1,5 @@
+<form action="{% url "move-judgment" judgment.uri %}" method="post">
+  {% csrf_token %}
+  {{ form }}
+  <input type="submit" value="Submit" />
+</form>

--- a/judgments/forms/judgment_move.py
+++ b/judgments/forms/judgment_move.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class MoveJudgmentForm(forms.Form):
+    neutral_citation = forms.CharField(label="New Neutral Citation")

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -23,6 +23,7 @@ from .views.judgment_hold import (
     hold,
     unhold,
 )
+from .views.judgment_move import MoveJudgmentView
 from .views.judgment_publish import (
     PublishJudgmentSuccessView,
     PublishJudgmentView,
@@ -116,6 +117,11 @@ urlpatterns = [
         "<path:judgment_uri>/unheld",
         UnholdJudgmentSuccessView.as_view(),
         name="unhold-judgment-success",
+    ),
+    path(
+        "<path:judgment_uri>/move",
+        MoveJudgmentView.as_view(),
+        name="move-judgment",
     ),
     path("<path:judgment_uri>/pdf", pdf_view, name="full-text-pdf"),
     path("<path:judgment_uri>/xml", xml_view, name="full-text-xml"),

--- a/judgments/views/judgment_move.py
+++ b/judgments/views/judgment_move.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict
+
+import ds_caselaw_utils as caselawutils
+from caselawclient.Client import api_client
+from django.contrib import messages
+from django.views.generic import FormView
+
+from judgments.forms.judgment_move import MoveJudgmentForm
+from judgments.utils import get_judgment_by_uri, update_judgment_uri
+
+
+class MoveJudgmentView(FormView):
+    template_name = "judgment/move.html"
+    form_class = MoveJudgmentForm
+    success_url = "/"
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        context = super(MoveJudgmentView, self).get_context_data(**kwargs)
+        context["judgment"] = get_judgment_by_uri(self.kwargs["judgment_uri"])
+        return context
+
+    def form_valid(self, form):
+        old_judgment = get_judgment_by_uri(self.kwargs["judgment_uri"])
+        old_uri = old_judgment.uri
+        new_citation = form.cleaned_data["neutral_citation"]
+        new_uri = caselawutils.neutral_url(new_citation)
+
+        # if a URI is not generated, the citation is probably invalid
+        if not new_uri:
+            messages.error(
+                self.request, f"Unable to parse neutral citation '{new_citation}'"
+            )
+            return super().form_valid(form)
+
+        # if both URIs match, just update the neutral citation, there's not need to move.
+        if new_uri.strip("/") == old_uri.strip("/"):
+            api_client.set_judgment_citation(old_uri, new_citation)
+            messages.success(
+                self.request, "Updated neutral citation (did not move judgment)"
+            )
+            return super().form_valid(form)
+
+        # otherwise proceed with the move.
+        # If the document does not exist, we can just create it.
+        # TODO: This is buggy and needs to be fixed or replaced
+        # TODO: handle overwrite mechanic
+        # TODO: write tests
+        update_judgment_uri(old_uri, new_citation)
+        # this also fails due to relying on S3 unless localstack is running
+
+        messages.success(self.request, f"{new_uri}, {old_uri}")
+        return super().form_valid(form)


### PR DESCRIPTION
Create a new /move endpoint to allow editors to move judgments from one neutral citation to another.

Currently a very buggy prototype, see TODOs for missing things needed before release.