### PR TITLE
Refine some of the language used in merge/move

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -9,14 +9,10 @@
       <input type="hidden" name="return_to" value="{{ return_to }}" />
       <div class="metadata-component__container">
         <div class="metadata-component__ncn">
-          <label for="neutral_citation" class="metadata-component__main-labels">
+          <aside for="neutral_citation" class="metadata-component__main-labels">
             {% translate "judgment.neutral_citation" %}
-          </label>
-          <input type="text"
-                 class="metadata-component__neutral_citation-input"
-                 value="{{ judgment.neutral_citation }}"
-                 name="neutral_citation"
-                 id="neutral_citation"/>
+          </aside>
+          <p id="neutral_citation">{{ judgment.neutral_citation }}</p>
         </div>
         <div class="metadata-component__court">
           <label for="court" class="metadata-component__main-labels">{% translate "judgment.court" %}</label>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -6,7 +6,7 @@
       <span class="judgment-metadata-panel__value">{{ judgment.consignment_reference }}</span>
     </li>
     <li>
-      <span class="judgment-metadata-panel__key">{% translate "judgments.ncn" %}</span>
+      <span class="judgment-metadata-panel__key">{% translate "judgment.neutral_citation" %}</span>
       <span class="judgment-metadata-panel__value">{{ judgment.neutral_citation }}</span>
     </li>
     <li>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
@@ -32,7 +32,7 @@
   <h4>{% translate "judgments.sidebar.manage" %}</h4>
   <ul>
     <li>
-      <a href="{% url 'move-judgment' judgment.uri %}">{% translate "judgment.movemerge" %}</a>
+      <a href="{% url 'move-judgment' judgment.uri %}">{% translate "judgment.change_ncn" %}</a>
     </li>
     <li>
       <a href="{% url 'unlock' %}?judgment_uri={{ judgment_uri }}">{% translate "judgment.unlock_judgment_title" %}</a>

--- a/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -20,7 +20,7 @@
         <span class="judgments-list__judgment-details-meta-value">{{ item.meta.consignment_reference }}</span>
       </li>
       <li>
-        <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.ncn" %}</span>
+        <span class="judgments-list__judgment-details-meta-key">{% translate "judgment.neutral_citation" %}</span>
         <span class="judgments-list__judgment-details-meta-value">{{ item.neutral_citation }}</span>
       </li>
       <li>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -24,14 +24,6 @@
   <form aria-label="Edit judgment" method="post">
     {% csrf_token %}
     <div class="edit-component__panel">
-      <label class="edit-component__text-field-label" for="metadata_name">{% translate "judgment.judgment_name" %}</label>
-      <input type="text"
-             class="edit-component__metadata_name-input"
-             value="{{ judgment.name }}"
-             name="metadata_name"
-             id="metadata_name"/>
-    </div>
-    <div class="edit-component__panel">
       <label class="edit-component__text-field-label" for="neutral_citation">
         {% translate "judgment.neutral_citation" %}
       </label>
@@ -40,7 +32,16 @@
              value="{{ judgment.neutral_citation }}"
              name="neutral_citation"
              id="neutral_citation"
-             size="30"/>
+             size="30"
+             disabled/>
+    </div>
+    <div class="edit-component__panel">
+      <label class="edit-component__text-field-label" for="metadata_name">{% translate "judgment.judgment_name" %}</label>
+      <input type="text"
+             class="edit-component__metadata_name-input"
+             value="{{ judgment.name }}"
+             name="metadata_name"
+             id="metadata_name"/>
     </div>
     <div class="edit-component__panel">
       <label class="edit-component__text-field-label" for="court">{% translate "judgment.court" %}</label>

--- a/ds_caselaw_editor_ui/templates/judgment/move.html
+++ b/ds_caselaw_editor_ui/templates/judgment/move.html
@@ -4,7 +4,7 @@
   {% include "includes/judgment/metadata_panel_static.html" with judgment=judgment %}
 {% endblock judgment_header %}
 {% block judgment_content %}
