### PR TITLE
Tidy up the sidebar, add link to related docs

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_sidebar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_sidebar.scss
@@ -1,8 +1,20 @@
 .judgment-sidebar {
   &__block {
-    margin-bottom: 2rem;
+    &:first-child {
+      margin-top: 3rem;
+    }
+
+    margin-bottom: 3rem;
     h4 {
-      margin-bottom: 0.6rem;
+      font-size: 0.8rem;
+      line-height: 1.4rem;
+      margin: 0;
+    }
+
+    p {
+      margin-top: 0;
+      font-size: 0.8rem;
+      line-height: 1.4rem;
     }
 
     a {
@@ -10,31 +22,20 @@
     }
 
     ul {
+      margin-top: 0;
       padding-left: 0;
     }
 
     li {
+      margin-top: 0;
       list-style: none;
-      margin-top: 0.4rem;
       font-size: 0.8rem;
-    }
-
-    dl {
-      margin-top: 1rem;
-      font-size: 0.8rem;
-    }
-
-    dt {
-      font-weight: bold;
-    }
-
-    dd {
-      margin-left: 0;
-      margin-bottom: $spacer__unit;
+      line-height: 1.4rem;
     }
 
     .judgment-status-indicator {
       font-size: 1rem;
+      margin-top: 0.2rem;
     }
   }
 

--- a/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
@@ -6,21 +6,28 @@
       <span class="judgment-status-indicator judgment-status-indicator--{{ judgment.status | status_tag_colour }}">{{ judgment.status }}</span>
     </li>
   </ul>
-  <h4>{% translate "judgments.sidebar.submission" %}</h4>
-  <dl class="items">
-    <dt class="judgment-sidebar__label">{% translate "judgments.submitter" %}</dt>
-    <dd>
-      {{ judgment.source_name }}
-    </dd>
-    <dt class="judgment-sidebar__label">{% translate "judgments.submitteremail" %}</dt>
-    <dd>
-      <a href="mailto:{{ judgment.source_email }}">{{ judgment.source_email }}</a>
-    </dd>
-    <dt class="judgment-sidebar__label">{% translate "judgments.consignmentref" %}</dt>
-    <dd>
-      {{ judgment.consignment_reference }}
-    </dd>
-  </dl>
+</div>
+<div class="judgment-sidebar__block">
+  <h4>{% translate "judgments.associated_douments" %}</h4>
+  <p>
+    {% if linked_document_uri %}
+      <a href="{% url 'full-text-html' linked_document_uri %}">
+        {% if document_type == "press_summary" %}
+          Judgment
+        {% else %}
+          Press Summary
+        {% endif %}
+      </a>
+    {% else %}
+      None
+    {% endif %}
+  </p>
+</div>
+<div class="judgment-sidebar__block">
+  <h4>{% translate "judgments.submitter" %}</h4>
+  <p>
+    <a href="mailto:{{ judgment.source_email }}">{{ judgment.source_name }}</a>
+  </p>
 </div>
 <div class="judgment-sidebar__block">
   <h4>{% translate "judgments.sidebar.tools" %}</h4>

--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -14,7 +14,10 @@ def assert_match(regex, string):
 
 class TestJudgmentEdit(TestCase):
     @patch("judgments.views.judgment_edit.get_judgment_by_uri_or_404")
-    def test_judgment_edit_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_edit_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="edtest/4321/123",
             name="Test v Tested",
@@ -108,7 +111,10 @@ class TestJudgmentEdit(TestCase):
 
 class TestJudgmentView(TestCase):
     @patch("judgments.views.full_text.get_judgment_by_uri_or_404")
-    def test_judgment_html_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_html_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="hvtest/4321/123",
             name="Test v Tested",
@@ -133,7 +139,10 @@ class TestJudgmentView(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.full_text.get_judgment_by_uri_or_404")
-    def test_judgment_html_view_with_failure(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_html_view_with_failure(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="hvtest/4321/123",
             html="<h1>Test Judgment</h1>",
@@ -201,7 +210,10 @@ class TestJudgmentView(TestCase):
 
 class TestJudgmentPublish(TestCase):
     @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
-    def test_judgment_publish_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_publish_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
             name="Test v Tested",
@@ -248,7 +260,10 @@ class TestJudgmentPublish(TestCase):
         mock_invalidate_caches.assert_called_once()
 
     @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
-    def test_judgment_publish_success_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_publish_success_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
             name="Test v Tested",
@@ -272,7 +287,10 @@ class TestJudgmentPublish(TestCase):
 
 class TestJudgmentHold(TestCase):
     @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
-    def test_judgment_hold_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_hold_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="holdtest/4321/123",
             name="Test v Tested",
@@ -319,7 +337,10 @@ class TestJudgmentHold(TestCase):
         mock_invalidate_caches.assert_called_once()
 
     @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
-    def test_judgment_hold_success_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_hold_success_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="holdtest/4321/123",
             name="Test v Tested",
@@ -343,7 +364,10 @@ class TestJudgmentHold(TestCase):
 
 class TestJudgmentUnhold(TestCase):
     @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
-    def test_judgment_unhold_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_unhold_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="unholdtest/4321/123",
             name="Test v Tested",
@@ -390,7 +414,10 @@ class TestJudgmentUnhold(TestCase):
         mock_invalidate_caches.assert_called_once()
 
     @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
-    def test_judgment_hold_success_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_hold_success_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="unholdtest/4321/123",
             name="Test v Tested",
@@ -414,7 +441,10 @@ class TestJudgmentUnhold(TestCase):
 
 class TestJudgmentUnpublish(TestCase):
     @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
-    def test_judgment_unpublish_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_unpublish_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
             name="Test v Tested",
@@ -463,7 +493,10 @@ class TestJudgmentUnpublish(TestCase):
         mock_invalidate_caches.assert_called_once()
 
     @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
-    def test_judgment_unpublish_success_view(self, mock_judgment):
+    @patch("judgments.utils.check_document_at_uri_exists")
+    def test_judgment_unpublish_success_view(self, document_exists, mock_judgment):
+        document_exists.return_value = None
+
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
             name="Test v Tested",

--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -2,6 +2,7 @@ import re
 from unittest.mock import patch
 from urllib.parse import urlencode
 
+from caselawclient.models.judgments import Judgment
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
@@ -14,8 +15,10 @@ def assert_match(regex, string):
 
 class TestJudgmentEdit(TestCase):
     @patch("judgments.views.judgment_edit.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_edit_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_edit_view(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -111,8 +114,10 @@ class TestJudgmentEdit(TestCase):
 
 class TestJudgmentView(TestCase):
     @patch("judgments.views.full_text.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_html_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_html_view(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -139,8 +144,12 @@ class TestJudgmentView(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.full_text.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_html_view_with_failure(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_html_view_with_failure(
+        self, document_type, document_exists, mock_judgment
+    ):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -210,8 +219,10 @@ class TestJudgmentView(TestCase):
 
 class TestJudgmentPublish(TestCase):
     @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_publish_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_publish_view(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -260,8 +271,12 @@ class TestJudgmentPublish(TestCase):
         mock_invalidate_caches.assert_called_once()
 
     @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_publish_success_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_publish_success_view(
+        self, document_type, document_exists, mock_judgment
+    ):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -287,8 +302,10 @@ class TestJudgmentPublish(TestCase):
 
 class TestJudgmentHold(TestCase):
     @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_hold_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_hold_view(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -337,8 +354,12 @@ class TestJudgmentHold(TestCase):
         mock_invalidate_caches.assert_called_once()
 
     @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_hold_success_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_hold_success_view(
+        self, document_type, document_exists, mock_judgment
+    ):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -364,8 +385,10 @@ class TestJudgmentHold(TestCase):
 
 class TestJudgmentUnhold(TestCase):
     @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_unhold_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_unhold_view(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -414,8 +437,12 @@ class TestJudgmentUnhold(TestCase):
         mock_invalidate_caches.assert_called_once()
 
     @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_hold_success_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_hold_success_view(
+        self, document_type, document_exists, mock_judgment
+    ):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -441,8 +468,12 @@ class TestJudgmentUnhold(TestCase):
 
 class TestJudgmentUnpublish(TestCase):
     @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_unpublish_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_unpublish_view(
+        self, document_type, document_exists, mock_judgment
+    ):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(
@@ -493,8 +524,12 @@ class TestJudgmentUnpublish(TestCase):
         mock_invalidate_caches.assert_called_once()
 
     @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
-    @patch("judgments.utils.check_document_at_uri_exists")
-    def test_judgment_unpublish_success_view(self, document_exists, mock_judgment):
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_judgment_unpublish_success_view(
+        self, document_type, document_exists, mock_judgment
+    ):
+        document_type.return_value = Judgment
         document_exists.return_value = None
 
         judgment = JudgmentFactory.build(

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -2,10 +2,12 @@ import re
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from operator import itemgetter
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 import ds_caselaw_utils as caselawutils
 from caselawclient.Client import MarklogicApiClient, MarklogicAPIError, api_client
+from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.judgments import Judgment
 from django.conf import settings
 from django.contrib.auth.models import Group, User
@@ -171,3 +173,29 @@ def get_judgment_by_uri(judgment_uri: str) -> Judgment:
     )
 
     return Judgment(judgment_uri, api_client)
+
+
+def check_document_at_uri_exists(document_uri: str) -> Optional[str]:
+    try:
+        get_judgment_by_uri(document_uri)
+        return document_uri
+    except DocumentNotFoundError:
+        return None
+
+
+def set_document_type_and_link(
+    context: Dict[str, Any], document_uri: str
+) -> Dict[str, Any]:
+    press_summary_suffix = "/press-summary/1"
+
+    if document_uri.endswith(press_summary_suffix):
+        context["document_type"] = "press_summary"
+        context["linked_document_uri"] = check_document_at_uri_exists(
+            document_uri.removesuffix(press_summary_suffix)
+        )
+    else:
+        context["document_type"] = "judgment"
+        context["linked_document_uri"] = check_document_at_uri_exists(
+            document_uri + press_summary_suffix
+        )
+    return context

--- a/judgments/views/full_text.py
+++ b/judgments/views/full_text.py
@@ -5,7 +5,7 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.template import loader
 from django.urls import reverse
 
-from judgments.utils import extract_version
+from judgments.utils import extract_version, set_document_type_and_link
 from judgments.utils.view_helpers import get_judgment_by_uri_or_404
 
 
@@ -20,14 +20,7 @@ def html_view(request, judgment_uri):
         "courts": caselawutils.courts.get_all(),
     }
 
-    press_summary_suffix = "/press-summary/1"
-    if judgment_uri.endswith(press_summary_suffix):
-        context["document_type"] = "press_summary"
-        context["linked_document_uri"] = judgment_uri.removesuffix(press_summary_suffix)
-
-    else:
-        context["document_type"] = "judgment"
-        context["linked_document_uri"] = judgment_uri + press_summary_suffix
+    context = set_document_type_and_link(context, judgment_uri)
 
     if not judgment.is_editable:
         judgment_content = judgment.content_as_xml()
@@ -62,14 +55,7 @@ def pdf_view(request, judgment_uri):
         "view": "judgment_text",
     }
 
-    press_summary_suffix = "/press-summary/1"
-    if judgment_uri.endswith(press_summary_suffix):
-        context["document_type"] = "press_summary"
-        context["linked_document_uri"] = judgment_uri.removesuffix(press_summary_suffix)
-
-    else:
-        context["document_type"] = "judgment"
-        context["linked_document_uri"] = judgment_uri + press_summary_suffix
+    context = set_document_type_and_link(context, judgment_uri)
 
     if version_uri:
         context["version"] = extract_version(version_uri)

--- a/judgments/views/full_text.py
+++ b/judgments/views/full_text.py
@@ -23,7 +23,7 @@ def html_view(request, judgment_uri):
     context = set_document_type_and_link(context, judgment_uri)
 
     if not judgment.is_editable:
-        judgment_content = judgment.content_as_xml()
+        judgment_content = judgment.content_as_xml
         metadata_name = judgment_uri
     else:
         judgment_content = judgment.content_as_html(version_uri=version_uri)
@@ -71,7 +71,7 @@ def pdf_view(request, judgment_uri):
 
 def xml_view(request, judgment_uri):
     judgment = get_judgment_by_uri_or_404(judgment_uri)
-    judgment_xml = judgment.content_as_xml()
+    judgment_xml = judgment.content_as_xml
 
     response = HttpResponse(judgment_xml, content_type="application/xml")
     response["Content-Disposition"] = f"attachment; filename={judgment_uri}.xml"

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -11,6 +11,7 @@ from judgments.utils import (
     MoveJudgmentError,
     NeutralCitationToUriError,
     editors_dict,
+    set_document_type_and_link,
     update_document_uri,
 )
 from judgments.utils.aws import invalidate_caches
@@ -37,17 +38,8 @@ class EditJudgmentView(View):
             judgment=judgment, request=request
         )
 
-        press_summary_suffix = "/press-summary/1"
-        if judgment_uri.endswith(press_summary_suffix):
-            context["document_type"] = "press_summary"
-            context["linked_document_uri"] = judgment_uri.removesuffix(
-                press_summary_suffix
-            )
-        else:
-            context["document_type"] = "judgment"
-            context["linked_document_uri"] = judgment_uri + press_summary_suffix
+        context = set_document_type_and_link(context, judgment_uri)
 
-        print(context)
         template = loader.get_template("judgment/edit.html")
         return HttpResponse(template.render(context, request))
 

--- a/judgments/views/judgment_hold.py
+++ b/judgments/views/judgment_hold.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from django.utils.translation import gettext
 from django.views.generic import TemplateView
 
-from judgments.utils import editors_dict
+from judgments.utils import editors_dict, set_document_type_and_link
 from judgments.utils.aws import invalidate_caches
 from judgments.utils.link_generators import build_raise_issue_email_link
 from judgments.utils.view_helpers import get_judgment_by_uri_or_404
@@ -39,15 +39,7 @@ class HoldJudgmentSuccessView(TemplateView):
         judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
-        press_summary_suffix = "/press-summary/1"
-        if judgment_uri.endswith(press_summary_suffix):
-            context["document_type"] = "press_summary"
-            context["linked_document_uri"] = judgment_uri.removesuffix(
-                press_summary_suffix
-            )
-        else:
-            context["document_type"] = "judgment"
-            context["linked_document_uri"] = judgment_uri + press_summary_suffix
+        context = set_document_type_and_link(context, judgment_uri)
 
         context.update(
             {
@@ -88,15 +80,7 @@ class UnholdJudgmentView(TemplateView):
         judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
-        press_summary_suffix = "/press-summary/1"
-        if judgment_uri.endswith(press_summary_suffix):
-            context["document_type"] = "press_summary"
-            context["linked_document_uri"] = judgment_uri.removesuffix(
-                press_summary_suffix
-            )
-        else:
-            context["document_type"] = "judgment"
-            context["linked_document_uri"] = judgment_uri + press_summary_suffix
+        context = set_document_type_and_link(context, judgment_uri)
 
         context.update(
             {
@@ -119,15 +103,7 @@ class UnholdJudgmentSuccessView(TemplateView):
         judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
-        press_summary_suffix = "/press-summary/1"
-        if judgment_uri.endswith(press_summary_suffix):
-            context["document_type"] = "press_summary"
-            context["linked_document_uri"] = judgment_uri.removesuffix(
-                press_summary_suffix
-            )
-        else:
-            context["document_type"] = "judgment"
-            context["linked_document_uri"] = judgment_uri + press_summary_suffix
+        context = set_document_type_and_link(context, judgment_uri)
 
         context.update(
             {

--- a/judgments/views/judgment_publish.py
+++ b/judgments/views/judgment_publish.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from django.utils.translation import gettext
 from django.views.generic import TemplateView
 
-from judgments.utils import editors_dict
+from judgments.utils import editors_dict, set_document_type_and_link
 from judgments.utils.aws import invalidate_caches
 from judgments.utils.link_generators import build_confirmation_email_link
 from judgments.utils.view_helpers import get_judgment_by_uri_or_404
@@ -18,15 +18,7 @@ class PublishJudgmentView(TemplateView):
         judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
-        press_summary_suffix = "/press-summary/1"
-        if judgment_uri.endswith(press_summary_suffix):
-            context["document_type"] = "press_summary"
-            context["linked_document_uri"] = judgment_uri.removesuffix(
-                press_summary_suffix
-            )
-        else:
-            context["document_type"] = "judgment"
-            context["linked_document_uri"] = judgment_uri + press_summary_suffix
+        context = set_document_type_and_link(context, judgment_uri)
 
         context.update(
             {
@@ -49,15 +41,7 @@ class PublishJudgmentSuccessView(TemplateView):
         judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
-        press_summary_suffix = "/press-summary/1"
-        if judgment_uri.endswith(press_summary_suffix):
-            context["document_type"] = "press_summary"
-            context["linked_document_uri"] = judgment_uri.removesuffix(
-                press_summary_suffix
-            )
-        else:
-            context["document_type"] = "judgment"
-            context["linked_document_uri"] = judgment_uri + press_summary_suffix
+        context = set_document_type_and_link(context, judgment_uri)
 
         context.update(
             {
@@ -98,15 +82,7 @@ class UnpublishJudgmentView(TemplateView):
         judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
-        press_summary_suffix = "/press-summary/1"
-        if judgment_uri.endswith(press_summary_suffix):
-            context["document_type"] = "press_summary"
-            context["linked_document_uri"] = judgment_uri.removesuffix(
-                press_summary_suffix
-            )
-        else:
-            context["document_type"] = "judgment"
-            context["linked_document_uri"] = judgment_uri + press_summary_suffix
+        context = set_document_type_and_link(context, judgment_uri)
 
         context.update(
             {
@@ -129,15 +105,7 @@ class UnpublishJudgmentSuccessView(TemplateView):
         judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
-        press_summary_suffix = "/press-summary/1"
-        if judgment_uri.endswith(press_summary_suffix):
-            context["document_type"] = "press_summary"
-            context["linked_document_uri"] = judgment_uri.removesuffix(
-                press_summary_suffix
-            )
-        else:
-            context["document_type"] = "judgment"
-            context["linked_document_uri"] = judgment_uri + press_summary_suffix
+        context = set_document_type_and_link(context, judgment_uri)
 
         context.update(
             {

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-17 14:23+0000\n"
+"POT-Creation-Date: 2023-07-26 12:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,11 +77,19 @@ msgstr "Name"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
-#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 #: judgments/utils/link_generators.py
 msgid "judgments.consignmentref"
 msgstr "TDR Ref"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
+msgid "judgments.sidebar.status"
+msgstr "Status"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+msgid "document.type"
+msgstr "Type"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -94,23 +102,14 @@ msgid "judgments.court"
 msgstr "Court"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
-msgid "judgments.sidebar.status"
-msgstr "Status"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
-msgid "judgments.sidebar.submission"
-msgstr "Submission"
+msgid "judgments.associated_douments"
+msgstr "Associated documents"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 #: judgments/utils/link_generators.py
 msgid "judgments.submitter"
 msgstr "Submitter"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
-#: judgments/utils/link_generators.py
-msgid "judgments.submitteremail"
-msgstr "Contact email"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.sidebar.tools"
@@ -128,7 +127,7 @@ msgstr "Unlock document"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgment.report_blocking_problem"
-msgstr "Report a publication-blocking problem"
+msgstr "Report a publication-blocking issue"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.sidebar.assigned_to"
@@ -332,6 +331,10 @@ msgstr ""
 "following the example in the template."
 
 
+#: judgments/utils/link_generators.py
+msgid "judgments.submitteremail"
+msgstr "Contact email"
+
 #: judgments/views/delete.py
 msgid "judgment.delete_a_judgment"
 msgstr "Delete a document"
@@ -351,7 +354,3 @@ msgstr "Document published"
 #: judgments/views/judgment_publish.py
 msgid "judgment.publish.unpublish_success_flash_message"
 msgstr "Document unpublished"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
-msgid "document.type"
-msgstr "Type"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==12.0.0
+ds-caselaw-marklogic-api-client==13.1.0
 ds-caselaw-utils~=1.0.2
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
## Changes in this PR:

This does a few things

- add a link to related documents in the editor sidebar
- refresh the visual design of the sidebar per terry's latest designs
- refactor the logic for identifying document type and related document in order to reduce repetition
- Bumps caselawapiclient to 13.1.0 and takes advantage of the new document type and document existence querying logic therein

## Trello card / Rollbar error (etc)

https://trello.com/c/PfJOSaeH/1202-eui-ps-add-a-link-to-the-associated-document-on-the-side-panel-for-publish-and-put-on-hold-screens

## Screenshots of UI changes:

### Before
<img width="322" alt="Screenshot 2023-07-26 at 18 45 36" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/f747b1ff-1f31-44bb-b2ab-a8dff997371a">

### After

<img width="322" alt="Screenshot 2023-07-26 at 18 41 35" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/70a130d7-de9f-4899-8c28-f582ff514291">
