### PR TITLE
Initial version of update NCN and version merging workflow

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -6,7 +6,7 @@
       <span class="judgment-metadata-panel__value">{{ judgment.consignment_reference }}</span>
     </li>
     <li>
-      <span class="judgment-metadata-panel__key">{% translate "judgments.ncn" %}</span>
+      <span class="judgment-metadata-panel__key">{% translate "judgment.neutral_citation" %}</span>
       <span class="judgment-metadata-panel__value">{{ judgment.neutral_citation }}</span>
     </li>
     <li>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
@@ -22,7 +22,6 @@
     </dd>
   </dl>
 </div>
-
 <div class="judgment-sidebar__block">
   <h4>{% translate "judgments.sidebar.manage" %}</h4>
   <ul>
@@ -34,7 +33,6 @@
     </li>
   </ul>
 </div>
-
 <div class="judgment-sidebar__block">
   <h4>{% translate "judgments.sidebar.tools" %}</h4>
   <ul>
@@ -50,7 +48,6 @@
     </li>
   </ul>
 </div>
-
 <div class="judgment-sidebar__block">
   <h4>{% translate "judgments.sidebar.assigned_to" %}</h4>
   <form action="{% url "assign" %}"

--- a/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
@@ -22,6 +22,19 @@
     </dd>
   </dl>
 </div>
+
+<div class="judgment-sidebar__block">
+  <h4>{% translate "judgments.sidebar.manage" %}</h4>
+  <ul>
+    <li>
+      <a href="{% url 'move-judgment' judgment.uri %}">{% translate "judgment.movemerge" %}</a>
+    </li>
+    <li>
+      <a href="{% url 'unlock' %}?judgment_uri={{ judgment_uri }}">{% translate "judgment.unlock_judgment_title" %}</a>
+    </li>
+  </ul>
+</div>
+
 <div class="judgment-sidebar__block">
   <h4>{% translate "judgments.sidebar.tools" %}</h4>
   <ul>
@@ -31,15 +44,13 @@
          rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a>
     </li>
     <li>
-      <a href="{% url 'unlock' %}?judgment_uri={{ judgment_uri }}">{% translate "judgment.unlock_judgment_title" %}</a>
-    </li>
-    <li>
       <a href="https://docs.google.com/forms/d/e/1FAIpQLSckmLdeUAEoEoBc55ybFVmOsXPEM7CG2VbN2YNwsX6kL9UZ4Q/viewform?usp=pp_url&entry.2047884653=Yes&entry.6716552=A+specific+judgment+or+decision&entry.481919886={{ request.build_absolute_uri|urlencode }}&entry.350152829={{ judgment.consignment_reference|urlencode }}"
          target="_blank"
          rel="noopener noreferrer">{% translate "judgment.report_blocking_problem" %}</a>
     </li>
   </ul>
 </div>
+
 <div class="judgment-sidebar__block">
   <h4>{% translate "judgments.sidebar.assigned_to" %}</h4>
   <form action="{% url "assign" %}"

--- a/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
@@ -26,7 +26,7 @@
   <h4>{% translate "judgments.sidebar.manage" %}</h4>
   <ul>
     <li>
-      <a href="{% url 'move-judgment' judgment.uri %}">{% translate "judgment.movemerge" %}</a>
+      <a href="{% url 'move-judgment' judgment.uri %}">{% translate "judgment.change_ncn" %}</a>
     </li>
     <li>
       <a href="{% url 'unlock' %}?judgment_uri={{ judgment_uri }}">{% translate "judgment.unlock_judgment_title" %}</a>

--- a/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -20,7 +20,7 @@
         <span class="judgments-list__judgment-details-meta-value">{{ item.metadata.consignment_reference }}</span>
       </li>
       <li>
-        <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.ncn" %}</span>
+        <span class="judgments-list__judgment-details-meta-key">{% translate "judgment.neutral_citation" %}</span>
         <span class="judgments-list__judgment-details-meta-value">{{ item.neutral_citation }}</span>
       </li>
       <li>

