### PR TITLE
reduced space above homepage listing by 1 rem

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgments_list.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgments_list.scss
@@ -1,6 +1,6 @@
 .judgments-list {
   &__judgments-list-controls-container {
-    margin-bottom: calc(2 * $spacer__unit);
+    margin-bottom: calc(1 * $spacer__unit);
   }
 
   &__container {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
- Took out 1 rem space between judgment count header and the listing below.
- realised as I write this that I didn't need to keep the calculation in sass. I'll do it again some time in the future.

## Trello card / Rollbar error (etc)
https://trello.com/c/iTetifk5/1132-eui-reduced-unnecessary-space-above-incoming-judgments-list-on-homepage
## Screenshots of UI changes:

### Before
![Screenshot 2023-07-07 at 09 00 53](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/102584881/47ca20fb-e3dd-4aa4-ba21-f39e8d320446)

### After

![Screenshot 2023-07-07 at 09 01 44](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/102584881/61e11034-48c6-4671-92c3-41a6ade8af4d)

- [ ] Requires env variable(s) to be updated
