### PR TITLE
Rename references to _judgment_text.scss to _document_text.scss in li…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,4 +282,4 @@ docker/*
 /ds_caselaw_editor_ui/static/js/dist/app.js
 
 # This is pulled in automaically by `fab run` from the ds-caselaw-public-ui repo.
-/ds_caselaw_editor_ui/sass/includes/_judgment_text.scss
+/ds_caselaw_editor_ui/sass/includes/_document_text.scss

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN chown django:django ${APP_HOME}
 # Use Github API to get latest tag for public-ui, then use the tag to get the Judgment CSS
 # This Judgment CSS is the "source of truth" for displaying judgments
 RUN apt-get update && apt-get install -y jq curl
-RUN curl https://raw.githubusercontent.com/nationalarchives/ds-caselaw-public-ui/$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/nationalarchives/ds-caselaw-public-ui/releases/latest | jq -r .tag_name)/ds_judgements_public_ui/sass/includes/_judgment_text.scss -o ds_caselaw_editor_ui/sass/includes/_judgment_text.scss
+RUN curl https://raw.githubusercontent.com/nationalarchives/ds-caselaw-public-ui/$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/nationalarchives/ds-caselaw-public-ui/releases/latest | jq -r .tag_name)/ds_judgements_public_ui/sass/includes/_document_text.scss -o ds_caselaw_editor_ui/sass/includes/_document_text.scss
 
 USER django
 

--- a/README.md
+++ b/README.md
@@ -237,18 +237,18 @@ replicated to this repository was tricky as it relied on the developers
 remembering to make changes in both places.
 
 Instead, we share the judgment CSS between both apps. `ds-caselaw-public-ui` is the "source of truth".
-The CSS is located in that repository at `ds_judgements_public_ui/sass/includes/_judgment_text.scss`.
+The CSS is located in that repository at `ds_judgements_public_ui/sass/includes/_document_text.scss`.
 
 Any edits made in `ds-caselaw-public-ui` which are then merged to main and included in a
 production release, will be reflected in `ds-caselaw-editor-ui` (note that the changes have to be included in
 [a release](https://github.com/nationalarchives/ds-caselaw-public-ui/releases) before they are used in the editor).
 
-`_judgment_text.scss` only contains styles for the HTML judgment view. Other CSS styles for the public UI and editor
+`_document_text.scss` only contains styles for the HTML judgment view. Other CSS styles for the public UI and editor
 UI applications are not shared.
 
 When running the application locally, the CSS is retrieved from `ds-caselaw-public-ui` via the local Dockerfile
 `compose/local/django/Dockerfile`. The Dockerfile retrieves the latest release tag of `ds-caselaw-public-ui`, uses that
-tag to build a URL to `_judgment_text.scss` and downloads the CSS to your local application. If you wish to edit the
+tag to build a URL to `_document_text.scss` and downloads the CSS to your local application. If you wish to edit the
 judgment CSS, you **MUST** make those edits in `ds-caselaw-public-ui`.
 
 ### Working with JavaScript

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -59,7 +59,7 @@ COPY . ${APP_HOME}
 # Use Github API to get latest tag for public-ui, then use the tag to get the Judgment CSS
 # This Judgment CSS is the "source of truth" for displaying judgments
 RUN apt-get update && apt-get install -y jq curl
-RUN curl https://raw.githubusercontent.com/nationalarchives/ds-caselaw-public-ui/$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/nationalarchives/ds-caselaw-public-ui/releases/latest | jq -r .tag_name)/ds_judgements_public_ui/sass/includes/_judgment_text.scss -o ds_caselaw_editor_ui/sass/includes/_judgment_text.scss
+RUN curl https://raw.githubusercontent.com/nationalarchives/ds-caselaw-public-ui/$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/nationalarchives/ds-caselaw-public-ui/releases/latest | jq -r .tag_name)/ds_judgements_public_ui/sass/includes/_document_text.scss -o ds_caselaw_editor_ui/sass/includes/_document_text.scss
 
 # Do nothing forever (use 'exec' to resuse the container)
 CMD tail -f /dev/null

--- a/fabfile.py
+++ b/fabfile.py
@@ -75,14 +75,14 @@ def run(c):
     django_exec("python manage.py migrate")
     django_exec("rm -rf /app/staticfiles")
     django_exec("python manage.py collectstatic")
-    # Get the public-ui version of _judgment_text.scss
+    # Get the public-ui version of _document_text.scss
     django_exec("apt-get update && apt-get install -y jq curl")
     django_exec(
         "curl https://raw.githubusercontent.com/nationalarchives/ds-caselaw-public-ui/"
         "$(curl -H 'Accept: application/vnd.github+json' "
         "https://api.github.com/repos/nationalarchives/ds-caselaw-public-ui/releases/latest | jq -r .tag_name)"
-        "/ds_judgements_public_ui/sass/includes/_judgment_text.scss "
-        "-o ds_caselaw_editor_ui/sass/includes/_judgment_text.scss"
+        "/ds_judgements_public_ui/sass/includes/_document_text.scss "
+        "-o ds_caselaw_editor_ui/sass/includes/_document_text.scss"
     )
     # Piping Marklogic logs to marklogic.log
     try:


### PR DESCRIPTION
…ne with the PUI renaming

<!-- Amend as appropriate -->

## Changes in this PR:
- Rename references to _judgment_text.scss to _document_text.scss in line with the PUI renaming since we import _judgment_text.scss in eui from the PUI github. We are going to think about a better way of sharing this between the 2 repos as this is brittle and not scalable.

NOTE: Only merge this in once we have merged in https://github.com/nationalarchives/ds-caselaw-public-ui/pull/837, but then we must quickly deploy EUI as quickly as possible as prod would still be looking for _judgment_text.scss in the PUI github the next time the application is spun up.

## Trello card / Rollbar error (etc)
https://trello.com/c/s6nPDKx6/1152-chore-generalise-pui-references-to-judgment-to-document