### PR TITLE
remove "view on public site" button

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -58,17 +58,6 @@
         <span class="judgment-toolbar__button button-secondary"
               aria-disabled="true">{% translate "judgment.toolbar.download_docx" %}</span>
       {% endif %}
-      {% if judgment.is_published %}
-        <a class="judgment-toolbar__button button-secondary"
-           href="{{ judgment.public_uri }}"
-           target="_blank"
-           rel="noopener noreferrer">
-          {% translate "judgment.toolbar.view_on_public" %}
-        </a>
-      {% else %}
-        <span class="judgment-toolbar__button button-secondary"
-              aria-disabled="true">{% translate "judgment.toolbar.view_on_public" %}</span>
-      {% endif %}
       {% if judgment.is_failure %}
         <form action="{% url "delete" %}" method="post">
           {% csrf_token %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Remove "view on public site" button
## Trello card / Rollbar error (etc)
https://trello.com/c/36oo8voH/1127-eui-remove-view-on-public-site-button-from-the-tool-bar
## Screenshots of UI changes:

### Before
![before-public](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/a6ddf0c7-8e06-474c-8e71-8f625ad0e071)

### After
![after-public](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/dd88a29b-cb75-4df5-884f-0edaad7065de)

- [ ] Requires env variable(s) to be updated