-  <h2>Move and merge</h2>
+  <h2>Change neutral citation number</h2>
   <p>
     Use this form to <b>set the neutral citation</b> of this judgment.
   </p>

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -2,17 +2,11 @@ import ds_caselaw_utils as caselawutils
 from caselawclient.Client import MarklogicAPIError, api_client
 from django.contrib import messages
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import redirect
 from django.template import loader
 from django.urls import reverse
 from django.views.generic import View
 
-from judgments.utils import (
-    MoveJudgmentError,
-    NeutralCitationToUriError,
-    editors_dict,
-    update_judgment_uri,
-)
+from judgments.utils import editors_dict
 from judgments.utils.aws import invalidate_caches
 from judgments.utils.link_generators import (
     build_confirmation_email_link,
@@ -67,10 +61,6 @@ class EditJudgmentView(View):
             new_name = request.POST["metadata_name"]
             api_client.set_judgment_name(judgment_uri, new_name)
 
-            # Set neutral citation
-            new_citation = request.POST["neutral_citation"]
-            api_client.set_judgment_citation(judgment_uri, new_citation)
-
             # Set court
             new_court = request.POST["court"]
             api_client.set_judgment_court(judgment_uri, new_court)
@@ -93,20 +83,7 @@ class EditJudgmentView(View):
                 if new_assignment := request.POST.get("assigned_to", False):
                     api_client.set_property(judgment_uri, "assigned-to", new_assignment)
 
-            # If judgment_uri is a `failure` URI, amend it to match new neutral citation and redirect
-            if "failures" in judgment_uri and new_citation is not None:
-                new_judgment_uri = update_judgment_uri(judgment_uri, new_citation)
-                return redirect(
-                    reverse("edit-judgment", kwargs={"judgment_uri": new_judgment_uri})
-                )
-
             messages.success(request, "Judgment successfully updated")
-
-        except (MoveJudgmentError, NeutralCitationToUriError) as e:
-            messages.error(
-                request,
-                f"There was an error updating the Judgment's neutral citation: {e}",
-            )
 
         except MarklogicAPIError as e:
             messages.error(request, f"There was an error saving the Judgment: {e}")

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-22 16:18+0000\n"
+"POT-Creation-Date: 2023-06-21 11:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,6 +63,8 @@ msgid "judgment.email_submitter.issue"
 msgstr "Raise issue(s) to submitter"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 #: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.neutral_citation"
 msgstr "NCN"
@@ -91,11 +93,6 @@ msgstr "Name"
 #: judgments/utils/link_generators.py
 msgid "judgments.consignmentref"
 msgstr "TDR Ref"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
-#: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
-msgid "judgments.ncn"
-msgstr "NCN"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -130,18 +127,18 @@ msgid "judgment.change_ncn"
 msgstr "Change neutral citation number"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
+#: judgments/views/unlock.py
+msgid "judgment.unlock_judgment_title"
+msgstr "Unlock judgment"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.sidebar.tools"
 msgstr "External Tools"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgment.create_in_jira"
 msgstr "Create in Jira"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
-#: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
-#: judgments/views/unlock.py
-msgid "judgment.unlock_judgment_title"
-msgstr "Unlock judgment"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgment.report_blocking_problem"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -67,7 +67,7 @@ msgstr "Raise issue(s) to submitter"
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 #: ds_caselaw_editor_ui/templates/judgment/edit.html
 msgid "judgment.neutral_citation"
-msgstr "NCN"
+msgstr "Neutral citation"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
 #: ds_caselaw_editor_ui/templates/judgment/edit.html

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -126,8 +126,8 @@ msgid "judgments.sidebar.manage"
 msgstr "Manage"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
-msgid "judgment.movemerge"
-msgstr "Move and merge"
+msgid "judgment.change_ncn"
+msgstr "Change neutral citation number"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.sidebar.tools"


### PR DESCRIPTION
The existing branch is a rough-and-ready approach; this refines some of the language to better reflect the actual intent of the workflow path.

This does _not_ include refining the path for merging into a new version or handling document collisions, in the interests of keeping things small and shippable.