--- a/ds_caselaw_editor_ui/templates/judgment/move.html
+++ b/ds_caselaw_editor_ui/templates/judgment/move.html
@@ -1,5 +1,21 @@
-<form action="{% url "move-judgment" judgment.uri %}" method="post">
-  {% csrf_token %}
-  {{ form }}
-  <input type="submit" value="Submit" />
-</form>
+{% extends "layouts/judgment_with_sidebar.html" %}
+{% load i18n %}
+{% block judgment_header %}
+  {% include "includes/judgment/metadata_panel_static.html" with judgment=judgment %}
+{% endblock judgment_header %}
+{% block judgment_content %}
+  <h2>Move and merge</h2>
+
+  <p>Use this form to <b>set the neutral citation</b> of this judgment.</p>
+
+    <ul>
+      <li>If there is no judgment with this neutral citation, this judgment will move to its new home. <b>This will change the document's URI</b>.</li>
+      <li>If there is already a judgment with this neutral citation, you will be able to compare this judgment to the existing one and merge the two, making this the most recent version at that URI.</li>
+    </ul>
+
+  <form action="{% url "move-judgment" judgment.uri %}" method="post">
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" value="Submit" />
+  </form>
+{% endblock judgment_content %}

--- a/ds_caselaw_editor_ui/templates/judgment/move.html
+++ b/ds_caselaw_editor_ui/templates/judgment/move.html
@@ -4,7 +4,7 @@
   {% include "includes/judgment/metadata_panel_static.html" with judgment=judgment %}
 {% endblock judgment_header %}
 {% block judgment_content %}
-  <h2>Move and merge</h2>
+  <h2>Change neutral citation number</h2>
   <p>
     Use this form to <b>set the neutral citation</b> of this judgment.
   </p>

--- a/ds_caselaw_editor_ui/templates/judgment/move.html
+++ b/ds_caselaw_editor_ui/templates/judgment/move.html
@@ -5,14 +5,17 @@
 {% endblock judgment_header %}
 {% block judgment_content %}
   <h2>Move and merge</h2>
-
-  <p>Use this form to <b>set the neutral citation</b> of this judgment.</p>
-
-    <ul>
-      <li>If there is no judgment with this neutral citation, this judgment will move to its new home. <b>This will change the document's URI</b>.</li>
-      <li>If there is already a judgment with this neutral citation, you will be able to compare this judgment to the existing one and merge the two, making this the most recent version at that URI.</li>
-    </ul>
-
+  <p>
+    Use this form to <b>set the neutral citation</b> of this judgment.
+  </p>
+  <ul>
+    <li>
+      If there is no judgment with this neutral citation, this judgment will move to its new home. <b>This will change the document's URI</b>.
+    </li>
+    <li>
+      If there is already a judgment with this neutral citation, you will be able to compare this judgment to the existing one and merge the two, making this the most recent version at that URI.
+    </li>
+  </ul>
   <form action="{% url "move-judgment" judgment.uri %}" method="post">
     {% csrf_token %}
     {{ form }}

--- a/ds_caselaw_editor_ui/templates/judgment/move.html
+++ b/ds_caselaw_editor_ui/templates/judgment/move.html
@@ -1,0 +1,5 @@
+<form action="{% url "move-judgment" judgment.uri %}" method="post">
+  {% csrf_token %}
+  {{ form }}
+  <input type="submit" value="Submit" />
+</form>

--- a/ds_caselaw_editor_ui/templates/judgment/overwrite.html
+++ b/ds_caselaw_editor_ui/templates/judgment/overwrite.html
@@ -1,0 +1,31 @@
+<h1>Overwrite!</h1>
+{{ incoming_judgment.uri }} will overwrite {{ target_judgment.uri }}
+<form action="{% url "overwrite-judgment" incoming_judgment.uri %}"
+      method="post">
+  {% csrf_token %}
+  {{ form }}
+  <input type="submit" value="Submit" />
+</form>
+<p>
+  Name: <b>{{ incoming_judgment.name }}</b> → <s>{{ target_judgment.name }}</s>
+</p>
+<p>
+  Court: <b>{{ incoming_judgment.court }}</b> → <s>{{ target_judgment.court }}</s>
+</p>
+<p>TODO: add more metadata</p>
+<div style="border:1px solid black;
+            height:100%;
+            width:48%;
+            overflow-y:scroll;
+            overflow-x:scroll;
+            float:left">
+  {{ incoming_judgment.content_as_html | safe }}
+</div>
+<div style="border:1px solid black;
+            height:100%;
+            width:48%;
+            overflow-y:scroll;
+            overflow-x:scroll;
+            float:left">
+  {{ target_judgment.content_as_html | safe }}
+</div>

