### PR TITLE
update metadata panel review page for press summaries

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -15,26 +15,24 @@
           <span class="judgment-metadata-panel__key">{% translate "judgments.court" %}</span>
           <span class="judgment-metadata-panel__value">{{ judgment.court }}</span>
         </li>
-        {% if document_type == "judgment" %}
-          <li>
-            <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_date" %}</span>
-            <time class="judgment-metadata-panel__value"
-                  datetime="{{ judgment.judgment_date_as_string }}">{{ judgment.judgment_date_as_string }}</time>
-          </li>
-        {% else %}
-          <li>
-            <span class="judgment-metadata-panel__key">{% translate "document.publication_date" %}</span>
-            <time class="judgment-metadata-panel__value"
-                  datetime="{{ judgment.judgment_date_as_string }}">{{ judgment.judgment_date_as_string }}</time>
-          </li>
-        {% endif %}
+        <li>
+          <span class="judgment-metadata-panel__key">
+            {% if document_type == "judgment" %}
+              {% translate "judgment.judgment_date" %}
+            {% else %}
+              {% translate "document.publication_date" %}
+            {% endif %}
+          </span>
+          <time class="judgment-metadata-panel__value"
+                datetime="{{ judgment.judgment_date_as_string }}">{{ judgment.judgment_date_as_string }}</time>
+        </li>
         <li>
           <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_name" %}</span>
           <span class="judgment-metadata-panel__value">{{ judgment.name }}</span>
         </li>
         <li>
-          <span class="judgment-metadata-panel__key">{% translate "judgment.document.type" %}</span>
-          <span class="judgment-metadata-panel__value">Press Summary</span>
+          <span class="judgment-metadata-panel__key">{% translate "document.type" %}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.document_noun|capfirst }}</span>
         </li>
       </ul>
     </div>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -1,26 +1,42 @@
 {% load i18n %}
-<div class="judgment-metadata-panel">
-  <ul class="judgment-metadata-panel__details">
-    <li>
-      <span class="judgment-metadata-panel__key">{% translate "judgments.consignmentref" %}</span>
-      <span class="judgment-metadata-panel__value">{{ judgment.consignment_reference }}</span>
-    </li>
-    <li>
-      <span class="judgment-metadata-panel__key">{% translate "judgments.ncn" %}</span>
-      <span class="judgment-metadata-panel__value">{{ judgment.neutral_citation }}</span>
-    </li>
-    <li>
-      <span class="judgment-metadata-panel__key">{% translate "judgments.court" %}</span>
-      <span class="judgment-metadata-panel__value">{{ judgment.court }}</span>
-    </li>
-    <li>
-      <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_date" %}</span>
-      <time class="judgment-metadata-panel__value"
-            datetime="{{ judgment.judgment_date_as_string }}">{{ judgment.judgment_date_as_string }}</time>
-    </li>
-    <li>
-      <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_name" %}</span>
-      <span class="judgment-metadata-panel__value">{{ judgment.name }}</span>
-    </li>
-  </ul>
+<div class="container edit-component">
+  <div class="judgment-component pb-2">
+    <div class="judgment-metadata-panel">
+      <ul class="judgment-metadata-panel__details">
+        <li>
+          <span class="judgment-metadata-panel__key">{% translate "judgments.consignmentref" %}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.consignment_reference }}</span>
+        </li>
+        <li>
+          <span class="judgment-metadata-panel__key">{% translate "judgments.ncn" %}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.neutral_citation }}</span>
+        </li>
+        <li>
+          <span class="judgment-metadata-panel__key">{% translate "judgments.court" %}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.court }}</span>
+        </li>
+        {% if document_type == "judgment" %}
+          <li>
+            <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_date" %}</span>
+            <time class="judgment-metadata-panel__value"
+                  datetime="{{ judgment.judgment_date_as_string }}">{{ judgment.judgment_date_as_string }}</time>
+          </li>
+        {% else %}
+          <li>
+            <span class="judgment-metadata-panel__key">{% translate "document.publication_date" %}</span>
+            <time class="judgment-metadata-panel__value"
+                  datetime="{{ judgment.judgment_date_as_string }}">{{ judgment.judgment_date_as_string }}</time>
+          </li>
+        {% endif %}
+        <li>
+          <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_name" %}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.name }}</span>
+        </li>
+        <li>
+          <span class="judgment-metadata-panel__key">{% translate "judgment.document.type" %}</span>
+          <span class="judgment-metadata-panel__value">Press Summary</span>
+        </li>
+      </ul>
+    </div>
+  </div>
 </div>

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
@@ -1,6 +1,10 @@
 {% extends "layouts/judgment.html" %}
 {% block content %}
