### PR TITLE
Upgrade docker OS to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG PYTHON_VERSION=3.11-slim-bullseye
-
-
+ARG PYTHON_VERSION=3.11-slim-bookworm
 
 # define an alias for the specfic python version used in this file.
 FROM python:${PYTHON_VERSION} as python

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.11-slim-bullseye
+ARG PYTHON_VERSION=3.11-slim-bookworm
 
 # define an alias for the specfic python version used in this file.
 FROM python:${PYTHON_VERSION} as python

--- a/compose/local/docs/Dockerfile
+++ b/compose/local/docs/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.11-slim-bullseye
+ARG PYTHON_VERSION=3.11-slim-bookworm
 
 # define an alias for the specfic python version used in this file.
 FROM python:${PYTHON_VERSION} as python

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.11-slim-bullseye
+ARG PYTHON_VERSION=3.11-slim-bookworm
 
 
 


### PR DESCRIPTION
We hit issues with  
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@webpack-cli/configtest@2.1.1',
npm WARN EBADENGINE   required: { node: '>=14.15.0' },
npm WARN EBADENGINE   current: { node: 'v12.22.12', npm: '7.5.2' }
npm WARN EBADENGINE }
```
leading to failed deploys due to the webpack upgrade
and think upgrading to debian bookworm will fix this 

https://packages.debian.org/bookworm/nodejs