### PR TITLE
FCL 29: refactor tests to support judgment exception

### DIFF
--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from urllib.parse import urlencode
 
 from django.contrib.auth.models import User
-from django.http import Http404
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.translation import gettext
@@ -267,7 +266,6 @@ class TestJudgmentView(TestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-
     def test_judgment_xml_view_redirect(self):
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])
         response = self.client.get("/xml?judgment_uri=ewca/civ/2004/63X")
@@ -474,7 +472,6 @@ class TestJudgmentUnhold(TestCase):
         mock_judgment.return_value.hold.assert_not_called()
         mock_invalidate_caches.assert_called_once()
 
-
     @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
     def test_judgment_hold_success_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
@@ -549,7 +546,6 @@ class TestJudgmentUnpublish(TestCase):
         mock_judgment.return_value.publish.assert_not_called()
         mock_judgment.return_value.unpublish.assert_called_once()
         mock_invalidate_caches.assert_called_once()
-
 
     @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
     def test_judgment_unpublish_success_view(self, mock_judgment):

--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -2,8 +2,8 @@ import re
 from unittest.mock import patch
 from urllib.parse import urlencode
 
-from caselawclient.Client import MarklogicResourceNotFoundError
 from django.contrib.auth.models import User
+from django.http import Http404
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.translation import gettext
@@ -15,7 +15,7 @@ def assert_match(regex, string):
 
 
 class TestJudgmentEdit(TestCase):
-    @patch("judgments.views.judgment_edit.get_judgment_by_uri")
+    @patch("judgments.views.judgment_edit.get_judgment_by_uri_or_404")
     def test_judgment_edit_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="edtest/4321/123",
@@ -44,7 +44,7 @@ class TestJudgmentEdit(TestCase):
 
     @patch("judgments.views.judgment_edit.invalidate_caches")
     @patch("judgments.views.judgment_edit.api_client")
-    @patch("judgments.views.judgment_edit.get_judgment_by_uri")
+    @patch("judgments.views.judgment_edit.get_judgment_by_uri_or_404")
     def test_judgment_publish_flow(
         self, mock_judgment, mock_api_client, mock_invalidate_caches
     ):
@@ -80,7 +80,7 @@ class TestJudgmentEdit(TestCase):
 
     @patch("judgments.views.judgment_edit.invalidate_caches")
     @patch("judgments.views.judgment_edit.api_client")
-    @patch("judgments.views.judgment_edit.get_judgment_by_uri")
+    @patch("judgments.views.judgment_edit.get_judgment_by_uri_or_404")
     def test_judgment_publish_flow_if_published(
         self, mock_judgment, mock_api_client, mock_invalidate_caches
     ):
@@ -115,7 +115,7 @@ class TestJudgmentEdit(TestCase):
 
     @patch("judgments.views.judgment_edit.invalidate_caches")
     @patch("judgments.views.judgment_edit.api_client")
-    @patch("judgments.views.judgment_edit.get_judgment_by_uri")
+    @patch("judgments.views.judgment_edit.get_judgment_by_uri_or_404")
     def test_judgment_unpublish_flow(
         self, mock_judgment, mock_api_client, mock_invalidate_caches
     ):
@@ -150,7 +150,7 @@ class TestJudgmentEdit(TestCase):
 
     @patch("judgments.views.judgment_edit.invalidate_caches")
     @patch("judgments.views.judgment_edit.api_client")
-    @patch("judgments.views.judgment_edit.get_judgment_by_uri")
+    @patch("judgments.views.judgment_edit.get_judgment_by_uri_or_404")
     def test_judgment_unpublish_flow_if_not_published(
         self, mock_judgment, mock_api_client, mock_invalidate_caches
     ):
@@ -184,7 +184,7 @@ class TestJudgmentEdit(TestCase):
 
 
 class TestJudgmentView(TestCase):
-    @patch("judgments.views.full_text.get_judgment_by_uri")
+    @patch("judgments.views.full_text.get_judgment_by_uri_or_404")
     def test_judgment_html_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="hvtest/4321/123",
@@ -209,7 +209,7 @@ class TestJudgmentView(TestCase):
         self.assertIn("<h1>Test Judgment</h1>", decoded_response)
         assert response.status_code == 200
 
