### PR TITLE
Support for changes in advance of discrete document types

### DIFF
--- a/judgments/templatetags/status_tag_css.py
+++ b/judgments/templatetags/status_tag_css.py
@@ -1,7 +1,7 @@
-from caselawclient.models.judgments import (
-    JUDGMENT_STATUS_HOLD,
-    JUDGMENT_STATUS_IN_PROGRESS,
-    JUDGMENT_STATUS_PUBLISHED,
+from caselawclient.models.documents import (
+    DOCUMENT_STATUS_HOLD,
+    DOCUMENT_STATUS_IN_PROGRESS,
+    DOCUMENT_STATUS_PUBLISHED,
 )
 from django import template
 from django.template.defaultfilters import stringfilter
@@ -12,10 +12,10 @@ register = template.Library()
 @register.filter
 @stringfilter
 def status_tag_colour(status):
-    if status == JUDGMENT_STATUS_IN_PROGRESS:
+    if status == DOCUMENT_STATUS_IN_PROGRESS:
         return "light-blue"
-    if status == JUDGMENT_STATUS_HOLD:
+    if status == DOCUMENT_STATUS_HOLD:
         return "red"
-    if status == JUDGMENT_STATUS_PUBLISHED:
+    if status == DOCUMENT_STATUS_PUBLISHED:
         return "green"
     return "grey"

--- a/judgments/tests/test_templatetags.py
+++ b/judgments/tests/test_templatetags.py
@@ -1,7 +1,7 @@
-from caselawclient.models.judgments import (
-    JUDGMENT_STATUS_HOLD,
-    JUDGMENT_STATUS_IN_PROGRESS,
-    JUDGMENT_STATUS_PUBLISHED,
+from caselawclient.models.documents import (
+    DOCUMENT_STATUS_HOLD,
+    DOCUMENT_STATUS_IN_PROGRESS,
+    DOCUMENT_STATUS_PUBLISHED,
 )
 
 from judgments.templatetags.status_tag_css import status_tag_colour
@@ -9,13 +9,13 @@ from judgments.templatetags.status_tag_css import status_tag_colour
 
 class TestStatusTagColour:
     def test_colour_in_progress(self):
-        assert status_tag_colour(JUDGMENT_STATUS_IN_PROGRESS) == "light-blue"
+        assert status_tag_colour(DOCUMENT_STATUS_IN_PROGRESS) == "light-blue"
 
     def test_colour_published(self):
-        assert status_tag_colour(JUDGMENT_STATUS_PUBLISHED) == "green"
+        assert status_tag_colour(DOCUMENT_STATUS_PUBLISHED) == "green"
 
     def test_colour_hold(self):
-        assert status_tag_colour(JUDGMENT_STATUS_HOLD) == "red"
+        assert status_tag_colour(DOCUMENT_STATUS_HOLD) == "red"
 
     def test_colour_undefined(self):
         assert status_tag_colour("undefined") == "grey"

--- a/judgments/tests/test_view_helpers.py
+++ b/judgments/tests/test_view_helpers.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from caselawclient.errors import JudgmentNotFoundError
+from caselawclient.errors import DocumentNotFoundError
 from django.http import Http404
 from factories import JudgmentFactory
 
@@ -23,7 +23,7 @@ class TestGetPublishedJudgment:
 
     @patch(
         "judgments.utils.view_helpers.get_judgment_by_uri",
-        side_effect=JudgmentNotFoundError,
+        side_effect=DocumentNotFoundError,
     )
     def test_judgment_missing(self, mock_judgment):
         with pytest.raises(Http404):

--- a/judgments/tests/utils/test_utils.py
+++ b/judgments/tests/utils/test_utils.py
@@ -113,7 +113,7 @@ class TestUtils(TestCase):
         we continue to move the document to the new location
         (where moving is copy + delete)"""
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
-        fake_api_client.judgment_exists.return_value = False
+        fake_api_client.document_exists.return_value = False
         fake_api_client.copy_document.return_value = True
         fake_api_client.delete_judgment.return_value = True
         fake_boto3_client.list_objects.return_value = []
@@ -133,7 +133,7 @@ class TestUtils(TestCase):
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
         fake_api_client.copy_document.return_value = True
         fake_api_client.delete_judgment.return_value = True
-        fake_api_client.judgment_exists.return_value = False
+        fake_api_client.document_exists.return_value = False
         fake_boto3_client.list_objects.return_value = []
 
         update_document_uri("old/uri", " [2002] EAT 1 ")
@@ -174,7 +174,7 @@ class TestUtils(TestCase):
 
     @patch("judgments.utils.api_client")
     def test_update_document_uri_duplicate_uri(self, fake_client):
-        fake_client.judgment_exists.return_value = True
+        fake_client.document_exists.return_value = True
         with self.assertRaises(judgments.utils.MoveJudgmentError):
             update_document_uri("old/uri", "[2002] EAT 1")
 

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -74,7 +74,7 @@ def update_document_uri(old_uri, new_citation):
             f"Unable to form new URI for {old_uri} from neutral citation: {new_citation}"
         )
 
-    if api_client.judgment_exists(new_uri):
+    if api_client.document_exists(new_uri):
         raise MoveJudgmentError(
             f"The URI {new_uri} generated from {new_citation} already exists, you cannot move this judgment to a"
             f" pre-existing Neutral Citation Number."

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -4,7 +4,7 @@ from caselawclient.Client import api_client
 from caselawclient.client_helpers.search_helpers import (
     search_judgments_and_parse_response,
 )
-from caselawclient.errors import JudgmentNotFoundError
+from caselawclient.errors import DocumentNotFoundError
 from caselawclient.search_parameters import SearchParameters
 from django.http import Http404
 
@@ -51,5 +51,5 @@ def get_search_results(parameters: dict[str, Any]) -> dict[str, Any]:
 def get_judgment_by_uri_or_404(uri: str) -> Judgment:
     try:
         return get_judgment_by_uri(uri)
-    except JudgmentNotFoundError:
+    except DocumentNotFoundError:
         raise Http404(f"Judgment not found at {uri}")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==11.0.1
+ds-caselaw-marklogic-api-client==12.0.0
 ds-caselaw-utils~=1.0.2
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
v12 of the api client introduces some changes to document classes in readiness to support multiple types. Part of this involves renaming some aspects so it's clear they relate to the abstract concept of a `Document`, rather than a specific type. This PR makes the necessary changes to support those renamings.

This does _not_ move EUI to use discrete document types - it continues to create `Judgment` objects which behave (almost) identically to before. A separate PR will move EUI to the point where it receives arbitrary document classes.