### PR TITLE
Remove pretext breadcrumbs on hold and publish 

### DIFF
--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -5,7 +5,6 @@ from urllib.parse import urlencode
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
-from django.utils.translation import gettext
 from factories import JudgmentFactory
 
 
@@ -218,7 +217,6 @@ class TestJudgmentPublish(TestCase):
         response = self.client.get(publish_uri)
 
         decoded_response = response.content.decode("utf-8")
-        self.assertIn(gettext("judgment.publish.publish_title"), decoded_response)
         self.assertIn("Test v Tested", decoded_response)
         assert response.status_code == 200
 
@@ -268,9 +266,6 @@ class TestJudgmentPublish(TestCase):
         response = self.client.get(publish_success_uri)
 
         decoded_response = response.content.decode("utf-8")
-        self.assertIn(
-            gettext("judgment.publish.publish_success_title"), decoded_response
-        )
         self.assertIn("Test v Tested", decoded_response)
         assert response.status_code == 200
 
@@ -293,7 +288,6 @@ class TestJudgmentHold(TestCase):
         response = self.client.get(hold_uri)
 
         decoded_response = response.content.decode("utf-8")
-        self.assertIn(gettext("judgment.hold.hold_title"), decoded_response)
         self.assertIn("Test v Tested", decoded_response)
         assert response.status_code == 200
 
@@ -343,7 +337,6 @@ class TestJudgmentHold(TestCase):
         response = self.client.get(hold_success_uri)
 
         decoded_response = response.content.decode("utf-8")
-        self.assertIn(gettext("judgment.hold.hold_success_title"), decoded_response)
         self.assertIn("Test v Tested", decoded_response)
         assert response.status_code == 200
 
@@ -366,7 +359,6 @@ class TestJudgmentUnhold(TestCase):
         response = self.client.get(unhold_uri)
 
         decoded_response = response.content.decode("utf-8")
-        self.assertIn(gettext("judgment.hold.unhold_title"), decoded_response)
         self.assertIn("Test v Tested", decoded_response)
         assert response.status_code == 200
 
@@ -416,7 +408,6 @@ class TestJudgmentUnhold(TestCase):
         response = self.client.get(unhold_success_uri)
 
         decoded_response = response.content.decode("utf-8")
-        self.assertIn(gettext("judgment.hold.unhold_success_title"), decoded_response)
         self.assertIn("Test v Tested", decoded_response)
         assert response.status_code == 200
 
@@ -441,7 +432,6 @@ class TestJudgmentUnpublish(TestCase):
         response = self.client.get(unpublish_uri)
 
         decoded_response = response.content.decode("utf-8")
-        self.assertIn(gettext("judgment.publish.unpublish_title"), decoded_response)
         self.assertIn("Test v Tested", decoded_response)
         assert response.status_code == 200
 
@@ -491,9 +481,6 @@ class TestJudgmentUnpublish(TestCase):
         response = self.client.get(unpublish_success_uri)
 
         decoded_response = response.content.decode("utf-8")
-        self.assertIn(
-            gettext("judgment.publish.unpublish_success_title"), decoded_response
-        )
         self.assertIn("Test v Tested", decoded_response)
         assert response.status_code == 200
 

