### PR TITLE
improve accessibility of cookie banner and harmonise styles

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/cookie_consent/_cookie-consent.scss
+++ b/ds_caselaw_editor_ui/sass/includes/cookie_consent/_cookie-consent.scss
@@ -3,10 +3,15 @@
     @include container;
 
     padding: $spacer__unit calc($spacer__unit * 2);
-
-    .cookie_head {
-      font-family: $font__roboto;
-      font-size: 1.8rem;
-    }
   }
+}
+
+#ds-cookie-consent-banner a {
+  color: $color__white;
+}
+
+#ds-cookie-consent-banner .container #btn_preferences:hover,
+#ds-cookie-consent-banner .container #btn_preferences:focus {
+  background: none;
+  border: 2px solid transparent;
 }

--- a/ds_caselaw_editor_ui/templates/layouts/base.html
+++ b/ds_caselaw_editor_ui/templates/layouts/base.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="{% static 'images/favicons/favicon.png' %}" />
     {% block css %}
-      <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&amp;family=Roboto:wght@400;600;700&amp;display=swap"
+      <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&amp;family=Roboto:wght@400;600;700&amp;family=Roboto+Mono:wght@400;600;700&amp;display=swap"
             rel="stylesheet"/>
       <link href="{% static 'css/main.css' %}" rel="stylesheet" />
     {% endblock css %}


### PR DESCRIPTION

## Changes in this PR:

- Tidy up the cookie banner - include the fonts needed to harmonise with global NA design
- Get rid of an unruly CSS override that was making the settings link hard to read

## Trello card / Rollbar error (etc)
https://trello.com/c/Igy4Oa4T/974-%E2%9C%94%EF%B8%8F-aa-pui-eui-cookie-banners-update-font-colour-contrast-fails-on-preferences-links

## Screenshots of UI changes:

### Before
<img width="1156" alt="Screenshot 2023-06-12 at 16 04 17" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/f29dcb73-c419-48d3-9207-002902ee9e5b">

### After
<img width="1156" alt="Screenshot 2023-06-12 at 16 04 04" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/2802d148-22fa-4bec-817d-c8451a529d13">

