### PR TITLE
Remove button edit globally

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -8,19 +8,16 @@
     {% endif %}
     <div class="judgment-toolbar__edit">
       {% if judgment.is_editable %}
-        <a class="judgment-toolbar__button {% if view == 'judgment_metadata' %}button-cta{% else %}button-secondary{% endif %}"
-           href="{% url 'edit-judgment' judgment.uri %}">{% translate "judgment.toolbar.edit_metadata" %}</a>
         <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
            href="{% url 'full-text-html' judgment.uri %}">{% translate "judgment.toolbar.review_document" %}</a>
       {% else %}
-        <span class="judgment-toolbar__button button-secondary"
-              aria-disabled="true">{% translate "judgment.toolbar.edit_metadata" %}</span>
         <span class="judgment-toolbar__button button-secondary"
               aria-disabled="true">{% translate "judgment.toolbar.review_document" %}</span>
       {% endif %}
       {% if judgment.is_published %}
         <span class="judgment-toolbar__button button-secondary"
-              aria-disabled="true">{% translate "judgment.toolbar.hold" %}</span>
+              aria-disabled="t
+              rue">{% translate "judgment.toolbar.hold" %}</span>
       {% else %}
         {% if judgment.is_held %}
           <a class="judgment-toolbar__button {% if view == 'hold_judgment' %}button-cta{% else %}button-secondary{% endif %}"

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -16,8 +16,7 @@
       {% endif %}
       {% if judgment.is_published %}
         <span class="judgment-toolbar__button button-secondary"
-              aria-disabled="t
-              rue">{% translate "judgment.toolbar.hold" %}</span>
+              aria-disabled="t rue">{% translate "judgment.toolbar.hold" %}</span>
       {% else %}
         {% if judgment.is_held %}
           <a class="judgment-toolbar__button {% if view == 'hold_judgment' %}button-cta{% else %}button-secondary{% endif %}"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-03 10:24+0000\n"
+"POT-Creation-Date: 2023-08-03 15:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,10 +150,6 @@ msgstr "Assign"
 #: ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
 msgid "judgment.toolbar.back"
 msgstr "Back to search results"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
-msgid "judgment.toolbar.edit_metadata"
-msgstr "Edit"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
 msgid "judgment.toolbar.review_document"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Remove 'edit' button globally
## Trello card / Rollbar error (etc)
https://trello.com/c/ASSAyUwV/1225-eui-remove-edit-button-globally
## Screenshots of UI changes:

### Before
Judgment
![after-judgment-view](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/474fb2ad-9a5c-4b2a-9a8d-dadf62ebe11c)


Press Summary
![before-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/133b22b8-5f22-4e99-aee0-d3acd3053c0b)

### After
Judgment
![after-judgment-view](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/a32ac7d2-c681-42b1-84d9-db3a06fdc134)



Press Summary
![after-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/6d35df2c-f9f4-4493-9459-5f0e011bd781)


- [ ] Requires env variable(s) to be updated
