### PR TITLE
Remove pillow from dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,4 @@
 pytz==2023.3  # https://github.com/stub42/pytz
-Pillow==10.0.0  # https://github.com/python-pillow/Pillow
 argon2-cffi==21.3.0  # https://github.com/hynek/argon2_cffi
 whitenoise==6.5.0  # https://github.com/evansd/whitenoise
 


### PR DESCRIPTION
This isn't used anywhere, but has a _lot_ of its own dependencies. Instead of wasting time and space installing them, we can remove pillow.