-  {% include "includes/judgment/metadata_panel_form.html" with return_to="html" %}
+  {% if document_type == "judgment" %}
+    {% include "includes/judgment/metadata_panel_form.html" with return_to="html" %}
+  {% else %}
+    {% include "includes/judgment/metadata_panel_static.html" with return_to="html" %}
+  {% endif %}
   {% include "includes/judgment/view_controls.html" with selected_tab=1 %}
   {% if judgment_content %}
     {% if judgment.is_failure %}

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_pdf.html
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_pdf.html
@@ -1,6 +1,10 @@
 {% extends "layouts/judgment.html" %}
 {% block content %}
-  {% include "includes/judgment/metadata_panel_form.html" with return_to="pdf" %}
+  {% if document_type == "judgment" %}
+    {% include "includes/judgment/metadata_panel_form.html" with return_to="pdf" %}
+  {% else %}
+    {% include "includes/judgment/metadata_panel_static.html" with return_to="pdf" %}
+  {% endif %}
   {% include "includes/judgment/view_controls.html" with selected_tab=2 %}
   <object data="{{ judgment.pdf_url }}"
           type="application/pdf"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -1,4 +1,3 @@
-# SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -8,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-26 12:17+0000\n"
+"POT-Creation-Date: 2023-08-02 09:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -104,6 +103,13 @@ msgstr "Court"
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.associated_douments"
 msgstr "Associated documents"
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+msgid "documment.publication_date"
+msgstr "Publication date"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+msgid "judgment.document.type"
+msgstr "Document type"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -330,11 +336,14 @@ msgstr ""
 "a seperate file under the includes/style_guide folder, and include it below "
 "following the example in the template."
 
+<<<<<<< HEAD
 
 #: judgments/utils/link_generators.py
 msgid "judgments.submitteremail"
 msgstr "Contact email"
 
+=======
+>>>>>>> a6781ce (update metadata panel review page press summaries)
 #: judgments/views/delete.py
 msgid "judgment.delete_a_judgment"
 msgstr "Delete a document"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 09:07+0000\n"
+"POT-Creation-Date: 2023-08-03 10:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -87,6 +87,7 @@ msgid "judgments.sidebar.status"
 msgstr "Status"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
 msgid "document.type"
 msgstr "Type"
 
@@ -100,16 +101,13 @@ msgstr "NCN"
 msgid "judgments.court"
 msgstr "Court"
 
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+msgid "document.publication_date"
+msgstr "Publication date"
+
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.associated_douments"
 msgstr "Associated documents"
-#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
-msgid "documment.publication_date"
-msgstr "Publication date"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
-msgid "judgment.document.type"
-msgstr "Document type"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -336,14 +334,10 @@ msgstr ""
 "a seperate file under the includes/style_guide folder, and include it below "
 "following the example in the template."
 
-<<<<<<< HEAD
-
 #: judgments/utils/link_generators.py
 msgid "judgments.submitteremail"
 msgstr "Contact email"
 
-=======
->>>>>>> a6781ce (update metadata panel review page press summaries)
 #: judgments/views/delete.py
 msgid "judgment.delete_a_judgment"
 msgstr "Delete a document"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
_Reuse_ the metadata panel static on review page for press summaries as designed https://ct3ku9.axshare.com/?id=8sulyn&p=ps-review-showing_metadata-panel_mvp_static&c=1
## Trello card / Rollbar error (etc)
https://trello.com/c/qfPQTUIB/1193-3-eui-mvp-frontend-for-metadata-press-summary
## Screenshots of UI changes:
[Screencast from 31-07-23 15:53:56.webm](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/d4255d33-6dd3-40d6-8157-9bfc094b2b7f)

### Before
![before](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/14c808b0-1c62-4c3d-9215-d2a8f6db9d4a)

### After
![after](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/4754140c-c335-4e06-8bf5-e2a780573272)

- [ ] Requires env variable(s) to be updated
