### PR TITLE
Add thousands separator to the number of search results

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -65,7 +65,7 @@ DJANGO_APPS = [
     "django.contrib.sites",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    # "django.contrib.humanize", # Handy template tags
+    "django.contrib.humanize",
     "django.contrib.admin",
     "django.forms",
 ]

--- a/ds_caselaw_editor_ui/templates/judgment/results.html
+++ b/ds_caselaw_editor_ui/templates/judgment/results.html
@@ -1,5 +1,5 @@
 {% extends "layouts/base.html" %}
-{% load i18n %}
+{% load i18n humanize %}
 {% block title %}
   {% translate "results.search.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}
@@ -12,7 +12,7 @@
       <div class="judgments-list__container">
         <div class="judgments-list__judgments-list-controls-container">
           <div class="results__result-header">
-            <p id="recently-published-judgments" class="judgments-list__header">We found {{ total }} judgments:</p>
+            <p id="recently-published-judgments" class="judgments-list__header">We found {{ total|intcomma }} judgments:</p>
           </div>
         </div>
         <div class="judgments-list__table">


### PR DESCRIPTION
## Changes in this PR

This is a small change to make the number more easily readable for humans.

## Screenshots of UI changes:

### Before

<img width="1086" alt="Screenshot 2023-05-11 at 20 23 54" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/136eca2d-127a-4d07-bf79-8938cdb3590e">

### After

![80880fbb10c67699483bba4e7612e1fc](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/6849a87c-3505-4298-83db-8a98d503e96e)
