### PR TITLE
Fix court usage on court results

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -25,7 +25,7 @@
       </li>
       <li>
         <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.court" %}</span>
-        <span class="judgments-list__judgment-details-meta-value">{{ item.court }}</span>
+        <span class="judgments-list__judgment-details-meta-value">{{ item.court.name }}</span>
       </li>
       <li>
         <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.submitter" %}</span>


### PR DESCRIPTION
## Changes in this PR:
Fix court usage on court results

## Trello card / Rollbar error (etc)
https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously

## Screenshots of UI changes:

### Before
![Screenshot 2023-06-06 at 15 14 01](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/f2464243-9525-49d5-bc96-b12a6079540d)

### After
![Screenshot 2023-06-06 at 15 13 41](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/46d9b8e1-ce59-4e9c-8099-589be44b992b)