--- a/judgments/views/judgment_hold.py
+++ b/judgments/views/judgment_hold.py
@@ -20,9 +20,7 @@ class HoldJudgmentView(TemplateView):
 
         context.update(
             {
-                "page_title": '{title}: "{judgment}"'.format(
-                    title=gettext("judgment.hold.hold_title"), judgment=judgment.name
-                ),
+                "page_title": "{judgment}".format(judgment=judgment.name),
                 "view": "hold_judgment",
                 "judgment": judgment,
                 "editors": editors_dict(),
@@ -53,8 +51,7 @@ class HoldJudgmentSuccessView(TemplateView):
 
         context.update(
             {
-                "page_title": '{title}: "{judgment}"'.format(
-                    title=gettext("judgment.hold.hold_success_title"),
+                "page_title": "{judgment}".format(
                     judgment=judgment.name,
                 ),
                 "judgment": judgment,
@@ -105,8 +102,7 @@ class UnholdJudgmentView(TemplateView):
 
         context.update(
             {
-                "page_title": '{title}: "{judgment}"'.format(
-                    title=gettext("judgment.hold.unhold_title"),
+                "page_title": "{judgment}".format(
                     judgment=judgment.name,
                 ),
                 "view": "hold_judgment",
@@ -139,8 +135,7 @@ class UnholdJudgmentSuccessView(TemplateView):
 
         context.update(
             {
-                "page_title": '{title}: "{judgment}"'.format(
-                    title=gettext("judgment.hold.unhold_success_title"),
+                "page_title": "{judgment}".format(
                     judgment=judgment.name,
                 ),
                 "judgment": judgment,

--- a/judgments/views/judgment_hold.py
+++ b/judgments/views/judgment_hold.py
@@ -20,7 +20,7 @@ class HoldJudgmentView(TemplateView):
 
         context.update(
             {
-                "page_title": "{judgment}".format(judgment=judgment.name),
+                "page_title": judgment.name,
                 "view": "hold_judgment",
                 "judgment": judgment,
                 "editors": editors_dict(),
@@ -51,9 +51,7 @@ class HoldJudgmentSuccessView(TemplateView):
 
         context.update(
             {
-                "page_title": "{judgment}".format(
-                    judgment=judgment.name,
-                ),
+                "page_title": judgment.name,
                 "judgment": judgment,
                 "email_issue_link": build_raise_issue_email_link(
                     judgment=judgment,
@@ -102,9 +100,7 @@ class UnholdJudgmentView(TemplateView):
 
         context.update(
             {
-                "page_title": "{judgment}".format(
-                    judgment=judgment.name,
-                ),
+                "page_title": judgment.name,
                 "view": "hold_judgment",
                 "judgment": judgment,
                 "editors": editors_dict(),
@@ -135,9 +131,7 @@ class UnholdJudgmentSuccessView(TemplateView):
 
         context.update(
             {
-                "page_title": "{judgment}".format(
-                    judgment=judgment.name,
-                ),
+                "page_title": judgment.name,
                 "judgment": judgment,
                 "editors": editors_dict(),
             }

--- a/judgments/views/judgment_publish.py
+++ b/judgments/views/judgment_publish.py
@@ -30,8 +30,7 @@ class PublishJudgmentView(TemplateView):
 
         context.update(
             {
-                "page_title": '{title}: "{judgment}"'.format(
-                    title=gettext("judgment.publish.publish_title"),
+                "page_title": "{judgment}".format(
                     judgment=judgment.name,
                 ),
                 "view": "publish_judgment",
@@ -64,8 +63,7 @@ class PublishJudgmentSuccessView(TemplateView):
 
         context.update(
             {
-                "page_title": '{title}: "{judgment}"'.format(
-                    title=gettext("judgment.publish.publish_success_title"),
+                "page_title": "{judgment}".format(
                     judgment=judgment.name,
                 ),
                 "judgment": judgment,
@@ -116,8 +114,7 @@ class UnpublishJudgmentView(TemplateView):
 
         context.update(
             {
-                "page_title": '{title}: "{judgment}"'.format(
-                    title=gettext("judgment.publish.unpublish_title"),
+                "page_title": "{judgment}".format(
                     judgment=judgment.name,
                 ),
                 "view": "publish_judgment",
@@ -150,8 +147,7 @@ class UnpublishJudgmentSuccessView(TemplateView):
 
         context.update(
             {
-                "page_title": '{title}: "{judgment}"'.format(
-                    title=gettext("judgment.publish.unpublish_success_title"),
+                "page_title": "{judgment}".format(
                     judgment=judgment.name,
                 ),
                 "judgment": judgment,

--- a/judgments/views/judgment_publish.py
+++ b/judgments/views/judgment_publish.py
@@ -30,9 +30,7 @@ class PublishJudgmentView(TemplateView):
 
         context.update(
             {
-                "page_title": "{judgment}".format(
-                    judgment=judgment.name,
-                ),
+                "page_title": judgment.name,
                 "view": "publish_judgment",
                 "judgment": judgment,
                 "editors": editors_dict(),
@@ -63,9 +61,7 @@ class PublishJudgmentSuccessView(TemplateView):
 
         context.update(
             {
-                "page_title": "{judgment}".format(
-                    judgment=judgment.name,
-                ),
+                "page_title": judgment.name,
                 "judgment": judgment,
                 "email_confirmation_link": build_confirmation_email_link(
                     judgment=judgment,
@@ -114,9 +110,7 @@ class UnpublishJudgmentView(TemplateView):
 
         context.update(
             {
-                "page_title": "{judgment}".format(
-                    judgment=judgment.name,
-                ),
+                "page_title": judgment.name,
                 "view": "publish_judgment",
                 "judgment": judgment,
                 "editors": editors_dict(),
@@ -147,9 +141,7 @@ class UnpublishJudgmentSuccessView(TemplateView):
 
         context.update(
             {
-                "page_title": "{judgment}".format(
-                    judgment=judgment.name,
-                ),
+                "page_title": judgment.name,
                 "judgment": judgment,
                 "editors": editors_dict(),
             }

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -271,7 +271,6 @@ msgid "results.search.title"
 msgstr "Search results"
 
 #: ds_caselaw_editor_ui/templates/judgment/unhold-success.html
-#: judgments/tests/test_judgments.py judgments/views/judgment_hold.py
 msgid "judgment.hold.unhold_success_title"
 msgstr "This document has been taken off hold"
 
@@ -280,7 +279,6 @@ msgid "judgment.unhold.success"
 msgstr "This document is no longer on hold."
 
 #: ds_caselaw_editor_ui/templates/judgment/unhold.html
-#: judgments/tests/test_judgments.py judgments/views/judgment_hold.py
 msgid "judgment.hold.unhold_title"
 msgstr "Take this document off hold"
 
@@ -289,12 +287,10 @@ msgid "judgment.unhold.unhold_button"
 msgstr "Unhold document"
 
 #: ds_caselaw_editor_ui/templates/judgment/unpublish-success.html
-#: judgments/tests/test_judgments.py judgments/views/judgment_publish.py
 msgid "judgment.publish.unpublish_success_title"
 msgstr "This document is no longer published"
 
 #: ds_caselaw_editor_ui/templates/judgment/unpublish.html
-#: judgments/tests/test_judgments.py judgments/views/judgment_publish.py
 msgid "judgment.publish.unpublish_title"
 msgstr "Unpublish this document"
 
@@ -335,21 +331,6 @@ msgstr ""
 "a seperate file under the includes/style_guide folder, and include it below "
 "following the example in the template."
 
-#: judgments/tests/test_judgments.py judgments/views/judgment_publish.py
-msgid "judgment.publish.publish_title"
-msgstr "Publish document"
-
-#: judgments/tests/test_judgments.py judgments/views/judgment_publish.py
-msgid "judgment.publish.publish_success_title"
-msgstr "Published document"
-
-#: judgments/tests/test_judgments.py judgments/views/judgment_hold.py
-msgid "judgment.hold.hold_title"
-msgstr "Put on hold"
-
-#: judgments/tests/test_judgments.py judgments/views/judgment_hold.py
-msgid "judgment.hold.hold_success_title"
-msgstr "Document on hold"
 
 #: judgments/views/delete.py
 msgid "judgment.delete_a_judgment"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Remove extra pretext breadcrumbs in the 'on hold' and 'publish' 
## Trello card / Rollbar error (etc)
https://trello.com/c/EslWpogp/1197-remove-extra-breadcrumbs-for-put-on-hold-and-publish-document
## Screenshots of UI changes:

### Before
Judgment View
![before-judgment-view](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/87b24e50-b31a-47c5-827a-59bd10e69978)
Press Summary View
![ps-view-before](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/1c82c0b6-77e0-45eb-9d6f-bdbbfb68ff9c)

### After
Judgment View
![after-judgment-view](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/af28b5a9-36ee-481d-ae0a-ac8a0278ff75)
Press Summary View
![ps-view-after](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/8217637e-4bf8-40e7-8e8c-7fa1877de3bd)

- [ ] Requires env variable(s) to be updated
