### PR TITLE
Remove 'edit' button globally

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -7,21 +7,12 @@
       </div>
     {% endif %}
     <div class="judgment-toolbar__edit">
-      {% if document_type == "judgment" and judgment.is_editable %}
-        <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}button-cta{% else %}button-secondary{% endif %}"
-           href="{% url 'edit-judgment' judgment.uri %}">{% translate "judgment.toolbar.edit_metadata" %}</a>
+      {% if judgment.is_editable %}
         <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
            href="{% url 'full-text-html' judgment.uri %}">{% translate "judgment.toolbar.review_document" %}</a>
-      {% else %}
-        {% if document_type == "press_summary" and judgment.is_editable %}
-          <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
-             href="{% url 'full-text-html' judgment.uri %}">{% translate "judgment.toolbar.review_document" %}</a>
         {% else %}
           <span class="judgment-toolbar__button button-secondary"
-                aria-disabled="true">{% translate "judgment.toolbar.edit_metadata" %}</span>
-          <span class="judgment-toolbar__button button-secondary"
                 aria-disabled="true">{% translate "judgment.toolbar.review_document" %}</span>
-        {% endif %}
       {% endif %}
       {% if judgment.is_published %}
         <span class="judgment-toolbar__button button-secondary"

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -10,9 +10,9 @@
       {% if judgment.is_editable %}
         <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
            href="{% url 'full-text-html' judgment.uri %}">{% translate "judgment.toolbar.review_document" %}</a>
-        {% else %}
-          <span class="judgment-toolbar__button button-secondary"
-                aria-disabled="true">{% translate "judgment.toolbar.review_document" %}</span>
+      {% else %}
+        <span class="judgment-toolbar__button button-secondary"
+              aria-disabled="true">{% translate "judgment.toolbar.review_document" %}</span>
       {% endif %}
       {% if judgment.is_published %}
         <span class="judgment-toolbar__button button-secondary"

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -7,16 +7,21 @@
       </div>
     {% endif %}
     <div class="judgment-toolbar__edit">
-      {% if judgment.is_editable %}
+      {% if document_type == "judgment" and judgment.is_editable %}
         <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}button-cta{% else %}button-secondary{% endif %}"
            href="{% url 'edit-judgment' judgment.uri %}">{% translate "judgment.toolbar.edit_metadata" %}</a>
         <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
            href="{% url 'full-text-html' judgment.uri %}">{% translate "judgment.toolbar.review_document" %}</a>
       {% else %}
-        <span class="judgment-toolbar__button button-secondary"
-              aria-disabled="true">{% translate "judgment.toolbar.edit_metadata" %}</span>
-        <span class="judgment-toolbar__button button-secondary"
-              aria-disabled="true">{% translate "judgment.toolbar.review_document" %}</span>
+        {% if document_type == "press_summary" and judgment.is_editable %}
+          <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
+             href="{% url 'full-text-html' judgment.uri %}">{% translate "judgment.toolbar.review_document" %}</a>
+        {% else %}
+          <span class="judgment-toolbar__button button-secondary"
+                aria-disabled="true">{% translate "judgment.toolbar.edit_metadata" %}</span>
+          <span class="judgment-toolbar__button button-secondary"
+                aria-disabled="true">{% translate "judgment.toolbar.review_document" %}</span>
+        {% endif %}
       {% endif %}
       {% if judgment.is_published %}
         <span class="judgment-toolbar__button button-secondary"

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -8,9 +8,13 @@
     {% endif %}
     <div class="judgment-toolbar__edit">
       {% if judgment.is_editable %}
+        <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}button-cta{% else %}button-secondary{% endif %}"
+           href="{% url 'edit-judgment' judgment.uri %}">{% translate "judgment.toolbar.edit_metadata" %}</a>
         <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
            href="{% url 'full-text-html' judgment.uri %}">{% translate "judgment.toolbar.review_document" %}</a>
       {% else %}
+        <span class="judgment-toolbar__button button-secondary"
+              aria-disabled="true">{% translate "judgment.toolbar.edit_metadata" %}</span>
         <span class="judgment-toolbar__button button-secondary"
               aria-disabled="true">{% translate "judgment.toolbar.review_document" %}</span>
       {% endif %}

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-03 10:24+0000\n"
+"POT-Creation-Date: 2023-08-03 14:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,10 +150,6 @@ msgstr "Assign"
 #: ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
 msgid "judgment.toolbar.back"
 msgstr "Back to search results"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
-msgid "judgment.toolbar.edit_metadata"
-msgstr "Edit"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
 msgid "judgment.toolbar.review_document"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Remove 'edit' button globally
## Trello card / Rollbar error (etc)
https://trello.com/c/ASSAyUwV/1225-remove-edit-button-in-press-summary-view
## Screenshots of UI changes:
### Before
Judgment
![before-judgment-view](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/dae4b2c1-0338-4f93-944f-3c4d12967120)

Press Summary
![before-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/b4b3cf76-b428-40e3-9564-c52e2d1d4686)

### After
![judgment-before](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/2f5065f3-6e08-4436-b9b5-233008650869)


Press Summary
![after-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/9d8ab5c6-600d-499b-ab96-cb93f1bc92f8)


- [ ] Requires env variable(s) to be updated
