### PR TITLE
Mark email fields as safe and remove repetition in email header

### DIFF
--- a/ds_caselaw_editor_ui/templates/emails/confirmation_to_submitter.txt
+++ b/ds_caselaw_editor_ui/templates/emails/confirmation_to_submitter.txt
@@ -1,4 +1,4 @@
-Dear {{ submitter|safe}},
+Dear {{ submitter|safe }},
 
 We are pleased to inform you that your uploaded judgment "{{ judgment_name|safe }}", reference {{ reference|safe }}, has been published on Find Case Law. You can see the published judgment at {{ public_judgment_url|safe }}.
 

--- a/ds_caselaw_editor_ui/templates/emails/confirmation_to_submitter.txt
+++ b/ds_caselaw_editor_ui/templates/emails/confirmation_to_submitter.txt
@@ -1,12 +1,12 @@
-Dear {{ submitter }},
+Dear {{ submitter|safe}},
 
-We are pleased to inform you that your uploaded judgment "{{ judgment_name|safe }}", reference {{ reference }}, has been published on Find Case Law. You can see the published judgment at {{ public_judgment_url|safe }}.
+We are pleased to inform you that your uploaded judgment "{{ judgment_name|safe }}", reference {{ reference|safe }}, has been published on Find Case Law. You can see the published judgment at {{ public_judgment_url|safe }}.
 
 Please check through the content of the published judgment for any errors.
 
 We cannot make any amendments to the content or formatting of the judgment. If you wish to supply us with an amended version of the judgment please resubmit it via TDR.
 
-If you need to contact us regarding your judgment please email judgments@nationalarchives.gov.uk quoting your case details and TDR reference "{{ reference }}".
+If you need to contact us regarding your judgment please email judgments@nationalarchives.gov.uk quoting your case details and TDR reference "{{ reference|safe }}".
 
 Kind regards,
-{{ user_signature }}
+{{ user_signature|safe }}

--- a/ds_caselaw_editor_ui/templates/emails/raise_issue_with_submitter.txt
+++ b/ds_caselaw_editor_ui/templates/emails/raise_issue_with_submitter.txt
@@ -1,6 +1,6 @@
-Dear {{ submitter }},
+Dear {{ submitter|safe }},
 
-Further to your recent upload of "{{ judgment_name }}", reference {{ reference }},
+Further to your recent upload of "{{ judgment_name|safe }}", reference {{ reference|safe }},
 
 
 
@@ -8,4 +8,4 @@ If you wish to supply us with an amended version of the judgment please resubmit
 
 Kind regards,
 
-{{ user_signature }}
+{{ user_signature|safe }}

--- a/judgments/tests/test_emails.py
+++ b/judgments/tests/test_emails.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qs, urlparse
+
 from factories import JudgmentFactory
 
 from judgments.views.judgment_edit import (
@@ -6,19 +8,33 @@ from judgments.views.judgment_edit import (
 )
 
 
-def test_issue_email():
-    judgment = JudgmentFactory.build()
-    email_link = build_raise_issue_email_link(judgment, "Username")
-    assert r"Username" in email_link
-    assert r"please%20resubmit" in email_link
-    assert r"uploader@example.com" in email_link
-    assert r"Example%20Uploader" in email_link
+def the_judgment():
+    return JudgmentFactory.build(
+        name="R v G & B",
+        source_name="Darwin Núñez",
+    )
 
 
-def test_confirmation_email():
-    judgment = JudgmentFactory.build()
-    email_link = build_confirmation_email_link(judgment, "Username")
-    assert r"Username" in email_link
-    assert r"uploader@example.com" in email_link
-    assert r"Example%20Uploader" in email_link
-    assert r"has%20been%20published" in email_link
+def get_body_from_email_link(link):
+    query = urlparse(link).query
+    return parse_qs(query)["body"][0]
+
+
+def test_issue_not_encoded():
+    email_link = build_raise_issue_email_link(the_judgment(), "Sid Carrà")
+    body = get_body_from_email_link(email_link)
+    assert "R v G & B" in body
+    assert "Sid Carrà" in body
+    assert "Darwin Núñez" in body
+    assert "please resubmit" in body
+    assert "uploader@example.com" in email_link
+
+
+def test_confirmation_issue_not_encoded():
+    email_link = build_confirmation_email_link(the_judgment(), "Sid Carrà")
+    body = get_body_from_email_link(email_link)
+    assert "R v G & B" in body
+    assert "Sid Carrà" in body
+    assert "Darwin Núñez" in body
+    assert "has been published" in body
+    assert "uploader@example.com" in email_link

--- a/judgments/utils/link_generators.py
+++ b/judgments/utils/link_generators.py
@@ -50,7 +50,7 @@ def build_confirmation_email_link(
 def build_raise_issue_email_link(
     judgment: Judgment, signature: Optional[str] = None
 ) -> str:
-    subject_string = "Find Case Law - Issue(s) found with {reference}".format(
+    subject_string = "Issue(s) found with {reference}".format(
         reference=judgment.consignment_reference
     )
     email_context = {


### PR DESCRIPTION
The text of the email must be interpretted without escaping, as there is no process that
will unescape it, unlike in a browser context.

Addresses https://trello.com/c/baGbbWHc/922-eui-changing-to-the-wording-of-email-from-eui-needed

We also remove a doubling up of the subject name -- Find Case Law is automatically prepended