### PR TITLE
Add email body to issues

### DIFF
--- a/ds_caselaw_editor_ui/templates/emails/confirmation_to_submitter.txt
+++ b/ds_caselaw_editor_ui/templates/emails/confirmation_to_submitter.txt
@@ -1,4 +1,4 @@
-Dear XXXXXX,
+Dear {{ submitter }},
 
 We are pleased to inform you that your uploaded judgment "{{ judgment_name|safe }}", reference {{ reference }}, has been published on Find Case Law. You can see the published judgment at {{ public_judgment_url|safe }}.
 

--- a/ds_caselaw_editor_ui/templates/emails/raise_issue_with_submitter.txt
+++ b/ds_caselaw_editor_ui/templates/emails/raise_issue_with_submitter.txt
@@ -1,0 +1,11 @@
+Dear {{ submitter }},
+
+Further to your recent upload of "{{ judgment_name }}", reference {{ reference }},
+
+
+
+If you wish to supply us with an amended version of the judgment please resubmit it via TDR.
+
+Kind regards,
+
+{{ user_signature }}

--- a/judgments/tests/test_emails.py
+++ b/judgments/tests/test_emails.py
@@ -1,0 +1,24 @@
+from factories import JudgmentFactory
+
+from judgments.views.judgment_edit import (
+    build_confirmation_email_link,
+    build_raise_issue_email_link,
+)
+
+
+def test_issue_email():
+    judgment = JudgmentFactory.build()
+    email_link = build_raise_issue_email_link(judgment, "Username")
+    assert r"Username" in email_link
+    assert r"please%20resubmit" in email_link
+    assert r"uploader@example.com" in email_link
+    assert r"Example%20Uploader" in email_link
+
+
+def test_confirmation_email():
+    judgment = JudgmentFactory.build()
+    email_link = build_confirmation_email_link(judgment, "Username")
+    assert r"Username" in email_link
+    assert r"uploader@example.com" in email_link
+    assert r"Example%20Uploader" in email_link
+    assert r"has%20been%20published" in email_link

--- a/judgments/utils/link_generators.py
+++ b/judgments/utils/link_generators.py
@@ -34,6 +34,7 @@ def build_confirmation_email_link(
         "judgment_name": judgment.name,
         "reference": judgment.consignment_reference,
         "public_judgment_url": judgment.public_uri,
+        "submitter": judgment.source_name,
         "user_signature": signature or "XXXXXX",
     }
 
@@ -49,11 +50,24 @@ def build_confirmation_email_link(
 def build_raise_issue_email_link(
     judgment: Judgment, signature: Optional[str] = None
 ) -> str:
-    subject_string = "Issue(s) found with {reference}".format(
+    subject_string = "Find Case Law - Issue(s) found with {reference}".format(
         reference=judgment.consignment_reference
     )
+    email_context = {
+        "judgment_name": judgment.name,
+        "reference": judgment.consignment_reference,
+        "public_judgment_url": judgment.public_uri,
+        "user_signature": signature,
+        "submitter": judgment.source_name or "XXXXXX",
+    }
 
-    return build_email_link_with_content(judgment.source_email, subject_string)
+    body_string = loader.render_to_string(
+        "emails/raise_issue_with_submitter.txt", email_context
+    )
+
+    return build_email_link_with_content(
+        judgment.source_email, subject_string, body_string
+    )
 
 
 def build_jira_create_link(judgment: Judgment, request: HttpRequest) -> str:


### PR DESCRIPTION
Also adds dynamic name of submitter to "published" email.
<img width="535" alt="image" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/85497046/3d5999b8-4381-49d6-9920-6a1cad2e3d24">
