### PR TITLE
Fix for missing metadata in list of unpublished judgments

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -13,11 +13,11 @@
     <ul class="judgments-list__judgment-details-meta">
       <li class="judgments-list__judgment-details-submitted-mobile">
         <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.submission_datetime" %}</span>
-        <span class="judgments-list__judgment-details-meta-value">{{ item.meta.submission_datetime }}</span>
+        <span class="judgments-list__judgment-details-meta-value">{{ item.metadata.submission_datetime }}</span>
       </li>
       <li>
         <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.consignmentref" %}</span>
-        <span class="judgments-list__judgment-details-meta-value">{{ item.meta.consignment_reference }}</span>
+        <span class="judgments-list__judgment-details-meta-value">{{ item.metadata.consignment_reference }}</span>
       </li>
       <li>
         <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.ncn" %}</span>
@@ -29,7 +29,7 @@
       </li>
       <li>
         <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.submitter" %}</span>
-        <span class="judgments-list__judgment-details-meta-value">{{ item.meta.author }}</span>
+        <span class="judgments-list__judgment-details-meta-value">{{ item.metadata.author }}</span>
       </li>
       <li>
         <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.editor_priority" %}</span>
@@ -39,15 +39,15 @@
             <input type="hidden" name="judgment_uri" value="{{ item.uri }}" />
             <select name="priority" id="editor_priority">
               <option value="low"
-                      {% if item.meta.editor_priority == "10" %}selected{% endif %}>
+                      {% if item.metadata.editor_priority == "10" %}selected{% endif %}>
                 Low
               </option>
               <option value="medium"
-                      {% if item.meta.editor_priority == "20" %}selected{% endif %}>
+                      {% if item.metadata.editor_priority == "20" %}selected{% endif %}>
                 Medium
               </option>
               <option value="high"
-                      {% if item.meta.editor_priority == "30" %}selected{% endif %}>
+                      {% if item.metadata.editor_priority == "30" %}selected{% endif %}>
                 High
               </option>
             </select>
@@ -58,15 +58,15 @@
       <li>
         <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.editor_status" %}</span>
         <span class="judgments-list__judgment-details-meta-value">
-          {{ item.meta.editor_status }}
-          {% if item.meta.assigned_to %}
-            <form action="{% if item.meta.editor_hold == 'true' %}{% url 'unhold' %}{% else %}{% url 'hold' %}{% endif %}"
+          {{ item.metadata.editor_status }}
+          {% if item.metadata.assigned_to %}
+            <form action="{% if item.metadata.editor_hold == 'true' %}{% url 'unhold' %}{% else %}{% url 'hold' %}{% endif %}"
                   method="post">
               {% csrf_token %}
               <input type="hidden" name="judgment_uri" value="{{ item.uri }}" />
               <input type="submit"
                      name="submit"
-                     value="{% if item.meta.editor_hold == 'true' %}Release{% else %}Hold{% endif %} judgment"/>
+                     value="{% if item.metadata.editor_hold == 'true' %}Release{% else %}Hold{% endif %} judgment"/>
             </form>
           {% endif %}
         </span>
@@ -74,8 +74,8 @@
       <li class="judgments-list__judgment-details-assigned-mobile">
         <span class="judgments-list__judgment-details-meta-key">{% translate "judgments.assigned_to" %}</span>
         <span class="judgments-list__judgment-details-meta-value">
-          {% if item.meta.assigned_to %}
-            <a href="{% url 'edit-judgment' item.uri %}#assigned_to">{{ item.meta.assigned_to }}</a>
+          {% if item.metadata.assigned_to %}
+            <a href="{% url 'edit-judgment' item.uri %}#assigned_to">{{ item.metadata.assigned_to }}</a>
           {% else %}
             <form action="{% url "assign" %}"
                   method="post"
@@ -93,13 +93,13 @@
     </ul>
   </div>
   <div class="judgments-list__judgment-submitted">
-    {{ item.meta.submission_datetime|date:"d M Y" }}
+    {{ item.metadata.submission_datetime|date:"d M Y" }}
     <br />
-    {{ item.meta.submission_datetime|time:"h:i a" }}
+    {{ item.metadata.submission_datetime|time:"h:i a" }}
   </div>
   <div class="judgments-list__judgment-assigned">
-    {% if item.meta.assigned_to %}
-      <a href="{% url 'edit-judgment' item.uri %}#assigned_to">{{ item.meta.assigned_to }}</a>
+    {% if item.metadata.assigned_to %}
+      <a href="{% url 'edit-judgment' item.uri %}#assigned_to">{{ item.metadata.assigned_to }}</a>
     {% else %}
       <form action="{% url "assign" %}"
             method="post"

--- a/judgments/tests/test_judgment_list.py
+++ b/judgments/tests/test_judgment_list.py
@@ -1,0 +1,77 @@
+import re
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.translation import gettext
+from factories import SearchResultFactory, SearchResultMetadataFactory
+
+
+def assert_match(regex, string):
+    assert re.search(regex, string) is not None
+
+
+class TestJudgmentView(TestCase):
+    @patch("judgments.utils.view_helpers.search_judgments_and_parse_response")
+    def test_judgment_list_smoketest(self, mock_search_results):
+        mock_search_results.return_value.results = []
+        mock_search_results.return_value.total = 0
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(reverse("home"))
+
+        assert response.status_code == 200
+
+    @patch("judgments.utils.view_helpers.search_judgments_and_parse_response")
+    def test_judgment_list_total_count(self, mock_search_results):
+        mock_search_results.return_value.results = [
+            SearchResultFactory.build(),
+            SearchResultFactory.build(),
+        ]
+        mock_search_results.return_value.total = 2
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(reverse("home"))
+
+        decoded_response = response.content.decode("utf-8")
+
+        assert "{}: 2".format(gettext("home.recent")) in decoded_response
+
+    @patch("judgments.utils.view_helpers.search_judgments_and_parse_response")
+    def test_judgment_list_items(self, mock_search_results):
+        mock_search_results.return_value.results = [
+            SearchResultFactory.build(
+                uri="test/2023/123",
+                name="Test Judgment 1",
+                metadata=SearchResultMetadataFactory.build(
+                    author="Author One",
+                    consignment_reference="TDR-2023-AB1",
+                ),
+            ),
+            SearchResultFactory.build(
+                uri="test/2023/456",
+                name="Test Judgment 2",
+                metadata=SearchResultMetadataFactory.build(
+                    author="Author Two",
+                    consignment_reference="TDR-2023-CD2",
+                ),
+            ),
+        ]
+        mock_search_results.return_value.total = 2
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(reverse("home"))
+
+        decoded_response = response.content.decode("utf-8")
+
+        assert "Test Judgment 1" in decoded_response
+        assert "Author One" in decoded_response
+        assert "TDR-2023-AB1" in decoded_response
+
+        assert "Test Judgment 2" in decoded_response
+        assert "Author Two" in decoded_response
+        assert "TDR-2023-CD2" in decoded_response


### PR DESCRIPTION
The new unified `SearchResult` class from the API Client uses `SearchResult.metadata` instead of `SearchResult.meta`, and this change was missed here.

This fixes both the missing metadata, and the broken assignment operation.