--- a/ds_caselaw_editor_ui/templates/judgment/overwrite.html
+++ b/ds_caselaw_editor_ui/templates/judgment/overwrite.html
@@ -9,7 +9,8 @@
     This will <b>create a new version</b> of the judgment at {{ target_judgment.uri }}.
   </p>
   <form action="{% url "overwrite-judgment" incoming_judgment.uri %}"
-        method="post">
+        method="post"
+        class="edit-component">
     {% csrf_token %}
     {{ form }}
     <input type="submit" value="Submit" />

--- a/ds_caselaw_editor_ui/templates/judgment/overwrite.html
+++ b/ds_caselaw_editor_ui/templates/judgment/overwrite.html
@@ -16,12 +16,28 @@
     <input type="submit" value="Submit" />
   </form>
   <p>
-    Name: <b>{{ incoming_judgment.name }}</b> → <s>{{ target_judgment.name }}</s>
+    Location: <s>{{ incoming_judgment.uri }}</s> → <b>{{ target_judgment.uri }}</b>
   </p>
   <p>
-    Court: <b>{{ incoming_judgment.court }}</b> → <s>{{ target_judgment.court }}</s>
+    Neutral Citation: <b>{{ target_judgment.neutral_citation }}</b>
   </p>
-  <p>TODO: add more metadata</p>
+  <hr/>
+  <p>
+    Name: <b>{{ incoming_judgment.name|default:"(none)" }}</b> → <s>{{ target_judgment.name|default:"(none)" }}</s>
+  </p>
+  <p>
+    Court: <b>{{ incoming_judgment.court|default:"(none)" }}</b> → <s>{{ target_judgment.court|default:"(none)" }}</s>
+  </p>
+  <p>
+    Judgment date: <b>{{ incoming_judgment.judgment_date_as_string }}</b> → <s>{{ target_judgment.judgment_date_as_string }}</s>
+  </p>
+  <hr/>
+  <p>
+    Submitter name: <b>{{ incoming_judgment.source_name|default:"(none)" }}</b> → <s>{{ target_judgment.source_name|default:"(none)" }}</s>
+  </p>
+  <p>
+    Consignment reference: <b>{{ incoming_judgment.consignment_reference|default:"(none)" }}</b> → <s>{{ target_judgment.consigment_reference|default:"(none)" }}</s>
+  </p>
   <div style="border:1px solid black;
               height:100vh;
               width:48%;

