### PR TITLE
fix notification margins so that it's centred above the review container

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
@@ -5,6 +5,7 @@
 
 .page-notification__container {
   @include container;
+  margin-top: calc(1.5 * $spacer__unit);
 }
 
 .page-notification {

--- a/ds_caselaw_editor_ui/templates/includes/notifications.html
+++ b/ds_caselaw_editor_ui/templates/includes/notifications.html
@@ -1,8 +1,8 @@
 {% if messages %}
   {% for message in messages %}
     {% spaceless %}
-      <div class="page-notification--{% if message.tags %}{{ message.tags }}{% else %}success{% endif %}">
-        <div class="page-notification__container">{{ message }}</div>
+      <div class="page-notification__container">
+        <div class="page-notification--{% if message.tags %}{{ message.tags }}{% else %}success{% endif %}">{{ message }}</div>
       </div>
     {% endspaceless %}
   {% endfor %}


### PR DESCRIPTION

## Changes in this PR:

This was a regression that crept in recently at some point!

## Screenshots of UI changes:

### Before
<img width="1288" alt="Screenshot 2023-07-27 at 16 46 25" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/85d673b9-9771-47ab-b3ef-cd14defb3d31">

### After
<img width="1209" alt="Screenshot 2023-07-27 at 16 35 02" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/67505316-ea4a-4164-b601-7c5786240223">
