### PR TITLE
fix bug judgment date update to document date

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -34,7 +34,7 @@
             <label for="judgment_date" class="metadata-component__main-labels">{% translate "judgment.judgment_date" %}</label>
             <input type="text"
                    class="metadata-component__judgment_date-input"
-                   value="{{ judgment.judgment_date_as_string }}"
+                   value="{{ judgment.document_date_as_string }}"
                    name="judgment_date"
                    id="judgment_date" />
           </div>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -24,7 +24,7 @@
             {% endif %}
           </span>
           <time class="judgment-metadata-panel__value"
-                datetime="{{ judgment.judgment_date_as_string }}">{{ judgment.judgment_date_as_string }}</time>
+                datetime="{{ judgment.document_date_as_string }}">{{ judgment.document_date_as_string }}</time>
         </li>
         <li>
           <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_name" %}</span>

--- a/ds_caselaw_editor_ui/templates/judgment/edit.html
+++ b/ds_caselaw_editor_ui/templates/judgment/edit.html
@@ -60,7 +60,7 @@
              for="judgment_date__text-field-label">{% translate "judgment.judgment_date" %}</label>
       <input type="text"
              class="edit-component__judgment_date-input"
-             value="{{ judgment.judgment_date_as_string }}"
+             value="{{ judgment.document_date_as_string }}"
              name="judgment_date"
              id="judgment_date" />
     </div>

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -28,7 +28,7 @@ class JudgmentFactory:
         "name": ("name", "Judgment v Judgement"),
         "neutral_citation": ("neutral_citation", "[2023] Test 123"),
         "court": ("court", "Court of Testing"),
-        "judgment_date_as_string": ("judgment_date_as_string", "2023-02-03"),
+        "document_date_as_string": ("document_date_as_string", "2023-02-03"),
         "is_published": ("is_published", False),
         "is_failure": ("is_failure", False),
         "source_name": ("source_name", "Example Uploader"),


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Fix bug - update judgment date to document date 
## Trello card / Rollbar error (etc)
https://trello.com/c/d8xx20TW/1229-eui-bug-dates-not-showing-replace-all-references-to-document-date-judgmentdateasstring-with-documentdateasstring
## Screenshots of UI changes:

### Before
Judgment
![before-judgment](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/6d922a71-14e3-4985-9f99-44dc795ab873)

Press Summary
![before-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/91030afb-94be-4f80-a083-f1ccb2ba2172)

### After
Judgment
![after-judgment](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/f599a623-1459-47ae-906c-14a8b36a8d62)

Press Summary
![after-prrss-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/79e1f8c8-bacd-46ac-8b80-61f4cb5fd139)

- [ ] Requires env variable(s) to be updated