--- a/ds_caselaw_editor_ui/templates/judgment/overwrite.html
+++ b/ds_caselaw_editor_ui/templates/judgment/overwrite.html
@@ -1,31 +1,40 @@
-<h1>Overwrite!</h1>
-{{ incoming_judgment.uri }} will overwrite {{ target_judgment.uri }}
-<form action="{% url "overwrite-judgment" incoming_judgment.uri %}"
-      method="post">
-  {% csrf_token %}
-  {{ form }}
-  <input type="submit" value="Submit" />
-</form>
-<p>
-  Name: <b>{{ incoming_judgment.name }}</b> → <s>{{ target_judgment.name }}</s>
-</p>
-<p>
-  Court: <b>{{ incoming_judgment.court }}</b> → <s>{{ target_judgment.court }}</s>
-</p>
-<p>TODO: add more metadata</p>
-<div style="border:1px solid black;
-            height:100%;
-            width:48%;
-            overflow-y:scroll;
-            overflow-x:scroll;
-            float:left">
-  {{ incoming_judgment.content_as_html | safe }}
-</div>
-<div style="border:1px solid black;
-            height:100%;
-            width:48%;
-            overflow-y:scroll;
-            overflow-x:scroll;
-            float:left">
-  {{ target_judgment.content_as_html | safe }}
-</div>
+{% extends "layouts/judgment.html" %}
+{% load i18n %}
+{% block judgment_header %}
+  {% include "includes/judgment/metadata_panel_static.html" with judgment=judgment %}
+{% endblock judgment_header %}
+{% block content %}
+  <h2>Compare and merge</h2>
+  <p>
+    This will <b>create a new version</b> of the judgment at {{ target_judgment.uri }}.
+  </p>
+  <form action="{% url "overwrite-judgment" incoming_judgment.uri %}"
+        method="post">
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" value="Submit" />
+  </form>
+  <p>
+    Name: <b>{{ incoming_judgment.name }}</b> → <s>{{ target_judgment.name }}</s>
+  </p>
+  <p>
+    Court: <b>{{ incoming_judgment.court }}</b> → <s>{{ target_judgment.court }}</s>
+  </p>
+  <p>TODO: add more metadata</p>
+  <div style="border:1px solid black;
+              height:100vh;
+              width:48%;
+              overflow-y:scroll;
+              overflow-x:scroll;
+              float:left">
+    {{ incoming_judgment.content_as_html | safe }}
+  </div>
+  <div style="border:1px solid black;
+              height:100vh;
+              width:48%;
+              overflow-y:scroll;
+              overflow-x:scroll;
+              float:left">
+    {{ target_judgment.content_as_html | safe }}
+  </div>
+{% endblock content %}

--- a/judgments/forms/judgment_move.py
+++ b/judgments/forms/judgment_move.py
@@ -1,0 +1,26 @@
+import ds_caselaw_utils as caselawutils
+from django import forms
+from django.core.exceptions import ValidationError
+
+
+class NeutralCitationField(forms.CharField):
+    def validate(self, value):
+        super().validate(value)
+
+        new_uri = caselawutils.neutral_url(value)
+
+        # if a URI is not generated, the citation is probably invalid
+        if not new_uri:
+            raise ValidationError(
+                f"Unable to parse neutral citation '{value}'", "invalid_citation"
+            )
+
+
+class MoveJudgmentForm(forms.Form):
+    neutral_citation = NeutralCitationField(label="New Neutral Citation")
+
+
+class OverwriteJudgmentForm(forms.Form):
+    neutral_citation = NeutralCitationField(
+        widget=forms.HiddenInput(), label="New Neutral Citation"
+    )

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -49,6 +49,13 @@ class JudgmentFactory:
                 "<p>This is a judgment.</p>"
             )
 
+        if "xml" in kwargs:
+            judgment_mock.return_value.content_as_xml.return_value = kwargs.pop("xml")
+        else:
+            judgment_mock.return_value.content_as_xml.return_value = (
+                "<akomantoso>This is some XML of a judgment.</akomantoso>"
+            )
+
         for map_to, map_from in cls.PARAMS_MAP.items():
             if map_from[0] in kwargs:
                 setattr(judgment_mock.return_value, map_to, kwargs[map_from[0]])

