### PR TITLE
Added status and type label to EUI

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_metadata.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_metadata.scss
@@ -19,39 +19,77 @@
     margin-bottom: calc($spacer__unit / 2);
     &:last-child {
       margin-bottom: 0;
+      padding: calc($spacer__unit / 2) 0 calc($spacer__unit / 2) 0;
     }
   }
 
   &__ncn {
-    width: 27%;
+    width: 18%;
   }
 
   &__court {
     width: 52%;
-    left: 3rem;
   }
+
   &__date {
-    width: 20%;
+    width: 15%;
   }
+
   &__tdr {
+    display: flex;
+    gap: 1rem;
     p {
       margin: 0;
+      margin-left: 0.5rem;
       line-height: 1rem;
     }
     margin-bottom: calc($spacer__unit / 2);
   }
+
+  &__type {
+    display: flex;
+    gap: 1rem;
+    margin-left: 0.5rem;
+    p {
+      margin: 0;
+      margin-left: 1.5rem;
+      line-height: 1rem;
+    }
+    margin-bottom: calc($spacer__unit / 2);
+  }
+
   &__panel {
     width: 80%;
+    padding: calc(#{$spacer__unit} / 2) 0;
   }
 
   &__bottom-right-column {
     width: 20%;
     padding: calc($spacer__unit / 2) 0;
+    margin-left: calc($spacer__unit / 0.5);
+  }
+
+  &__top-right-column {
+    width: 20%;
   }
 
   &__actions {
     width: auto;
   }
+
+  &__status {
+    display: flex;
+    gap: 1rem;
+    p {
+      margin: 0;
+      margin-left: 1rem;
+      line-height: 1rem;
+      border: 3px solid white;
+    }
+    margin-bottom: calc($spacer__unit / 2);
+    width: auto;
+  }
+
   &__main-labels {
     display: block;
     margin-bottom: calc($spacer__unit / 4);
@@ -73,14 +111,24 @@
     width: fit-content;
     padding: calc(#{$spacer__unit} / 2);
   }
-  &__panel {
-    padding: calc(#{$spacer__unit} / 2) 0;
-  }
 
   input[type="submit"] {
     @include call-to-action-button;
     width: 10rem;
     min-height: 0.5rem;
+  }
+
+  &__court-input {
+    @include text_field;
+    box-sizing: border-box;
+    width: 50%;
+    left: 2rem;
+    min-height: 2rem;
+    font-size: 1rem;
+    $font__open-sans: "Open Sans", sans-serif;
+    padding: 0.5rem;
+    border: 2px solid $color__dark-grey;
+    margin: 0;
   }
 
   &__judgment_date-input {
@@ -111,7 +159,7 @@
   input[type="text"] {
     @include text_field;
     box-sizing: border-box;
-    width: 100%;
+    width: 95%;
     min-height: 2rem;
     font-size: 1rem;
     $font__open-sans: "Open Sans", sans-serif;
@@ -121,6 +169,7 @@
   }
 
   input[type="submit"] {
-    width: 100%;
+    width: 85%;
+    margin-left: 0.5rem;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_metadata.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_metadata.scss
@@ -11,83 +11,91 @@
     left: 50%;
     transform: translate(-50%);
   }
-
-  &__container {
+  form {
     display: flex;
-    gap: 1rem;
-    width: 100%;
-    margin-bottom: calc($spacer__unit / 2);
-    &:last-child {
-      margin-bottom: 0;
-      padding: calc($spacer__unit / 2) 0 calc($spacer__unit / 2) 0;
+    gap: calc(2 * $spacer__unit);
+  }
+  &__left-column {
+    width: 80%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__right-column {
+    width: 20%;
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    > div {
+      @media (min-width: $grid__breakpoint-large) {
+        height: calc(1.8 * $spacer__unit);
+      }
     }
+
+    .metadata-component__main-labels {
+      @media (min-width: $grid__breakpoint-large) {
+        display: inline-block;
+        margin: 0;
+        width: calc(4 * $spacer__unit);
+      }
+    }
+
+    p {
+      @media (min-width: $grid__breakpoint-large) {
+        display: inline-block;
+        margin: 0;
+        line-height: $spacer__unit;
+      }
+    }
+  }
+
+  &__top-left-row {
+    display: flex;
+    flex-direction: row;
+    gap: $spacer__unit;
   }
 
   &__ncn {
-    width: 18%;
+    width: 33.33%;
+    input {
+      width: 100% !important;
+    }
   }
 
   &__court {
-    width: 52%;
+    width: 33%;
+    @media (min-width: $grid__breakpoint-large) {
+      width: 50%;
+    }
+    input {
+      width: 100% !important;
+    }
   }
 
   &__date {
-    width: 15%;
-  }
-
-  &__tdr {
-    display: flex;
-    gap: 1rem;
-    p {
-      margin: 0;
-      margin-left: 0.5rem;
-      line-height: 1rem;
+    width: 33%;
+    @media (min-width: $grid__breakpoint-large) {
+      width: 16.67%;
     }
-    margin-bottom: calc($spacer__unit / 2);
-  }
-
-  &__type {
-    display: flex;
-    gap: 1rem;
-    margin-left: 0.5rem;
-    p {
-      margin: 0;
-      margin-left: 1.5rem;
-      line-height: 1rem;
+    input {
+      width: 100% !important;
     }
-    margin-bottom: calc($spacer__unit / 2);
-  }
-
-  &__panel {
-    width: 80%;
-    padding: calc(#{$spacer__unit} / 2) 0;
-  }
-
-  &__bottom-right-column {
-    width: 20%;
-    padding: calc($spacer__unit / 2) 0;
-    margin-left: calc($spacer__unit / 0.5);
-  }
-
-  &__top-right-column {
-    width: 20%;
   }
 
   &__actions {
-    width: auto;
+    margin-top: auto;
+    width: 100%;
+    height: auto !important;
+    input {
+      margin: 0;
+    }
   }
 
   &__status {
-    display: flex;
-    gap: 1rem;
     p {
-      margin: 0;
-      margin-left: 1rem;
-      line-height: 1rem;
       border: 3px solid white;
     }
     margin-bottom: calc($spacer__unit / 2);
-    width: auto;
   }
 
   &__main-labels {
@@ -151,7 +159,7 @@
     width: 100%;
     margin-top: 0;
     box-sizing: border-box;
-    height: calc(100% - 1.45rem);
+    height: calc(100% - 1rem);
     font-size: 1rem;
     resize: none;
   }

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -6,73 +6,69 @@
           action="{% url 'edit-judgment' judgment.uri %}">
       {% csrf_token %}
       <input type="hidden" name="return_to" value="{{ return_to }}" />
-      <div class="metadata-component__container">
-        <div class="metadata-component__ncn">
-          <label for="neutral_citation" class="metadata-component__main-labels">
-            {% translate "judgment.neutral_citation" %}
-          </label>
-          <input type="text"
-                 class="metadata-component__neutral_citation-input"
-                 value="{{ judgment.neutral_citation }}"
-                 name="neutral_citation"
-                 id="neutral_citation" />
-        </div>
-        <div class="metadata-component__court">
-          <label for="court" class="metadata-component__main-labels">{% translate "judgment.court" %}</label>
-          <input type="text"
-                 class="metadata-component__court-input"
-                 value="{{ judgment.court }}"
-                 name="court"
-                 id="court"
-                 list="court-ids" />
-          <datalist id="court-ids">
-            {% for court in courts %}<option value="{{ court.code }}">{{ court.name }}</option>{% endfor %}
-          </datalist>
-        </div>
-        <div class="metadata-component__date">
-          <label for="judgment_date" class="metadata-component__main-labels">{% translate "judgment.judgment_date" %}</label>
-          <input type="text"
-                 class="metadata-component__judgment_date-input"
-                 value="{{ judgment.judgment_date_as_string }}"
-                 name="judgment_date"
-                 id="judgment_date" />
-        </div>
-        <div class="metadata-component__top-right-column">
-          <div class="metadata-component__tdr">
-            <aside for="metadata_name" class="metadata-component__main-labels">
-              {% translate "judgments.consignmentref" %}
-            </aside>
-            <p>{{ judgment.consignment_reference }}</p>
+      <div class="metadata-component__left-column">
+        <div class="metadata-component__top-left-row">
+          <div class="metadata-component__ncn">
+            <label for="neutral_citation" class="metadata-component__main-labels">
+              {% translate "judgment.neutral_citation" %}
+            </label>
+            <input type="text"
+                   class="metadata-component__neutral_citation-input"
+                   value="{{ judgment.neutral_citation }}"
+                   name="neutral_citation"
+                   id="neutral_citation" />
           </div>
-          <div class="metadata-component__status">
-            <aside for="metadata_name" class="metadata-component__main-labels">
-              {% translate "judgments.sidebar.status" %}
-            </aside>
-            <p class="judgment-status-indicator judgment-status-indicator--{{ judgment.status | status_tag_colour }}">
-              {{ judgment.status }}
-            </p>
+          <div class="metadata-component__court">
+            <label for="court" class="metadata-component__main-labels">{% translate "judgment.court" %}</label>
+            <input type="text"
+                   class="metadata-component__court-input"
+                   value="{{ judgment.court }}"
+                   name="court"
+                   id="court"
+                   list="court-ids" />
+            <datalist id="court-ids">
+              {% for court in courts %}<option value="{{ court.code }}">{{ court.name }}</option>{% endfor %}
+            </datalist>
+          </div>
+          <div class="metadata-component__date">
+            <label for="judgment_date" class="metadata-component__main-labels">{% translate "judgment.judgment_date" %}</label>
+            <input type="text"
+                   class="metadata-component__judgment_date-input"
+                   value="{{ judgment.judgment_date_as_string }}"
+                   name="judgment_date"
+                   id="judgment_date" />
           </div>
         </div>
-      </div>
-      <div class="metadata-component__container">
         <div class="metadata-component__panel">
           <label for="metadata_name" class="metadata-component__main-labels">{% translate "judgment.judgment_name" %}</label>
-          <textarea class="metadata-component__metadata_name-input"
-                    name="metadata_name"
-                    id="metadata_name"
-                    rows="2">{{ judgment.name }}</textarea>
+          <textarea class="metadata-component__metadata_name-input" name="metadata_name" id="metadata_name" rows="2">
+{{ judgment.name }}</textarea>
         </div>
-        <div class="metadata-component__bottom-right-column">
-          <div class="metadata-component__type">
-            <aside for="metadata_name" class="metadata-component__main-labels">
-              {% translate "document.type" %}
-            </aside>
-            <p>{{ judgment.document_type }}</p>
-          </div>
-          <div class="metadata-component__actions">
-            <input type="hidden" name="judgment_uri" value="{{ judgment_uri }}" />
-            <input type="submit" value="Save" />
-          </div>
+      </div>
+      <div class="metadata-component__right-column">
+        <div class="metadata-component__tdr">
+          <aside for="metadata_name" class="metadata-component__main-labels">
+            {% translate "judgments.consignmentref" %}
+          </aside>
+          <p>{{ judgment.consignment_reference }}</p>
+        </div>
+        <div class="metadata-component__status">
+          <aside for="metadata_name" class="metadata-component__main-labels">
+            {% translate "judgments.sidebar.status" %}
+          </aside>
+          <p class="judgment-status-indicator judgment-status-indicator--{{ judgment.status | status_tag_colour }}">
+            {{ judgment.status }}
+          </p>
+        </div>
+        <div class="metadata-component__type">
+          <aside for="metadata_name" class="metadata-component__main-labels">
+            {% translate "document.type" %}
+          </aside>
+          <p>{{ judgment.document_type }}</p>
+        </div>
+        <div class="metadata-component__actions">
+          <input type="hidden" name="judgment_uri" value="{{ judgment_uri }}" />
+          <input type="submit" value="Save" />
         </div>
       </div>
     </form>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -64,7 +64,7 @@
           <aside for="metadata_name" class="metadata-component__main-labels">
             {% translate "document.type" %}
           </aside>
-          <p>{{ judgment.document_type }}</p>
+          <p>{{ judgment.document_noun|capfirst }}</p>
         </div>
         <div class="metadata-component__actions">
           <input type="hidden" name="judgment_uri" value="{{ judgment_uri }}" />

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -67,7 +67,7 @@
             <aside for="metadata_name" class="metadata-component__main-labels">
               {% translate "document.type" %}
             </aside>
-            <p>Judgment or Press Summary BE</p>
+            <p>{{ judgment.document_type }}</p>
           </div>
           <div class="metadata-component__actions">
             <input type="hidden" name="judgment_uri" value="{{ judgment_uri }}" />

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n status_tag_css %}
 <div class="metadata-header__block">
   <div class="metadata-component">
     <form aria-label="Edit judgment"
@@ -37,6 +37,22 @@
                  name="judgment_date"
                  id="judgment_date" />
         </div>
+        <div class="metadata-component__top-right-column">
+          <div class="metadata-component__tdr">
+            <aside for="metadata_name" class="metadata-component__main-labels">
+              {% translate "judgments.consignmentref" %}
+            </aside>
+            <p>{{ judgment.consignment_reference }}</p>
+          </div>
+          <div class="metadata-component__status">
+            <aside for="metadata_name" class="metadata-component__main-labels">
+              {% translate "judgments.sidebar.status" %}
+            </aside>
+            <p class="judgment-status-indicator judgment-status-indicator--{{ judgment.status | status_tag_colour }}">
+              {{ judgment.status }}
+            </p>
+          </div>
+        </div>
       </div>
       <div class="metadata-component__container">
         <div class="metadata-component__panel">
@@ -47,11 +63,11 @@
                     rows="2">{{ judgment.name }}</textarea>
         </div>
         <div class="metadata-component__bottom-right-column">
-          <div class="metadata-component__tdr">
+          <div class="metadata-component__type">
             <aside for="metadata_name" class="metadata-component__main-labels">
-              {% translate "judgments.consignmentref" %}
+              {% translate "document.type" %}
             </aside>
-            <p>{{ judgment.consignment_reference }}</p>
+            <p>Judgment or Press Summary BE</p>
           </div>
           <div class="metadata-component__actions">
             <input type="hidden" name="judgment_uri" value="{{ judgment_uri }}" />

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -387,3 +387,7 @@ msgstr "Document published"
 #: judgments/views/judgment_publish.py
 msgid "judgment.publish.unpublish_success_flash_message"
 msgstr "Document unpublished"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+msgid "document.type"
+msgstr "Type"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Added status and type label as per design here https://xsodca.axshare.com/?id=ae2k60&p=metadata-panel-with-status-and-type&c=1 some backend required BE placeholder after Type label see images below card has been created for BE.

## Trello card / Rollbar error (etc)
https://trello.com/c/ucQ9ia8u/1134-eui-add-judgment-status-and-doc-type-label-into-metadata-panel-fe-dev
## Screenshots of UI changes:

### Before
![before](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/72e64dbb-bcb1-4a95-9021-c683c2f77e0d)

### After
Judgment
![judgment-view](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/f9534cf0-20e0-4891-9443-f66ee7f19a63)

Press Summary
![press-summary-view](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/9a717b34-48e7-4008-aede-2adaed665e62)

- [ ] Requires env variable(s) to be updated
