### PR TITLE
Enforce updated translations file in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,11 @@ jobs:
       - name: Build the Stack
         run: docker-compose build postgres django
 
+      - name: Verify translations
+        run: |
+          docker-compose run --rm django script/makemessages
+          script/verify-translations
+
       - name: Run DB Migrations
         run: docker-compose run --rm django python manage.py migrate --settings=config.settings.test
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ We're using [the built-in django translation module](https://docs.djangoproject.
 3. Update the locale file by running the following command in a `fab sh` shell:
 
 ```
-python manage.py makemessages --no-obsolete --add-location file -l en_GB
+script/makemessages
 ```
 
 4. In the generated `.po` file, find the generated translation section, it will be a block like this, with the `msgid` corresponding to the key you added in the template:

--- a/script/makemessages
+++ b/script/makemessages
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+python manage.py makemessages --no-obsolete --add-location file -l en_GB

--- a/script/verify-translations
+++ b/script/verify-translations
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if git diff -I POT-Creation-Date --exit-code; then
+  echo Translations check passed: all messages are up to date.
+else
+  echo Translations check failed: you may need to run script/makemessages and commit the changes to django.po
+  exit 1
+fi


### PR DESCRIPTION
CI now checks that translations have actually been updated, and will fail a build if not.

This works by running `script/makemessage` (a new helper script for building translations, so we don't need to keep checking the README for the right invocation), and then `script/verify-translations` which uses `git diff` with an ignore pattern for the line which includes the date of last update.

An example of a failed workflow is at https://github.com/nationalarchives/ds-caselaw-editor-ui/actions/runs/5749924858/job/15585691509?pr=1093