--- a/judgments/tests/test_move.py
+++ b/judgments/tests/test_move.py
@@ -1,0 +1,155 @@
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth.models import User
+from django.http import Http404
+from factories import JudgmentFactory
+
+
+def get_mock_judgment(uri):
+    if not uri:
+        raise Http404("empty uri")
+    if "bad" in uri or "666" in uri:
+        raise Http404("deliberate test failure")
+    if "good" in uri or "888" in uri:
+        return JudgmentFactory.build(uri=uri)
+
+
+@pytest.mark.django_db
+@patch("judgments.views.judgment_move.get_judgment_by_uri_or_404")
+def test_get_move(mock_judgment, client):
+    "We can get a /move page for a judgment that exists"
+    mock_judgment.side_effect = get_mock_judgment
+    client.force_login(User.objects.get_or_create(username="testuser")[0])
+    response = client.get("/good/2099/888/move")
+    assert response.status_code == 200
+    assert b"New Neutral Citation" in response.content
+
+
+@pytest.mark.django_db
+@patch("judgments.views.judgment_move.get_judgment_by_uri_or_404")
+def test_perform_move_invalid_target(mock_judgment, client):
+    "There is an error if the neutral citation is invalid"
+    mock_judgment.side_effect = get_mock_judgment
+    client.force_login(User.objects.get_or_create(username="testuser")[0])
+    response = client.post("/good/2099/888/move", {"neutral_citation": "jam"})
+    assert response.status_code == 200
+    assert b"Unable to parse" in response.content
+
+
+@pytest.mark.django_db
+@patch("judgments.views.judgment_move.get_judgment_by_uri_or_404")
+@patch("judgments.views.judgment_move.api_client")
+@patch("judgments.views.judgment_move.update_document_uri")
+def test_perform_move_present_target(
+    mock_update, mock_api_client, mock_judgment, client
+):
+    "Given an existing target, we should redirect to overwrite"
+    mock_api_client.judgment_exists.return_value = True
+    mock_judgment.side_effect = get_mock_judgment
+    client.force_login(User.objects.get_or_create(username="testuser")[0])
+    response = client.post("/good/2099/1/move", {"neutral_citation": "[2099] EAT 888"})
+    mock_api_client.set_judgment_citation.assert_not_called()
+    mock_update.assert_not_called()
+    assert response.status_code == 302
+    assert response.url == "/good/2099/1/overwrite?target=%5B2099%5D+EAT+888"
+    overwrite_response = client.get(response.url)
+    assert (
+        b'<input type="hidden" name="neutral_citation" value="[2099] EAT 888" id="id_neutral_citation">'
+        in overwrite_response.content
+    )
+
+
+@pytest.mark.django_db
+@patch("judgments.views.judgment_move.get_judgment_by_uri_or_404")
+@patch("judgments.views.judgment_move.api_client")
+@patch("judgments.views.judgment_move.update_document_uri")
+def test_perform_move_absent_target(
+    mock_update, mock_api_client, mock_judgment, client
+):
+    "Given an absent target, we should move the judgment to the new location"
+    mock_api_client.judgment_exists.return_value = False
+    mock_judgment.side_effect = get_mock_judgment
+    client.force_login(User.objects.get_or_create(username="testuser")[0])
+    response = client.post("/good/2099/1/move", {"neutral_citation": "[2099] EAT 888"})
+    mock_update.assert_called_with("good/2099/1", "[2099] EAT 888")
+    mock_api_client.set_judgment_citation.assert_called_with(
+        "/eat/2099/888", "[2099] EAT 888"
+    )
+    assert response.status_code == 302
+    assert response.url == "/eat/2099/888"
+
+
+########################################
+
+
+@pytest.mark.django_db
+@patch("judgments.views.judgment_move.get_judgment_by_uri_or_404")
+def test_get_overwrite(mock_judgment, client):
+    "We can get an overwrite page if there's a target"
+    mock_judgment.side_effect = get_mock_judgment
+    client.force_login(User.objects.get_or_create(username="testuser")[0])
+    response = client.get("/good/2099/888/overwrite?target=[2023]+EWCA+Civ+888")
+    assert response.status_code == 200
+    assert (
+        b'<input type="hidden" name="neutral_citation" value="[2023] EWCA Civ 888"'
+        in response.content
+    )
+
+
+@pytest.mark.django_db
+@patch("judgments.views.judgment_move.get_judgment_by_uri_or_404")
+def test_get_overwrite_no_such_target(mock_judgment, client):
+    "We do not get an overwrite page if there's no such target"
+    mock_judgment.side_effect = get_mock_judgment
+    client.force_login(User.objects.get_or_create(username="testuser")[0])
+    response = client.get("/good/2099/888/overwrite?target=[2023]+EWCA+Civ+666")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@patch("judgments.views.judgment_move.get_judgment_by_uri_or_404")
+def test_get_overwrite_no_such_source(mock_judgment, client):
+    "We do not get an overwrite page if there's no such source"
+    mock_judgment.side_effect = get_mock_judgment
+    client.force_login(User.objects.get_or_create(username="testuser")[0])
+    response = client.get("/good/2099/666/overwrite?target=[2023]+EWCA+Civ+888")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@patch("judgments.views.judgment_move.get_judgment_by_uri_or_404")
+def test_post_overwrite_invalid(mock_judgment, client):
+    mock_judgment.side_effect = get_mock_judgment
+    client.force_login(User.objects.get_or_create(username="testuser")[0])
+    response = client.post(
+        "/good/2099/888/overwrite?target=[2023]+EWCA+Civ+888",
+        {"neutral_citation": "jam"},
+    )
+    assert response.status_code == 200
+    assert b"Unable to parse" in response.content
+
+
+@pytest.mark.django_db
+@patch("judgments.utils.get_judgment_by_uri")
+@patch("judgments.views.judgment_move.get_judgment_by_uri_or_404")
+@patch("judgments.views.judgment_move.api_client")
+@patch("judgments.views.judgment_move.overwrite_judgment")
+def test_perform_overwrite_present_target(
+    mock_overwrite, mock_api_client, mock_judgment_or_404, mock_judgment_by_uri, client
+):
+    "Given an existing target, we should overwrite it"
+    mock_overwrite.return_value = "/eat/2099/888"
+    mock_api_client.judgment_exists.return_value = True
+    mock_judgment_or_404.side_effect = get_mock_judgment
+    client.force_login(User.objects.get_or_create(username="testuser")[0])
+    response = client.post(
+        "/good/2099/1/overwrite", {"neutral_citation": "[2099] EAT 888"}
+    )
+    mock_overwrite.assert_called_with("good/2099/1", "[2099] EAT 888")
+    mock_api_client.set_judgment_citation.assert_called_with(
+        "/eat/2099/888", "[2099] EAT 888"
+    )
+
+    assert response.status_code == 302
+    assert response.url == "/eat/2099/888"

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -23,6 +23,7 @@ from .views.judgment_hold import (
     hold,
     unhold,
 )
