### PR TITLE
Update all user facing copy to say 'document' rather than 'judgment' …

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/browse_by_court.html
+++ b/ds_caselaw_editor_ui/templates/includes/browse_by_court.html
@@ -1,7 +1,7 @@
 {% block content %}
   <div class="judgment-browse-by-court">
     <div class="judgment-browse-by-court__container">
-      <h2 id="browse-by-court" class="judgment-browse-by-court__header">Find judgments by court</h2>
+      <h2 id="browse-by-court" class="judgment-browse-by-court__header">Find documents by court</h2>
       <ul class="judgment-browse-by-court__list">
         {% for court in courts %}
           {# {% for court in courts | sort(attribute='name') %} #}

--- a/ds_caselaw_editor_ui/templates/includes/pagination.html
+++ b/ds_caselaw_editor_ui/templates/includes/pagination.html
@@ -1,5 +1,5 @@
-<nav class="pagination" aria-label="unpublished judgments pagination">
-  <h3>Unpublished judgments pagination</h3>
+<nav class="pagination" aria-label="unpublished documents pagination">
+  <h3>Unpublished documents pagination</h3>
   <ul class="pagination__list">
     <li class="pagination__list-item">
       {% if paginator.has_prev_page %}

--- a/ds_caselaw_editor_ui/templates/judgment/results.html
+++ b/ds_caselaw_editor_ui/templates/judgment/results.html
@@ -12,7 +12,7 @@
       <div class="judgments-list__container">
         <div class="judgments-list__judgments-list-controls-container">
           <div class="results__result-header">
-            <p id="recently-published-judgments" class="judgments-list__header">We found {{ total|intcomma }} judgments:</p>
+            <p id="recently-published-judgments" class="judgments-list__header">We found {{ total|intcomma }} documents:</p>
           </div>
         </div>
         <div class="judgments-list__table">

--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -186,7 +186,7 @@ class TestJudgmentView(TestCase):
         response = self.client.get("/test/1234/pdf")
         decoded_response = response.content.decode("utf-8")
         self.assertIn(
-            "Judgment &quot;JUDGMENT v JUDGEMENT&quot; does not have a PDF.",
+            "Document &quot;JUDGMENT v JUDGEMENT&quot; does not have a PDF.",
             decoded_response,
         )
         self.assertEqual(response.status_code, 404)

--- a/judgments/tests/test_unlock.py
+++ b/judgments/tests/test_unlock.py
@@ -36,6 +36,6 @@ def test_break_lock_post(messages, break_checkout, mock_judgment):
 
     response = client.post("/unlock", data={"judgment_uri": "/ewca/civ/2023/1"})
     break_checkout.assert_called_with("ewca/civ/2023/1")
-    messages.success.assert_called_with(ANY, "Judgment unlocked.")
+    messages.success.assert_called_with(ANY, "Document unlocked.")
     assert response.status_code == 302
     assert response.url == reverse("edit-judgment", kwargs={"judgment_uri": "ewca/civ/2023/1"})  # type: ignore

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -76,7 +76,7 @@ def update_document_uri(old_uri, new_citation):
 
     if api_client.document_exists(new_uri):
         raise MoveJudgmentError(
-            f"The URI {new_uri} generated from {new_citation} already exists, you cannot move this judgment to a"
+            f"The URI {new_uri} generated from {new_citation} already exists, you cannot move this document to a"
             f" pre-existing Neutral Citation Number."
         )
 
@@ -87,14 +87,14 @@ def update_document_uri(old_uri, new_citation):
         api_client.set_judgment_this_uri(new_uri)
     except MarklogicAPIError as e:
         raise MoveJudgmentError(
-            f"Failure when attempting to copy judgment from {old_uri} to {new_uri}: {e}"
+            f"Failure when attempting to copy document from {old_uri} to {new_uri}: {e}"
         )
 
     try:
         api_client.delete_judgment(old_uri)
     except MarklogicAPIError as e:
         raise MoveJudgmentError(
-            f"Failure when attempting to delete judgment from {old_uri}: {e}"
+            f"Failure when attempting to delete document from {old_uri}: {e}"
         )
 
     return new_uri

--- a/judgments/views/button_handlers.py
+++ b/judgments/views/button_handlers.py
@@ -21,7 +21,7 @@ def hold_judgment_button(request):
         word = "held"
     else:
         word = "released"
-    messages.success(request, f"Judgment {word}.")
+    messages.success(request, f"Document {word}.")
     return redirect(ensure_local_referer_url(request))
 
 
@@ -34,7 +34,7 @@ def assign_judgment_button(request):
     elif assigned_to == "":
         msg = "Document unassigned."
     else:
-        msg = f"Judgment assigned to {assigned_to}."
+        msg = f"Document assigned to {assigned_to}."
     if request.headers.get("X-Requested-With") == "XMLHttpRequest":
         return HttpResponse(
             json.dumps({"assigned_to": request.user.username, "message": msg}),
@@ -62,7 +62,7 @@ def prioritise_judgment_button(request):
     if priority:
         api_client.set_property(judgment_uri, "editor-priority", priority)
 
-        messages.success(request, "Judgment priority set.")
+        messages.success(request, "Document priority set.")
         return redirect(ensure_local_referer_url(request))
 
     return HttpResponseBadRequest("Priority string not recognised")

--- a/judgments/views/delete.py
+++ b/judgments/views/delete.py
@@ -21,5 +21,5 @@ def delete(request):
 
     template = loader.get_template("judgment/deleted.html")
 
-    messages.success(request, "Judgment deleted.")
+    messages.success(request, "Document deleted.")
     return HttpResponse(template.render(context, request))

--- a/judgments/views/full_text.py
+++ b/judgments/views/full_text.py
@@ -45,7 +45,7 @@ def pdf_view(request, judgment_uri):
     judgment = get_judgment_by_uri_or_404(judgment_uri)
 
     if not judgment.pdf_url:
-        raise Http404(f'Judgment "{judgment.name}" does not have a PDF.')
+        raise Http404(f'Document "{judgment.name}" does not have a PDF.')
 
     context = {
         "judgment_uri": judgment_uri,

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -73,16 +73,16 @@ class EditJudgmentView(View):
                     reverse("edit-judgment", kwargs={"judgment_uri": new_judgment_uri})
                 )
 
-            messages.success(request, "Judgment successfully updated")
+            messages.success(request, "Document successfully updated")
 
         except (MoveJudgmentError, NeutralCitationToUriError) as e:
             messages.error(
                 request,
-                f"There was an error updating the Judgment's neutral citation: {e}",
+                f"There was an error updating the Document's neutral citation: {e}",
             )
 
         except MarklogicAPIError as e:
-            messages.error(request, f"There was an error saving the Judgment: {e}")
+            messages.error(request, f"There was an error saving the Document: {e}")
 
         invalidate_caches(judgment.uri)
 

--- a/judgments/views/unlock.py
+++ b/judgments/views/unlock.py
@@ -39,8 +39,8 @@ def unlock_post(request):
         api_client.break_checkout(judgment.uri)
     except MarklogicResourceUnmanagedError as exc:
         raise Http404(
-            f"Resource Unmanaged: Judgment '{judgment_uri}' might not exist."
+            f"Resource Unmanaged: Document '{judgment_uri}' might not exist."
         ) from exc
     else:
-        messages.success(request, "Judgment unlocked.")
+        messages.success(request, "Document unlocked.")
         return redirect(reverse("edit-judgment", kwargs={"judgment_uri": judgment.uri}))

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -124,7 +124,7 @@ msgstr "Create in Jira"
 #: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
 #: judgments/views/unlock.py
 msgid "judgment.unlock_judgment_title"
-msgstr "Unlock judgment"
+msgstr "Unlock document"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgment.report_blocking_problem"
@@ -182,7 +182,7 @@ msgstr "Delete"
 
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html
 msgid "judgments.details"
-msgstr "Judgment details:"
+msgstr "Document details:"
 
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_header.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -208,26 +208,26 @@ msgstr "Assigned to:"
 #: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
 #: judgments/tests/test_judgment_list.py
 msgid "home.recent"
-msgstr "Unpublished judgments"
+msgstr "Unpublished documents"
 
 #: ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
 #: ds_caselaw_editor_ui/templates/judgment/results.html
 msgid "judgments.allrecent"
-msgstr "See all recent judgments"
+msgstr "See all recent documents"
 
 #: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
 msgid "judgment.confirm_unlock"
 msgstr ""
-"Forcibly unlock this judgment? This will make any enrichment processes on "
-"the judgment fail."
+"Forcibly unlock this document? This will make any enrichment processes on "
+"the document fail."
 
 #: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
 msgid "judgment.back_to_judgment"
-msgstr "Back to judgment"
+msgstr "Back to document"
 
 #: ds_caselaw_editor_ui/templates/judgment/deleted.html
 msgid "judgment.deleted"
-msgstr "Judgment successfully deleted"
+msgstr "Document successfully deleted"
 
 #: ds_caselaw_editor_ui/templates/judgment/deleted.html
 msgid "judgment.return_home"
@@ -337,11 +337,11 @@ msgstr ""
 
 #: judgments/tests/test_judgments.py judgments/views/judgment_publish.py
 msgid "judgment.publish.publish_title"
-msgstr "Publish judgment"
+msgstr "Publish document"
 
 #: judgments/tests/test_judgments.py judgments/views/judgment_publish.py
 msgid "judgment.publish.publish_success_title"
-msgstr "Published judgment"
+msgstr "Published document"
 
 #: judgments/tests/test_judgments.py judgments/views/judgment_hold.py
 msgid "judgment.hold.hold_title"
@@ -353,7 +353,7 @@ msgstr "Document on hold"
 
 #: judgments/views/delete.py
 msgid "judgment.delete_a_judgment"
-msgstr "Delete a judgment"
+msgstr "Delete a document"
 
 #: judgments/views/judgment_hold.py
 msgid "judgment.hold.hold_success_flash_message"


### PR DESCRIPTION

## Changes in this PR:


…where appropriate

apart from the templates for emails to submitters, and the name of the 'date' field, which will probably need some logic to use the correct verb, as it's important they be specific.

I haven't yet updated eg class names / filenames - will do this in a seperate PR as it's a larger job that touches more files, so best done when we haven't got lots of other things going on in parallel

<!-- Amend as appropriate -->


## Trello card / Rollbar error (etc)
https://trello.com/c/Kv2RUSrZ/1123-eui-update-user-facing-language-in-editor-ui-to-say-document-instead-of-judgment-in-situations-where-either-a-judgment-or-a-pres
