### PR TITLE
Add a hover color to the tabset, and fix a bug when used twice on the same page

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_tabs.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_tabs.scss
@@ -7,9 +7,9 @@
     margin: 0 0.25rem;
 
     label {
-      background: $color__dark-blue;
+      background: $color__aqua-blue;
       padding-top: 0.75rem;
-      border: 2px solid $color__dark-blue;
+      border: 2px solid $color__aqua-blue;
       border-bottom: none;
       border-top-left-radius: 10px;
       border-top-right-radius: 10px;
@@ -28,6 +28,11 @@
           outline-offset: 5px;
         }
       }
+
+      &:hover {
+        background: $color__dark-blue;
+        border-color: $color__dark-blue;
+      }
     }
 
     input[type="radio"] {
@@ -38,12 +43,13 @@
       border-bottom: 2px solid $color__white;
       background: $color__white;
       a {
-        color: $color__dark-blue;
+        color: $color__aqua-blue;
+        cursor: default;
       }
     }
   }
 
   &__divider {
-    border-top: solid 2px $color__dark-blue;
+    border-top: solid 2px $color__aqua-blue;
   }
 }

--- a/ds_caselaw_editor_ui/templates/includes/style_guide/tabs.html
+++ b/ds_caselaw_editor_ui/templates/includes/style_guide/tabs.html
@@ -2,10 +2,10 @@
 <details>
   <summary>Usage details</summary>
   <p>
-    Tabs are usually used to accommodate sections of content that can share the same space and heirarchy. For example the 'HTML view' and the 'PDF view' on the editor user interface.
+    Tabs are usually used to accommodate sections of content that can share the same space and heirarchy. For example the 'HTML view' and the 'PDF view' on the editor user interface. If for some reason you need to use more than one tab set on a page, you must provide a unique <code>name</code> variable to each. If there's only one tab set on the page, this is optional.
   </p>
 </details>
 <p>
   Use with <code>include "includes/tabs.html" with label1="HTML view" label2="PDF view" url1="#first-tab" url2="#second-tab" selected=1 javascript_enabled=True</code>:
 </p>
-{% include "includes/tabs.html" with label1="HTML view" label2="PDF view" url1="#first-tab" url2="#second-tab" selected=1 javascript_enabled=True %}
+{% include "includes/tabs.html" with label1="HTML view" label2="PDF view" url1="#first-tab" url2="#second-tab" selected=1 name="tab-set-demo" javascript_enabled=True %}

--- a/ds_caselaw_editor_ui/templates/includes/tabs.html
+++ b/ds_caselaw_editor_ui/templates/includes/tabs.html
@@ -2,7 +2,7 @@
   <div class="tabs-set__item">
     <input type="radio"
            id="tab1"
-           name="tabs-set"
+           name="{{ name|default:"tabs-set" }}"
            value="1"
            {% if selected == 1 %}checked{% endif %} />
     <label for="tab1">
@@ -12,7 +12,7 @@
   <div class="tabs-set__item">
     <input type="radio"
            id="tab2"
-           name="tabs-set"
+           name="{{ name|default:"tabs-set" }}"
            value="2"
            {% if selected == 2 %}checked{% endif %} />
     <label for="tab2">


### PR DESCRIPTION

## Changes in this PR:

Two minor improvements, we now have a hover colour on unselected tabs (and the cursor displays correctly on selected tabs), and the colours for hover/inactive/selected are consistent with the CTAs (before they were reversed)

I also i fixed a slightly puzzling thing where if the tabset is used twice in the same page, the first instance appears to break (showing all tabs as unselected). This has meant a slight change to the interface - if it's used twice on the same page, each tabset must be given a unique `name` property, which is noted in the styleguide.


## Trello card / Rollbar error (etc)

https://trello.com/c/0pOIKYIQ/1189-bug-tabs-component-design-fix-hover-colour
## Screenshots of UI changes:

### Before
<img width="571" alt="Screenshot 2023-07-24 at 14 22 27" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/337a7e05-a574-4bdd-bd90-7a7cbb169eda">

### After
#### No Hover
<img width="571" alt="Screenshot 2023-07-24 at 14 58 30" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/50f1fa0f-0332-4a8f-908d-f048a2d3637a">
#### Hover

<img width="571" alt="Screenshot 2023-07-24 at 14 58 35" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/45783950-40da-4e38-a1a9-5ad8ef1bf01d">