+from .views.judgment_move import MoveJudgmentView, OverwriteJudgmentView
 from .views.judgment_publish import (
     PublishJudgmentSuccessView,
     PublishJudgmentView,
@@ -116,6 +117,16 @@ urlpatterns = [
         "<path:judgment_uri>/unheld",
         UnholdJudgmentSuccessView.as_view(),
         name="unhold-judgment-success",
+    ),
+    path(
+        "<path:judgment_uri>/move",
+        MoveJudgmentView.as_view(),
+        name="move-judgment",
+    ),
+    path(
+        "<path:judgment_uri>/overwrite",
+        OverwriteJudgmentView.as_view(),
+        name="overwrite-judgment",
     ),
     path("<path:judgment_uri>/pdf", pdf_view, name="full-text-pdf"),
     path("<path:judgment_uri>/xml", xml_view, name="full-text-xml"),

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -24,6 +24,10 @@ class MoveJudgmentError(Exception):
     pass
 
 
+class OverwriteJudgmentError(Exception):
+    pass
+
+
 class NeutralCitationToUriError(Exception):
     pass
 
@@ -61,6 +65,50 @@ def get_judgment_root(judgment_xml) -> str:
         return parsed_xml.tag
     except ET.ParseError:
         return "error"
+
+
+def overwrite_judgment(old_uri, new_citation):
+    """Move the judgment at old_uri on top of the new citation, which must already exist
+    Compare to update_document_uri"""
+    new_uri = caselawutils.neutral_url(new_citation.strip())
+
+    if new_uri == old_uri:
+        raise RuntimeError(f"trying to overwrite yourself, {old_uri}")
+    if new_uri is None:
+        raise NeutralCitationToUriError(
+            f"Unable to form new URI for {old_uri} from neutral citation: {new_citation}"
+        )
+    if not api_client.judgment_exists(new_uri):
+        raise OverwriteJudgmentError(
+            f"The URI {new_uri} generated from {new_citation} does not already exist, so cannot be overwritten"
+        )
+    old_judgment = get_judgment_by_uri(old_uri)
+
+    try:
+        old_judgment_bytes = old_judgment.content_as_xml()
+        old_judgment_xml = ET.XML(bytes(old_judgment_bytes, encoding="utf-8"))
+        api_client.save_judgment_xml(
+            new_uri,
+            old_judgment_xml,
+            annotation=f"overwritten from {old_uri}",
+        )
+        set_metadata(old_uri, new_uri)
+        # TODO: consider deleting existing public assets at that location
+        copy_assets(old_uri, new_uri)
+        api_client.set_judgment_this_uri(new_uri)
+    except MarklogicAPIError as e:
+        raise OverwriteJudgmentError(
+            f"Failure when attempting to copy judgment from {old_uri} to {new_uri}: {e}"
+        )
+
+    try:
+        api_client.delete_judgment(old_uri)
+    except MarklogicAPIError as e:
+        raise OverwriteJudgmentError(
+            f"Failure when attempting to delete judgment from {old_uri}: {e}"
+        )
+
+    return new_uri
 
 
 def update_document_uri(old_uri, new_citation):

--- a/judgments/views/judgment_move.py
+++ b/judgments/views/judgment_move.py
@@ -85,6 +85,7 @@ class OverwriteJudgmentView(FormView):
         context["target_judgment"] = get_judgment_by_uri_or_404(
             caselawutils.neutral_url(target_neutral_citation)
         )
+        context["judgment"] = context["incoming_judgment"]
 
         return context
 

--- a/judgments/views/judgment_move.py
+++ b/judgments/views/judgment_move.py
@@ -1,0 +1,107 @@
+from typing import Any, Dict
+from urllib.parse import urlencode
+
+import ds_caselaw_utils as caselawutils
+from caselawclient.Client import api_client
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.views.generic import FormView
+
+from judgments.forms.judgment_move import MoveJudgmentForm, OverwriteJudgmentForm
+from judgments.utils import overwrite_judgment, update_document_uri
+from judgments.utils.view_helpers import get_judgment_by_uri_or_404
+
+
+class MoveJudgmentView(FormView):
+    template_name = "judgment/move.html"
+    form_class = MoveJudgmentForm
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        context = super(MoveJudgmentView, self).get_context_data(**kwargs)
+        context["judgment"] = get_judgment_by_uri_or_404(self.kwargs["judgment_uri"])
+        return context
+
+    def form_valid(self, form):
+        old_judgment = get_judgment_by_uri_or_404(self.kwargs["judgment_uri"])
+        old_uri = old_judgment.uri
+        new_citation = form.cleaned_data["neutral_citation"]
+        new_uri = caselawutils.neutral_url(new_citation)
+
+        # if both URIs match, just update the neutral citation, there's not need to move.
+        if new_uri.strip("/") == old_uri.strip("/"):
+            api_client.set_judgment_citation(old_uri, new_citation)
+            messages.success(
+                self.request, "Updated neutral citation (did not move judgment)"
+            )
+            return redirect(new_uri)
+
+        # there is an existing document at the URI
+        elif api_client.judgment_exists(new_uri):
+            # TODO: allow editors to see the two judgments and compare notes
+            # TODO: tests
+            # overwrite_judgment(old_uri, new_citation)
+            # api_client.set_judgment_citation(new_uri, new_citation)
+            # messages.success(
+            #     self.request, f"Updated {new_uri} with content from {old_uri}"
+            # )
+            return redirect(
+                "{path}?{params}".format(
+                    path=reverse(
+                        "overwrite-judgment", kwargs={"judgment_uri": old_judgment.uri}
+                    ),
+                    params=urlencode({"target": new_citation}),
+                )
+            )
+
+        else:
+            # the new document does not exist, we can just create it, using the existing behaviour
+            update_document_uri(old_uri, new_citation)
+            api_client.set_judgment_citation(new_uri, new_citation)
+            # this will fail locally unless localstack is running as it will also update S3.
+
+            messages.success(
+                self.request, f"Successfully moved document at {old_uri} to {new_uri}"
+            )
+            return redirect(new_uri)
+
+
+class OverwriteJudgmentView(FormView):
+    # TODO: handle change of collections
+    template_name = "judgment/overwrite.html"
+    form_class = OverwriteJudgmentForm
+
+    def get_initial(self):
+        return {"neutral_citation": self.request.GET.get("target", None)}
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        target_neutral_citation = self.request.GET.get("target", default=None)
+        if not target_neutral_citation:
+            raise RuntimeError("The overwriter did not get a target to overwrite")
+        context = super(OverwriteJudgmentView, self).get_context_data(**kwargs)
+        context["incoming_judgment"] = get_judgment_by_uri_or_404(
+            self.kwargs["judgment_uri"]
+        )
+        context["target_judgment"] = get_judgment_by_uri_or_404(
+            caselawutils.neutral_url(target_neutral_citation)
+        )
+
+        return context
+
+    def form_valid(self, form):
+        source_judgment = get_judgment_by_uri_or_404(self.kwargs["judgment_uri"])
+        source_uri = source_judgment.uri
+        target_citation = form.cleaned_data["neutral_citation"]
+        target_uri = caselawutils.neutral_url(target_citation)
+        if not api_client.judgment_exists(target_uri):
+            raise RuntimeError("Tried to overwrite something that didn't exist")
+        # if both URIs match, just update the neutral citation, there's not need to move.
+        if target_uri.strip("/") == source_uri.strip("/"):
+            raise RuntimeError("collision: should have been handled in edit")
+
+        overwrite_judgment(source_uri, target_citation)
+        api_client.set_judgment_citation(target_uri, target_citation)
+        messages.success(
+            self.request, f"Updated {target_uri} with content from {source_uri}"
+        )
+        return redirect(target_uri)

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -117,8 +117,8 @@ msgid "judgments.sidebar.manage"
 msgstr "Manage"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
-msgid "judgment.movemerge"
-msgstr "Move and merge"
+msgid "judgment.change_ncn"
+msgstr "Change neutral citation number"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.sidebar.tools"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -54,6 +54,8 @@ msgid "feedback.link"
 msgstr "Report a problem to the digital team"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 #: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.neutral_citation"
 msgstr "NCN"
@@ -82,11 +84,6 @@ msgstr "Name"
 #: judgments/utils/link_generators.py
 msgid "judgments.consignmentref"
 msgstr "TDR Ref"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
-msgid "judgments.ncn"
-msgstr "NCN"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -121,18 +118,18 @@ msgid "judgment.change_ncn"
 msgstr "Change neutral citation number"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
+#: judgments/views/unlock.py
+msgid "judgment.unlock_judgment_title"
+msgstr "Unlock judgment"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.sidebar.tools"
 msgstr "External Tools"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgment.create_in_jira"
 msgstr "Create in Jira"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
-#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
-#: judgments/views/unlock.py
-msgid "judgment.unlock_judgment_title"
-msgstr "Unlock document"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgment.report_blocking_problem"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -58,7 +58,7 @@ msgstr "Report a problem to the digital team"
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 #: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.neutral_citation"
-msgstr "NCN"
+msgstr "Neutral citation"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
 #: ds_caselaw_editor_ui/templates/judgment/edit.html

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -113,8 +113,16 @@ msgid "judgments.submitteremail"
 msgstr "Contact email"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+msgid "judgments.sidebar.manage"
+msgstr "Manage"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+msgid "judgment.movemerge"
+msgstr "Move and merge"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.sidebar.tools"
-msgstr "Tools"
+msgstr "External Tools"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgment.create_in_jira"


### PR DESCRIPTION
This provides a new workflow for editors to update the NCN of a judgment (aka the "move" workflow). Updating an NCN will also update the URI of a judgment, and making editors use this workflow provides an opportunity to more fully explain the consequences of doing so.

This workflow will also (in a somewhat hidden way) let you append one document to another as an updated version (aka the "merge" workflow). This is always available if a document is given the same NCN as another, but this functionality isn't advertised.

Upcoming changes to the ingester will allow documents in this 'colliding' state to be surfaced and editors offered the "merge" workflow.