-    @patch("judgments.views.full_text.get_judgment_by_uri")
+    @patch("judgments.views.full_text.get_judgment_by_uri_or_404")
     def test_judgment_html_view_with_failure(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="hvtest/4321/123",
@@ -227,17 +227,6 @@ class TestJudgmentView(TestCase):
         decoded_response = response.content.decode("utf-8")
         self.assertIn("&lt;h1&gt;Test Judgment&lt;/h1&gt;", decoded_response)
         assert response.status_code == 200
-
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_html_view_not_found_response(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-        response = self.client.get("/ewca/civ/2004/63X")
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn("Judgment was not found", decoded_response)
-        self.assertEqual(response.status_code, 404)
 
     def test_judgment_html_view_redirect(self):
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])
@@ -264,18 +253,7 @@ class TestJudgmentView(TestCase):
         )
 
     @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_pdf_view_not_found_response(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-        response = self.client.get("/test/1234/pdf")
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn("Judgment was not found", decoded_response)
-        self.assertEqual(response.status_code, 404)
-
-    @patch(
-        "judgments.views.full_text.get_judgment_by_uri",
+        "judgments.views.full_text.get_judgment_by_uri_or_404",
     )
     def test_judgment_pdf_view_no_pdf_response(self, mock_judgment):
         mock_judgment.return_value.name = "JUDGMENT v JUDGEMENT"
@@ -289,16 +267,6 @@ class TestJudgmentView(TestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_xml_view_not_found_response(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-        response = self.client.get("/ewca/civ/2004/63X/xml")
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn("Judgment was not found", decoded_response)
-        self.assertEqual(response.status_code, 404)
 
     def test_judgment_xml_view_redirect(self):
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])
@@ -310,7 +278,7 @@ class TestJudgmentView(TestCase):
 
 
 class TestJudgmentPublish(TestCase):
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri")
+    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
     def test_judgment_publish_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
@@ -332,7 +300,7 @@ class TestJudgmentPublish(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.judgment_publish.invalidate_caches")
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri")
+    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
     def test_judgment_publish_flow(self, mock_judgment, mock_invalidate_caches):
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
@@ -358,35 +326,7 @@ class TestJudgmentPublish(TestCase):
         mock_judgment.return_value.unpublish.assert_not_called()
         mock_invalidate_caches.assert_called_once()
 
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_publish_view_missing_uri(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-
-        response = self.client.post(
-            reverse("publish"),
-            data={},
-        )
-        assert response.status_code == 400
-
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_publish_view_invalid_uri(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-
-        response = self.client.post(
-            reverse("publish"),
-            data={
-                "judgment_uri": "invalid",
-            },
-        )
-        assert response.status_code == 400
-
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri")
+    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
     def test_judgment_publish_success_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
@@ -413,7 +353,7 @@ class TestJudgmentPublish(TestCase):
 
 
 class TestJudgmentHold(TestCase):
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri")
+    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
     def test_judgment_hold_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="holdtest/4321/123",
@@ -435,7 +375,7 @@ class TestJudgmentHold(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.judgment_hold.invalidate_caches")
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri")
+    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
     def test_judgment_hold_flow(self, mock_judgment, mock_invalidate_caches):
         judgment = JudgmentFactory.build(
             uri="holdtest/4321/123",
@@ -461,35 +401,7 @@ class TestJudgmentHold(TestCase):
         mock_judgment.return_value.unhold.assert_not_called()
         mock_invalidate_caches.assert_called_once()
 
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_hold_view_missing_uri(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-
-        response = self.client.post(
-            reverse("hold"),
-            data={},
-        )
-        assert response.status_code == 400
-
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_hold_view_invalid_uri(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-
-        response = self.client.post(
-            reverse("hold"),
-            data={
-                "judgment_uri": "invalid",
-            },
-        )
-        assert response.status_code == 400
-
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri")
+    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
     def test_judgment_hold_success_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="holdtest/4321/123",
@@ -514,7 +426,7 @@ class TestJudgmentHold(TestCase):
 
 
 class TestJudgmentUnhold(TestCase):
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri")
+    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
     def test_judgment_unhold_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="unholdtest/4321/123",
@@ -536,7 +448,7 @@ class TestJudgmentUnhold(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.judgment_hold.invalidate_caches")
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri")
+    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
     def test_judgment_unhold_flow(self, mock_judgment, mock_invalidate_caches):
         judgment = JudgmentFactory.build(
             uri="unholdtest/4321/123",
@@ -562,35 +474,8 @@ class TestJudgmentUnhold(TestCase):
         mock_judgment.return_value.hold.assert_not_called()
         mock_invalidate_caches.assert_called_once()
 
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_unhold_view_missing_uri(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
 
-        response = self.client.post(
-            reverse("unhold"),
-            data={},
-        )
-        assert response.status_code == 400
-
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_unhold_view_invalid_uri(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-
-        response = self.client.post(
-            reverse("unhold"),
-            data={
-                "judgment_uri": "invalid",
-            },
-        )
-        assert response.status_code == 400
-
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri")
+    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
     def test_judgment_hold_success_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="unholdtest/4321/123",
@@ -615,7 +500,7 @@ class TestJudgmentUnhold(TestCase):
 
 
 class TestJudgmentUnpublish(TestCase):
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri")
+    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
     def test_judgment_unpublish_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
@@ -639,7 +524,7 @@ class TestJudgmentUnpublish(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.judgment_publish.invalidate_caches")
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri")
+    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
     def test_judgment_unpublish_flow(self, mock_judgment, mock_invalidate_caches):
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
@@ -665,35 +550,8 @@ class TestJudgmentUnpublish(TestCase):
         mock_judgment.return_value.unpublish.assert_called_once()
         mock_invalidate_caches.assert_called_once()
 
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_unpublish_view_missing_uri(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
 
-        response = self.client.post(
-            reverse("unpublish"),
-            data={},
-        )
-        assert response.status_code == 400
-
-    @patch(
-        "caselawclient.models.judgments.MarklogicApiClient.get_judgment_citation",
-        side_effect=MarklogicResourceNotFoundError(),
-    )
-    def test_judgment_unpublish_view_invalid_uri(self, mock_api_client):
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-
-        response = self.client.post(
-            reverse("unpublish"),
-            data={
-                "judgment_uri": "invalid",
-            },
-        )
-        assert response.status_code == 400
-
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri")
+    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
     def test_judgment_unpublish_success_view(self, mock_judgment):
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",

--- a/judgments/tests/test_unlock.py
+++ b/judgments/tests/test_unlock.py
@@ -22,7 +22,7 @@ def test_break_lock_confirm_page():
 
 
 @pytest.mark.django_db
-@patch("judgments.views.unlock.get_judgment_by_uri")
+@patch("judgments.views.unlock.get_judgment_by_uri_or_404")
 @patch("judgments.views.unlock.api_client.break_checkout")
 @patch("judgments.views.unlock.messages")
 def test_break_lock_post(messages, break_checkout, mock_judgment):

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import ds_caselaw_utils
 import pytest
-from caselawclient.errors import JudgmentNotFoundError, MarklogicAPIError
+from caselawclient.errors import MarklogicAPIError
 from django.contrib.auth.models import Group
 from django.test import TestCase
 from factories import JudgmentFactory, UserFactory
@@ -108,12 +108,10 @@ class TestUtils(TestCase):
 
     @patch("judgments.utils.api_client")
     @patch("boto3.session.Session.client")
-    def test_update_judgment_uri_success(
-        self, fake_boto3_client, fake_api_client
-    ):
+    def test_update_judgment_uri_success(self, fake_boto3_client, fake_api_client):
         """Given the target judgment does not exist,
-           we continue to move the judgment to the new location
-           (where moving is copy + delete)"""
+        we continue to move the judgment to the new location
+        (where moving is copy + delete)"""
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
         fake_api_client.judgment_exists.return_value = False
         fake_api_client.copy_judgment.return_value = True
@@ -146,7 +144,7 @@ class TestUtils(TestCase):
     @patch("judgments.utils.get_judgment_by_uri")
     def test_update_judgment_uri_exception_copy(self, fake_judgment, fake_client):
         """Given a judgment exists at the target, and copy_judgment fails,
-            we raise a MoveJudgmentError"""
+        we raise a MoveJudgmentError"""
         fake_judgment.return_value = JudgmentFactory.build()
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
         fake_client.copy_judgment.side_effect = MarklogicAPIError
@@ -159,7 +157,7 @@ class TestUtils(TestCase):
     @patch("judgments.utils.get_judgment_by_uri")
     def test_update_judgment_uri_exception_delete(self, fake_getter, fake_client):
         """If there's a target at the judgment and deleting fails,
-           raise a MoveJudgmentError"""
+        raise a MoveJudgmentError"""
         fake_getter.return_value = JudgmentFactory.build()
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
         fake_client.copy_judgment.return_value = True

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock, Mock, patch
 
 import ds_caselaw_utils
 import pytest
-from caselawclient.Client import MarklogicAPIError
+from caselawclient.errors import JudgmentNotFoundError, MarklogicAPIError
 from django.contrib.auth.models import Group
 from django.test import TestCase
-from factories import UserFactory
+from factories import JudgmentFactory, UserFactory
 
 import judgments
 from judgments.utils import (
@@ -108,16 +108,17 @@ class TestUtils(TestCase):
 
     @patch("judgments.utils.api_client")
     @patch("boto3.session.Session.client")
-    def test_update_judgment_uri_success(self, fake_boto3_client, fake_api_client):
+    def test_update_judgment_uri_success(
+        self, fake_boto3_client, fake_api_client
+    ):
+        """Given the target judgment does not exist,
+           we continue to move the judgment to the new location
+           (where moving is copy + delete)"""
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        api_attrs = {
-            "get_judgment_xml.side_effect": MarklogicAPIError,
-            "copy_judgment.return_value": True,
-            "delete_judgment.return_value": True,
-        }
-        fake_api_client.configure_mock(**api_attrs)
-        boto_attrs: dict[str, list] = {"list_objects.return_value": []}
-        fake_boto3_client.configure_mock(**boto_attrs)
+        fake_api_client.judgment_exists.return_value = False
+        fake_api_client.copy_judgment.return_value = True
+        fake_api_client.delete_judgment.return_value = True
+        fake_boto3_client.list_objects.return_value = []
 
         result = update_judgment_uri("old/uri", "[2002] EAT 1")
 
@@ -127,43 +128,42 @@ class TestUtils(TestCase):
 
     @patch("judgments.utils.api_client")
     @patch("boto3.session.Session.client")
+    @patch("judgments.utils.get_judgment_by_uri")
     def test_update_judgment_uri_strips_whitespace(
-        self, fake_boto3_client, fake_api_client
+        self, fake_getter, fake_boto3_client, fake_api_client
     ):
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        api_attrs = {
-            "get_judgment_xml.side_effect": MarklogicAPIError,
-            "copy_judgment.return_value": True,
-            "delete_judgment.return_value": True,
-        }
-        fake_api_client.configure_mock(**api_attrs)
-        boto_attrs: dict[str, list] = {"list_objects.return_value": []}
-        fake_boto3_client.configure_mock(**boto_attrs)
+        fake_api_client.copy_judgment.return_value = True
+        fake_api_client.delete_judgment.return_value = True
+        fake_api_client.judgment_exists.return_value = False
+        fake_boto3_client.list_objects.return_value = []
 
         update_judgment_uri("old/uri", " [2002] EAT 1 ")
 
         ds_caselaw_utils.neutral_url.assert_called_with("[2002] EAT 1")
 
     @patch("judgments.utils.api_client")
-    def test_update_judgment_uri_exception_copy(self, fake_client):
+    @patch("judgments.utils.get_judgment_by_uri")
+    def test_update_judgment_uri_exception_copy(self, fake_judgment, fake_client):
+        """Given a judgment exists at the target, and copy_judgment fails,
+            we raise a MoveJudgmentError"""
+        fake_judgment.return_value = JudgmentFactory.build()
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        attrs = {
-            "copy_judgment.side_effect": MarklogicAPIError,
-            "delete_judgment.return_value": True,
-        }
-        fake_client.configure_mock(**attrs)
+        fake_client.copy_judgment.side_effect = MarklogicAPIError
+        fake_client.delete_judgment.side_effect = True
 
         with self.assertRaises(judgments.utils.MoveJudgmentError):
             update_judgment_uri("old/uri", "[2002] EAT 1")
 
     @patch("judgments.utils.api_client")
-    def test_update_judgment_uri_exception_delete(self, fake_client):
+    @patch("judgments.utils.get_judgment_by_uri")
+    def test_update_judgment_uri_exception_delete(self, fake_getter, fake_client):
+        """If there's a target at the judgment and deleting fails,
+           raise a MoveJudgmentError"""
+        fake_getter.return_value = JudgmentFactory.build()
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        attrs = {
-            "copy_judgment.return_value": True,
-            "delete_judgment.side_effect": MarklogicAPIError,
-        }
-        fake_client.configure_mock(**attrs)
+        fake_client.copy_judgment.return_value = True
+        fake_client.delete_judgment.side_effect = MarklogicAPIError
 
         with self.assertRaises(judgments.utils.MoveJudgmentError):
             update_judgment_uri("old/uri", "[2002] EAT 1")
@@ -176,12 +176,7 @@ class TestUtils(TestCase):
 
     @patch("judgments.utils.api_client")
     def test_update_judgment_uri_duplicate_uri(self, fake_client):
-        ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        attrs = {
-            "get_judgment_xml.return_value": "<akomaNtoso><judgment></judgment></akomaNtoso>",
-        }
-        fake_client.configure_mock(**attrs)
-
+        fake_client.judgment_exists.return_value = True
         with self.assertRaises(judgments.utils.MoveJudgmentError):
             update_judgment_uri("old/uri", "[2002] EAT 1")
 

--- a/judgments/tests/test_view_helpers.py
+++ b/judgments/tests/test_view_helpers.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+
+import pytest
+from caselawclient.errors import JudgmentNotFoundError
+from django.http import Http404
+from factories import JudgmentFactory
+
+from judgments.utils.view_helpers import get_judgment_by_uri_or_404
+
+
+class TestGetPublishedJudgment:
+    @patch("judgments.utils.view_helpers.get_judgment_by_uri")
+    def test_published_judgment_returns(self, mock_judgment):
+        judgment = JudgmentFactory.build(is_published=True)
+        mock_judgment.return_value = judgment
+        assert get_judgment_by_uri_or_404("2022/eat/1") == judgment
+
+    @patch("judgments.utils.view_helpers.get_judgment_by_uri")
+    def test_unpublished_judgment_returns(self, mock_judgment):
+        judgment = JudgmentFactory.build(is_published=False)
+        mock_judgment.return_value = judgment
+        assert get_judgment_by_uri_or_404("2022/eat/1") == judgment
+
+    @patch(
+        "judgments.utils.view_helpers.get_judgment_by_uri",
+        side_effect=JudgmentNotFoundError,
+    )
+    def test_judgment_missing(self, mock_judgment):
+        with pytest.raises(Http404):
+            get_judgment_by_uri_or_404("not-a-judgment")

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -6,11 +6,9 @@ from urllib.parse import urlparse
 
 import ds_caselaw_utils as caselawutils
 from caselawclient.Client import MarklogicApiClient, MarklogicAPIError, api_client
-from caselawclient.errors import JudgmentNotFoundError
 from caselawclient.models.judgments import Judgment
 from django.conf import settings
 from django.contrib.auth.models import Group, User
-from django.http import Http404
 
 from .aws import copy_assets
 

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -1,4 +1,8 @@
+from caselawclient.errors import JudgmentNotFoundError
+from django.http import Http404
+
 from judgments.models import SearchResult
+from judgments.utils import Judgment, get_judgment_by_uri
 from judgments.utils.paginator import paginator
 from judgments.utils.perform_advanced_search import perform_advanced_search
 
@@ -36,3 +40,10 @@ def get_search_results(query):
         "order": query["order"],
         "paginator": paginator(query["page"], model.total),
     }
+
+
+def get_judgment_by_uri_or_404(uri: str) -> Judgment:
+    try:
+        return get_judgment_by_uri(uri)
+    except JudgmentNotFoundError:
+        raise Http404(f"Judgment not found at {uri}")

--- a/judgments/views/delete.py
+++ b/judgments/views/delete.py
@@ -1,10 +1,11 @@
-from caselawclient.Client import MarklogicResourceNotFoundError, api_client
+from caselawclient.Client import api_client
 from django.contrib import messages
-from django.http import Http404, HttpResponse
+from django.http import HttpResponse
 from django.template import loader
 from django.utils.translation import gettext
 
 from judgments.utils.aws import delete_documents
+from judgments.utils.view_helpers import get_judgment_by_uri_or_404
 
 
 def delete(request):
@@ -13,12 +14,10 @@ def delete(request):
         "judgment_uri": judgment_uri,
         "page_title": gettext("judgment.delete_a_judgment"),
     }
-    try:
-        api_client.delete_judgment(judgment_uri)
 
-        delete_documents(judgment_uri)
-    except MarklogicResourceNotFoundError as e:
-        raise Http404(f"Judgment was not found at uri {judgment_uri}, {e}")
+    judgment = get_judgment_by_uri_or_404(judgment_uri)
+    api_client.delete_judgment(judgment.uri)
+    delete_documents(judgment.uri)
 
     template = loader.get_template("judgment/deleted.html")
 

--- a/judgments/views/index.py
+++ b/judgments/views/index.py
@@ -1,17 +1,11 @@
-from caselawclient.Client import MarklogicResourceNotFoundError
-from django.http import Http404, HttpResponse
+from django.http import HttpResponse
 from django.template import loader
 
 from judgments.utils.view_helpers import get_search_parameters, get_search_results
 
 
 def index(request):
-    try:
-        query = get_search_parameters(request.GET, only_unpublished=True)
-        context = get_search_results(query)
-    except MarklogicResourceNotFoundError as e:
-        raise Http404(
-            f"Search results not found, {e}"
-        )  # TODO: This should be something else!
+    query = get_search_parameters(request.GET, only_unpublished=True)
+    context = get_search_results(query)
     template = loader.get_template("pages/home.html")
     return HttpResponse(template.render(context, request))

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -16,10 +16,10 @@ from judgments.utils import (
     MoveJudgmentError,
     NeutralCitationToUriError,
     editors_dict,
-    get_judgment_by_uri,
     update_judgment_uri,
 )
 from judgments.utils.aws import invalidate_caches
+from judgments.utils.view_helpers import get_judgment_by_uri_or_404
 
 
 def build_email_link_with_content(address, subject, body=None):
@@ -104,7 +104,7 @@ class EditJudgmentView(View):
 
     def get(self, request, *args, **kwargs):
         judgment_uri = kwargs["judgment_uri"]
-        judgment = get_judgment_by_uri(judgment_uri)
+        judgment = get_judgment_by_uri_or_404(judgment_uri)
 
         context = {"judgment_uri": judgment_uri}
 
@@ -133,7 +133,7 @@ class EditJudgmentView(View):
 
     def post(self, request, *args, **kwargs):
         judgment_uri = request.POST["judgment_uri"]
-        judgment = get_judgment_by_uri(judgment_uri)
+        judgment = get_judgment_by_uri_or_404(judgment_uri)
 
         return_to = request.POST.get("return_to", None)
 

--- a/judgments/views/unlock.py
+++ b/judgments/views/unlock.py
@@ -1,8 +1,4 @@
-from caselawclient.Client import (
-    MarklogicResourceNotFoundError,
-    MarklogicResourceUnmanagedError,
-    api_client,
-)
+from caselawclient.Client import MarklogicResourceUnmanagedError, api_client
 from django.contrib import messages
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
@@ -11,7 +7,7 @@ from django.urls import reverse
 from django.utils.translation import gettext
 from django.views.decorators.http import require_http_methods
 
-from judgments.utils import get_judgment_by_uri
+from judgments.utils.view_helpers import get_judgment_by_uri_or_404
 
 
 @require_http_methods(["POST", "GET", "HEAD"])
@@ -39,15 +35,11 @@ def unlock_post(request):
 
     judgment_uri = request.POST.get("judgment_uri")
     try:
-        judgment = get_judgment_by_uri(judgment_uri)
+        judgment = get_judgment_by_uri_or_404(judgment_uri)
         api_client.break_checkout(judgment.uri)
     except MarklogicResourceUnmanagedError as exc:
         raise Http404(
             f"Resource Unmanaged: Judgment '{judgment_uri}' might not exist."
-        ) from exc
-    except MarklogicResourceNotFoundError as exc:
-        raise Http404(
-            f"Resource Not Found: Judgment '{judgment_uri}' was not found."
         ) from exc
     else:
         messages.success(request, "Judgment unlocked.")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ requests-toolbelt~=1.0.0
 lxml~=4.9.2
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==6.1.0
+ds-caselaw-marklogic-api-client==7.0.0
 ds-caselaw-utils~=1.0.0
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
A number of editor tests fail because we've changed how we check if a judgment is present, so the mocks were wrong.

**REQUIRES** v7 of the custom-api-client

Ready to review, but **not** ready to merge!