### PR TITLE
Fix/assign dropdown style

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_sidebar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_sidebar.scss
@@ -40,7 +40,11 @@
 
   &__assignment-input {
     display: block;
-    min-width: 66%;
+    width: 100%;
+    height: calc(2.4 * $spacer__unit);
+    border: solid 2px $color__dark-grey;
+    font-size: 1rem;
+    $font__open-sans: "Open Sans", sans-serif;
   }
 
   &__context-notification {

--- a/ds_caselaw_editor_ui/sass/includes/components/_judgment_status_indicator.scss
+++ b/ds_caselaw_editor_ui/sass/includes/components/_judgment_status_indicator.scss
@@ -8,10 +8,10 @@
 
   color: $color__white;
   background-color: $color__dark-blue;
-  letter-spacing: 1px;
 
   text-decoration: none;
   text-transform: uppercase;
+  font-weight: bold;
 }
 
 .judgment-status-indicator--grey {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Improved design...
- The target area is more generous now and is easier to select.
- The font is now Open sans and 1rem (used for all form elements)
- The border is 2px (GDS guidance).

## Trello card / Rollbar error (etc)
https://trello.com/c/1WUeVsOg/1131-eui-restyled-the-assign-to-dropdown-on-the-side-menu
## Screenshots of UI changes:

### Before

![Screenshot 2023-07-07 at 08 33 59](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/102584881/7b014836-468c-49ab-b5a6-4312de18f4af)

### After
![Screenshot 2023-07-07 at 08 34 06](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/102584881/61cc400c-82b4-4a94-81b6-bb155598b5a6)
- [ ] Requires env variable(s) to be updated
