### PR TITLE
changed colour of border bottom in static metadata

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_metadata_panel.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_metadata_panel.scss
@@ -5,7 +5,7 @@
   width: 100%;
   box-sizing: border-box;
   padding: 0 calc($spacer__unit / 2);
-  border-bottom: 1px solid $color__aqua-blue;
+  border-bottom: 1px solid $color__almost-black;
 
   &__details {
     list-style-type: none;


### PR DESCRIPTION
<!-- Amend as appropriate -->
Border bottom should be 'Almost black rather than blue.
Made this change on Sass.
## Changes in this PR:

## Trello card / Rollbar error (etc)
https://trello.com/c/FNLPsMNG/1232-eui-fix-colour-border-bottom-for-static-metadata-panel
## Screenshots of UI changes:

### Before
![Screenshot 2023-08-07 at 14 47 44](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/102584881/02104218-de77-4c86-89a8-22ab5eb7901c)

### After
![Screenshot 2023-08-07 at 14 46 50](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/102584881/af6e7ebd-d571-49f1-8e58-0336afa7354a)


- [ ] Requires env variable(s) to be updated
