### PR TITLE
Updating judgment uri sets collection based off new uri

### DIFF
--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -63,9 +63,9 @@ def get_judgment_root(judgment_xml) -> str:
         return "error"
 
 
-def update_judgment_uri(old_uri, new_citation):
+def update_document_uri(old_uri, new_citation):
     """
-    Move the judgment at old_uri to the correct location based on the neutral citation
+    Move the document at old_uri to the correct location based on the neutral citation
     The new neutral citation *must* not already exist (that is handled elsewhere)
     """
     new_uri = caselawutils.neutral_url(new_citation.strip())
@@ -81,7 +81,7 @@ def update_judgment_uri(old_uri, new_citation):
         )
 
     try:
-        api_client.copy_judgment(old_uri, new_uri)
+        api_client.copy_document(old_uri, new_uri)
         set_metadata(old_uri, new_uri)
         copy_assets(old_uri, new_uri)
         api_client.set_judgment_this_uri(new_uri)

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -11,7 +11,7 @@ from judgments.utils import (
     MoveJudgmentError,
     NeutralCitationToUriError,
     editors_dict,
-    update_judgment_uri,
+    update_document_uri,
 )
 from judgments.utils.aws import invalidate_caches
 from judgments.utils.link_generators import (
@@ -95,7 +95,7 @@ class EditJudgmentView(View):
 
             # If judgment_uri is a `failure` URI, amend it to match new neutral citation and redirect
             if "failures" in judgment_uri and new_citation is not None:
-                new_judgment_uri = update_judgment_uri(judgment_uri, new_citation)
+                new_judgment_uri = update_document_uri(judgment_uri, new_citation)
                 return redirect(
                     reverse("edit-judgment", kwargs={"judgment_uri": new_judgment_uri})
                 )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==10.1.0
+ds-caselaw-marklogic-api-client==11.0.0
 ds-caselaw-utils~=1.0.1
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
## Changes in this PR:

- Update marklogic api client to 11.0.0 https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases/tag/v11.0.0 to make use of the updated and renamed `copy_document` method so that it sets the collection of the new document based off the uri, so that we dont get floating documents which were at a /failure/ uri since the parser failed to pick up an ncn which existed in the document and then got updated to a real ncn uri by an editor.

Without this, these docs that were published were not showing up in search due to the fact that we were creating new docs without a collection by when copying a document, and we filter so that we only show docs in judgment collection.

Note: the reason failure uris show in judgment collection is that we default to anything without press-summary in the uri to be in the judgment collection for now.

## Trello card / Rollbar error (etc)

https://trello.com/c/0Q5fI6gA/1072-ingesting-uri-parse-failures-not-being-added-to-judgment-or-press-summary-collection