### PR TITLE
Remove ability to update NCN using the edit form

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -9,14 +9,10 @@
       <input type="hidden" name="return_to" value="{{ return_to }}" />
       <div class="metadata-component__container">
         <div class="metadata-component__ncn">
-          <label for="neutral_citation" class="metadata-component__main-labels">
+          <aside for="neutral_citation" class="metadata-component__main-labels">
             {% translate "judgment.neutral_citation" %}
-          </label>
-          <input type="text"
-                 class="metadata-component__neutral_citation-input"
-                 value="{{ judgment.neutral_citation }}"
-                 name="neutral_citation"
-                 id="neutral_citation"/>
+          </aside>
+          <p id="neutral_citation">{{ judgment.neutral_citation }}</p>
         </div>
         <div class="metadata-component__court">
           <label for="court" class="metadata-component__main-labels">{% translate "judgment.court" %}</label>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -12,7 +12,9 @@
           <aside for="neutral_citation" class="metadata-component__main-labels">
             {% translate "judgment.neutral_citation" %}
           </aside>
-          <p id="neutral_citation">{{ judgment.neutral_citation }}</p>
+          <p id="neutral_citation">
+            {{ judgment.neutral_citation }} <a href="{% url 'move-judgment' judgment.uri %}">✎</a>
+          </p>
         </div>
         <div class="metadata-component__court">
           <label for="court" class="metadata-component__main-labels">{% translate "judgment.court" %}</label>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -24,14 +24,6 @@
   <form aria-label="Edit judgment" method="post">
     {% csrf_token %}
     <div class="edit-component__panel">
-      <label class="edit-component__text-field-label" for="metadata_name">{% translate "judgment.judgment_name" %}</label>
-      <input type="text"
-             class="edit-component__metadata_name-input"
-             value="{{ judgment.name }}"
-             name="metadata_name"
-             id="metadata_name"/>
-    </div>
-    <div class="edit-component__panel">
       <label class="edit-component__text-field-label" for="neutral_citation">
         {% translate "judgment.neutral_citation" %}
       </label>
@@ -40,7 +32,16 @@
              value="{{ judgment.neutral_citation }}"
              name="neutral_citation"
              id="neutral_citation"
-             size="30"/>
+             size="30"
+             disabled/>
+    </div>
+    <div class="edit-component__panel">
+      <label class="edit-component__text-field-label" for="metadata_name">{% translate "judgment.judgment_name" %}</label>
+      <input type="text"
+             class="edit-component__metadata_name-input"
+             value="{{ judgment.name }}"
+             name="metadata_name"
+             id="metadata_name"/>
     </div>
     <div class="edit-component__panel">
       <label class="edit-component__text-field-label" for="court">{% translate "judgment.court" %}</label>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -34,6 +34,7 @@
              id="neutral_citation"
              size="30"
              disabled/>
+      <a href="{% url 'move-judgment' judgment.uri %}">✎</a>
     </div>
     <div class="edit-component__panel">
       <label class="edit-component__text-field-label" for="metadata_name">{% translate "judgment.judgment_name" %}</label>

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -2,17 +2,11 @@ import ds_caselaw_utils as caselawutils
 from caselawclient.Client import MarklogicAPIError, api_client
 from django.contrib import messages
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import redirect
 from django.template import loader
 from django.urls import reverse
 from django.views.generic import View
 
-from judgments.utils import (
-    MoveJudgmentError,
-    NeutralCitationToUriError,
-    editors_dict,
-    update_document_uri,
-)
+from judgments.utils import editors_dict
 from judgments.utils.aws import invalidate_caches
 from judgments.utils.link_generators import (
     build_confirmation_email_link,
@@ -67,10 +61,6 @@ class EditJudgmentView(View):
             new_name = request.POST["metadata_name"]
             api_client.set_judgment_name(judgment_uri, new_name)
 
-            # Set neutral citation
-            new_citation = request.POST["neutral_citation"]
-            api_client.set_judgment_citation(judgment_uri, new_citation)
-
             # Set court
             new_court = request.POST["court"]
             api_client.set_judgment_court(judgment_uri, new_court)
@@ -93,20 +83,7 @@ class EditJudgmentView(View):
                 if new_assignment := request.POST.get("assigned_to", False):
                     api_client.set_property(judgment_uri, "assigned-to", new_assignment)
 
-            # If judgment_uri is a `failure` URI, amend it to match new neutral citation and redirect
-            if "failures" in judgment_uri and new_citation is not None:
-                new_judgment_uri = update_document_uri(judgment_uri, new_citation)
-                return redirect(
-                    reverse("edit-judgment", kwargs={"judgment_uri": new_judgment_uri})
-                )
-
             messages.success(request, "Judgment successfully updated")
-
-        except (MoveJudgmentError, NeutralCitationToUriError) as e:
-            messages.error(
-                request,
-                f"There was an error updating the Judgment's neutral citation: {e}",
-            )
 
         except MarklogicAPIError as e:
             messages.error(request, f"There was an error saving the Judgment: {e}")


### PR DESCRIPTION
Removing this from the edit work since it means we can't deploy safely; we shouldn't deploy this until we're happy.