### PR TITLE
Make NCNs and correct document type show in press summary documents' metadata panels

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -14,7 +14,7 @@
             </label>
             <input type="text"
                    class="metadata-component__neutral_citation-input"
-                   value="{{ judgment.neutral_citation }}"
+                   value="{{ judgment.best_human_identifier }}"
                    name="neutral_citation"
                    id="neutral_citation" />
           </div>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -9,7 +9,7 @@
         </li>
         <li>
           <span class="judgment-metadata-panel__key">{% translate "judgments.ncn" %}</span>
-          <span class="judgment-metadata-panel__value">{{ judgment.neutral_citation }}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.best_human_identifier }}</span>
         </li>
         <li>
           <span class="judgment-metadata-panel__key">{% translate "judgments.court" %}</span>

--- a/judgments/tests/test_document_edit.py
+++ b/judgments/tests/test_document_edit.py
@@ -16,7 +16,7 @@ class TestDocumentEdit(TestCase):
         )
 
     @patch("judgments.views.judgment_edit.api_client")
-    @patch("judgments.views.judgment_edit.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_edit.get_document_by_uri_or_404")
     def test_edit_judgment(self, mock_judgment, api_client):
         judgment = JudgmentFactory.build(
             uri="edittest/4321/123",
@@ -56,7 +56,7 @@ class TestDocumentEdit(TestCase):
         )
 
     @patch("judgments.views.judgment_edit.api_client")
-    @patch("judgments.views.judgment_edit.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_edit.get_document_by_uri_or_404")
     def test_edit_judgment_without_assignment(self, mock_judgment, api_client):
         judgment = JudgmentFactory.build(
             uri="edittest/4321/123",

--- a/judgments/tests/test_document_history.py
+++ b/judgments/tests/test_document_history.py
@@ -8,7 +8,7 @@ from factories import JudgmentFactory
 
 
 class TestDocumentHistory(TestCase):
-    @patch("judgments.views.judgment_history.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_history.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_document_history_view(self, document_type, document_exists, mock_document):

--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -14,7 +14,7 @@ def assert_match(regex, string):
 
 
 class TestJudgmentView(TestCase):
-    @patch("judgments.views.full_text.get_judgment_by_uri_or_404")
+    @patch("judgments.views.full_text.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_html_view(self, document_type, document_exists, mock_judgment):
@@ -44,7 +44,7 @@ class TestJudgmentView(TestCase):
         self.assertIn("<h1>Test Judgment</h1>", decoded_response)
         assert response.status_code == 200
 
-    @patch("judgments.views.full_text.get_judgment_by_uri_or_404")
+    @patch("judgments.views.full_text.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_html_view_with_failure(
@@ -95,7 +95,7 @@ class TestJudgmentView(TestCase):
         )
 
     @patch(
-        "judgments.views.full_text.get_judgment_by_uri_or_404",
+        "judgments.views.full_text.get_document_by_uri_or_404",
     )
     def test_judgment_pdf_view_no_pdf_response(self, mock_judgment):
         mock_judgment.return_value.name = "JUDGMENT v JUDGEMENT"
@@ -119,7 +119,7 @@ class TestJudgmentView(TestCase):
 
 
 class TestJudgmentPublish(TestCase):
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_publish.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_publish_view(self, document_type, document_exists, mock_judgment):
@@ -145,7 +145,7 @@ class TestJudgmentPublish(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.judgment_publish.invalidate_caches")
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_publish.get_document_by_uri_or_404")
     def test_judgment_publish_flow(self, mock_judgment, mock_invalidate_caches):
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
@@ -171,7 +171,7 @@ class TestJudgmentPublish(TestCase):
         mock_judgment.return_value.unpublish.assert_not_called()
         mock_invalidate_caches.assert_called_once()
 
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_publish.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_publish_success_view(
@@ -202,7 +202,7 @@ class TestJudgmentPublish(TestCase):
 
 
 class TestJudgmentHold(TestCase):
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_hold.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_hold_view(self, document_type, document_exists, mock_judgment):
@@ -228,7 +228,7 @@ class TestJudgmentHold(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.judgment_hold.invalidate_caches")
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_hold.get_document_by_uri_or_404")
     def test_judgment_hold_flow(self, mock_judgment, mock_invalidate_caches):
         judgment = JudgmentFactory.build(
             uri="holdtest/4321/123",
@@ -254,7 +254,7 @@ class TestJudgmentHold(TestCase):
         mock_judgment.return_value.unhold.assert_not_called()
         mock_invalidate_caches.assert_called_once()
 
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_hold.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_hold_success_view(
@@ -285,7 +285,7 @@ class TestJudgmentHold(TestCase):
 
 
 class TestJudgmentUnhold(TestCase):
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_hold.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_unhold_view(self, document_type, document_exists, mock_judgment):
@@ -311,7 +311,7 @@ class TestJudgmentUnhold(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.judgment_hold.invalidate_caches")
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_hold.get_document_by_uri_or_404")
     def test_judgment_unhold_flow(self, mock_judgment, mock_invalidate_caches):
         judgment = JudgmentFactory.build(
             uri="unholdtest/4321/123",
@@ -337,7 +337,7 @@ class TestJudgmentUnhold(TestCase):
         mock_judgment.return_value.hold.assert_not_called()
         mock_invalidate_caches.assert_called_once()
 
-    @patch("judgments.views.judgment_hold.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_hold.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_hold_success_view(
@@ -368,7 +368,7 @@ class TestJudgmentUnhold(TestCase):
 
 
 class TestJudgmentUnpublish(TestCase):
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_publish.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_unpublish_view(
@@ -398,7 +398,7 @@ class TestJudgmentUnpublish(TestCase):
         assert response.status_code == 200
 
     @patch("judgments.views.judgment_publish.invalidate_caches")
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_publish.get_document_by_uri_or_404")
     def test_judgment_unpublish_flow(self, mock_judgment, mock_invalidate_caches):
         judgment = JudgmentFactory.build(
             uri="pubtest/4321/123",
@@ -424,7 +424,7 @@ class TestJudgmentUnpublish(TestCase):
         mock_judgment.return_value.unpublish.assert_called_once()
         mock_invalidate_caches.assert_called_once()
 
-    @patch("judgments.views.judgment_publish.get_judgment_by_uri_or_404")
+    @patch("judgments.views.judgment_publish.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
     def test_judgment_unpublish_success_view(

--- a/judgments/tests/test_unlock.py
+++ b/judgments/tests/test_unlock.py
@@ -22,7 +22,7 @@ def test_break_lock_confirm_page():
 
 
 @pytest.mark.django_db
-@patch("judgments.views.unlock.get_judgment_by_uri_or_404")
+@patch("judgments.views.unlock.get_document_by_uri_or_404")
 @patch("judgments.views.unlock.api_client.break_checkout")
 @patch("judgments.views.unlock.messages")
 def test_break_lock_post(messages, break_checkout, mock_judgment):

--- a/judgments/tests/test_view_helpers.py
+++ b/judgments/tests/test_view_helpers.py
@@ -5,26 +5,26 @@ from caselawclient.errors import DocumentNotFoundError
 from django.http import Http404
 from factories import JudgmentFactory
 
-from judgments.utils.view_helpers import get_judgment_by_uri_or_404
+from judgments.utils.view_helpers import get_document_by_uri_or_404
 
 
-class TestGetPublishedJudgment:
-    @patch("judgments.utils.view_helpers.get_judgment_by_uri")
+class TestGetDocumentByURIOr404:
+    @patch("judgments.utils.view_helpers.api_client.get_document_by_uri")
     def test_published_judgment_returns(self, mock_judgment):
         judgment = JudgmentFactory.build(is_published=True)
         mock_judgment.return_value = judgment
-        assert get_judgment_by_uri_or_404("2022/eat/1") == judgment
+        assert get_document_by_uri_or_404("2022/eat/1") == judgment
 
-    @patch("judgments.utils.view_helpers.get_judgment_by_uri")
+    @patch("judgments.utils.view_helpers.api_client.get_document_by_uri")
     def test_unpublished_judgment_returns(self, mock_judgment):
         judgment = JudgmentFactory.build(is_published=False)
         mock_judgment.return_value = judgment
-        assert get_judgment_by_uri_or_404("2022/eat/1") == judgment
+        assert get_document_by_uri_or_404("2022/eat/1") == judgment
 
     @patch(
-        "judgments.utils.view_helpers.get_judgment_by_uri",
+        "judgments.utils.view_helpers.api_client.get_document_by_uri",
         side_effect=DocumentNotFoundError,
     )
     def test_judgment_missing(self, mock_judgment):
         with pytest.raises(Http404):
-            get_judgment_by_uri_or_404("not-a-judgment")
+            get_document_by_uri_or_404("not-a-judgment")

--- a/judgments/tests/utils/test_utils.py
+++ b/judgments/tests/utils/test_utils.py
@@ -9,7 +9,7 @@ from caselawclient.models.judgments import Judgment
 from caselawclient.models.press_summaries import PressSummary
 from django.contrib.auth.models import Group
 from django.test import TestCase
-from factories import JudgmentFactory, UserFactory
+from factories import UserFactory
 
 import judgments
 from judgments.utils import (
@@ -130,9 +130,8 @@ class TestUtils(TestCase):
 
     @patch("judgments.utils.api_client")
     @patch("boto3.session.Session.client")
-    @patch("judgments.utils.get_judgment_by_uri")
     def test_update_document_uri_strips_whitespace(
-        self, fake_getter, fake_boto3_client, fake_api_client
+        self, fake_boto3_client, fake_api_client
     ):
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
         fake_api_client.copy_document.return_value = True
@@ -145,11 +144,9 @@ class TestUtils(TestCase):
         ds_caselaw_utils.neutral_url.assert_called_with("[2002] EAT 1")
 
     @patch("judgments.utils.api_client")
-    @patch("judgments.utils.get_judgment_by_uri")
-    def test_update_document_uri_exception_copy(self, fake_judgment, fake_client):
+    def test_update_document_uri_exception_copy(self, fake_client):
         """Given a document exists at the target uri, and copy_document fails,
         we raise a MoveJudgmentError"""
-        fake_judgment.return_value = JudgmentFactory.build()
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
         fake_client.copy_document.side_effect = MarklogicAPIError
         fake_client.delete_judgment.side_effect = True
@@ -158,11 +155,9 @@ class TestUtils(TestCase):
             update_document_uri("old/uri", "[2002] EAT 1")
 
     @patch("judgments.utils.api_client")
-    @patch("judgments.utils.get_judgment_by_uri")
-    def test_update_document_uri_exception_delete(self, fake_getter, fake_client):
+    def test_update_document_uri_exception_delete(self, fake_client):
         """If there's a target at the document uri and deleting fails,
         raise a MoveJudgmentError"""
-        fake_getter.return_value = JudgmentFactory.build()
         ds_caselaw_utils.neutral_url = MagicMock(return_value="new/uri")
         fake_client.copy_document.return_value = True
         fake_client.delete_judgment.side_effect = MarklogicAPIError

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse
 
 import ds_caselaw_utils as caselawutils
 from caselawclient.Client import MarklogicAPIError, api_client
-from caselawclient.models.judgments import Judgment
 from caselawclient.models.press_summaries import PressSummary
 from django.conf import settings
 from django.contrib.auth.models import Group, User
@@ -162,10 +161,6 @@ def editors_dict():
         ],
         key=itemgetter("print_name"),
     )
-
-
-def get_judgment_by_uri(judgment_uri: str) -> Judgment:
-    return Judgment(judgment_uri, api_client)
 
 
 def related_document_uri(document_type, document_uri):

--- a/judgments/utils/link_generators.py
+++ b/judgments/utils/link_generators.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from urllib.parse import quote, urlencode
 
-from caselawclient.models.judgments import Judgment
+from caselawclient.models.documents import Document
 from django.conf import settings
 from django.http import HttpRequest
 from django.template import loader
@@ -24,17 +24,17 @@ def build_email_link_with_content(
 
 
 def build_confirmation_email_link(
-    judgment: Judgment, signature: Optional[str] = None
+    document: Document, signature: Optional[str] = None
 ) -> str:
     subject_string = "Notification of publication [TDR ref: {reference}]".format(
-        reference=judgment.consignment_reference
+        reference=document.consignment_reference
     )
 
     email_context = {
-        "judgment_name": judgment.name,
-        "reference": judgment.consignment_reference,
-        "public_judgment_url": judgment.public_uri,
-        "submitter": judgment.source_name,
+        "judgment_name": document.name,
+        "reference": document.consignment_reference,
+        "public_judgment_url": document.public_uri,
+        "submitter": document.source_name,
         "user_signature": signature or "XXXXXX",
     }
 
@@ -43,22 +43,22 @@ def build_confirmation_email_link(
     )
 
     return build_email_link_with_content(
-        judgment.source_email, subject_string, body_string
+        document.source_email, subject_string, body_string
     )
 
 
 def build_raise_issue_email_link(
-    judgment: Judgment, signature: Optional[str] = None
+    document: Document, signature: Optional[str] = None
 ) -> str:
     subject_string = "Issue(s) found with {reference}".format(
-        reference=judgment.consignment_reference
+        reference=document.consignment_reference
     )
     email_context = {
-        "judgment_name": judgment.name,
-        "reference": judgment.consignment_reference,
-        "public_judgment_url": judgment.public_uri,
+        "judgment_name": document.name,
+        "reference": document.consignment_reference,
+        "public_judgment_url": document.public_uri,
         "user_signature": signature,
-        "submitter": judgment.source_name or "XXXXXX",
+        "submitter": document.source_name or "XXXXXX",
     }
 
     body_string = loader.render_to_string(
@@ -66,19 +66,19 @@ def build_raise_issue_email_link(
     )
 
     return build_email_link_with_content(
-        judgment.source_email, subject_string, body_string
+        document.source_email, subject_string, body_string
     )
 
 
-def build_jira_create_link(judgment: Judgment, request: HttpRequest) -> str:
+def build_jira_create_link(document: Document, request: HttpRequest) -> str:
     summary_string = "{name} / {ncn} / {tdr}".format(
-        name=judgment.name,
-        ncn=judgment.neutral_citation,
-        tdr=judgment.consignment_reference,
+        name=document.name,
+        ncn=document.best_human_identifier,
+        tdr=document.consignment_reference,
     )
 
     editor_html_url = request.build_absolute_uri(
-        reverse("full-text-html", kwargs={"judgment_uri": judgment.uri})
+        reverse("full-text-html", kwargs={"judgment_uri": document.uri})
     )
 
     description_string = "{editor_html_url}".format(
@@ -89,11 +89,11 @@ def build_jira_create_link(judgment: Judgment, request: HttpRequest) -> str:
 {consignment_ref_label}: {consignment_ref}""".format(
             html_url=editor_html_url,
             source_name_label=gettext("judgments.submitter"),
-            source_name=judgment.source_name,
+            source_name=document.source_name,
             source_email_label=gettext("judgments.submitteremail"),
-            source_email=judgment.source_email,
+            source_email=document.source_email,
             consignment_ref_label=gettext("judgments.consignmentref"),
-            consignment_ref=judgment.consignment_reference,
+            consignment_ref=document.consignment_reference,
         )
     )
 

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -5,10 +5,10 @@ from caselawclient.client_helpers.search_helpers import (
     search_judgments_and_parse_response,
 )
 from caselawclient.errors import DocumentNotFoundError
+from caselawclient.models.documents import Document
 from caselawclient.search_parameters import SearchParameters
 from django.http import Http404
 
-from judgments.utils import Judgment, get_judgment_by_uri
 from judgments.utils.paginator import paginator
 
 ALLOWED_ORDERS = ["date", "-date"]
@@ -48,8 +48,8 @@ def get_search_results(parameters: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def get_judgment_by_uri_or_404(uri: str) -> Judgment:
+def get_document_by_uri_or_404(uri: str) -> Document:
     try:
-        return get_judgment_by_uri(uri)
+        return api_client.get_document_by_uri(uri)
     except DocumentNotFoundError:
-        raise Http404(f"Judgment not found at {uri}")
+        raise Http404(f"Document not found at {uri}")

--- a/judgments/views/full_text.py
+++ b/judgments/views/full_text.py
@@ -6,14 +6,14 @@ from django.template import loader
 from django.urls import reverse
 
 from judgments.utils import extract_version, set_document_type_and_link
-from judgments.utils.view_helpers import get_judgment_by_uri_or_404
+from judgments.utils.view_helpers import get_document_by_uri_or_404
 
 
 def html_view(request, judgment_uri):
     params = request.GET
     version_uri = params.get("version_uri", None)
 
-    judgment = get_judgment_by_uri_or_404(judgment_uri)
+    judgment = get_document_by_uri_or_404(judgment_uri)
     context = {
         "judgment_uri": judgment_uri,
         "judgment": judgment,
@@ -44,7 +44,7 @@ def pdf_view(request, judgment_uri):
     params = request.GET
     version_uri = params.get("version_uri", None)
 
-    judgment = get_judgment_by_uri_or_404(judgment_uri)
+    judgment = get_document_by_uri_or_404(judgment_uri)
     if not judgment.pdf_url:
         raise Http404(f'Document "{judgment.name}" does not have a PDF.')
 
@@ -70,7 +70,7 @@ def pdf_view(request, judgment_uri):
 
 
 def xml_view(request, judgment_uri):
-    judgment = get_judgment_by_uri_or_404(judgment_uri)
+    judgment = get_document_by_uri_or_404(judgment_uri)
     judgment_xml = judgment.content_as_xml
 
     response = HttpResponse(judgment_xml, content_type="application/xml")

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -11,7 +11,7 @@ from judgments.utils import (
     update_document_uri,
 )
 from judgments.utils.aws import invalidate_caches
-from judgments.utils.view_helpers import get_judgment_by_uri_or_404
+from judgments.utils.view_helpers import get_document_by_uri_or_404
 
 
 class EditJudgmentView(View):
@@ -22,7 +22,7 @@ class EditJudgmentView(View):
 
     def post(self, request, *args, **kwargs):
         judgment_uri = request.POST["judgment_uri"]
-        judgment = get_judgment_by_uri_or_404(judgment_uri)
+        judgment = get_document_by_uri_or_404(judgment_uri)
 
         return_to = request.POST.get("return_to", None)
 

--- a/judgments/views/judgment_history.py
+++ b/judgments/views/judgment_history.py
@@ -5,14 +5,14 @@ from django.views.generic import View
 
 from judgments.utils import editors_dict, set_document_type_and_link
 from judgments.utils.link_generators import build_jira_create_link
-from judgments.utils.view_helpers import get_judgment_by_uri_or_404
+from judgments.utils.view_helpers import get_document_by_uri_or_404
 
 
 class DocumentHistoryView(View):
     def get(self, request, *args, **kwargs):
         document_uri = kwargs["document_uri"]
 
-        document = get_judgment_by_uri_or_404(document_uri)
+        document = get_document_by_uri_or_404(document_uri)
 
         context = {"document_uri": document_uri}
 
@@ -27,7 +27,7 @@ class DocumentHistoryView(View):
         context.update({"editors": editors_dict()})
 
         context["jira_create_link"] = build_jira_create_link(
-            judgment=document, request=request
+            document=document, request=request
         )
 
         context = set_document_type_and_link(context, document_uri)

--- a/judgments/views/judgment_hold.py
+++ b/judgments/views/judgment_hold.py
@@ -7,7 +7,7 @@ from django.views.generic import TemplateView
 from judgments.utils import editors_dict, set_document_type_and_link
 from judgments.utils.aws import invalidate_caches
 from judgments.utils.link_generators import build_raise_issue_email_link
-from judgments.utils.view_helpers import get_judgment_by_uri_or_404
+from judgments.utils.view_helpers import get_document_by_uri_or_404
 
 
 class HoldJudgmentView(TemplateView):
@@ -16,7 +16,7 @@ class HoldJudgmentView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(HoldJudgmentView, self).get_context_data(**kwargs)
 
-        judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
+        judgment = get_document_by_uri_or_404(kwargs["judgment_uri"])
 
         context.update(
             {
@@ -36,17 +36,17 @@ class HoldJudgmentSuccessView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(HoldJudgmentSuccessView, self).get_context_data(**kwargs)
 
-        judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
-        judgment_uri = kwargs["judgment_uri"]
+        document = get_document_by_uri_or_404(kwargs["judgment_uri"])
+        document_uri = kwargs["judgment_uri"]
 
-        context = set_document_type_and_link(context, judgment_uri)
+        context = set_document_type_and_link(context, document_uri)
 
         context.update(
             {
-                "page_title": judgment.name,
-                "judgment": judgment,
+                "page_title": document.name,
+                "judgment": document,
                 "email_issue_link": build_raise_issue_email_link(
-                    judgment=judgment,
+                    document=document,
                     signature=(
                         self.request.user.get_full_name()
                         if self.request.user.is_authenticated
@@ -62,7 +62,7 @@ class HoldJudgmentSuccessView(TemplateView):
 
 def hold(request):
     judgment_uri = request.POST.get("judgment_uri", None)
-    judgment = get_judgment_by_uri_or_404(judgment_uri)
+    judgment = get_document_by_uri_or_404(judgment_uri)
     judgment.hold()
     invalidate_caches(judgment.uri)
     messages.success(request, gettext("judgment.hold.hold_success_flash_message"))
@@ -77,7 +77,7 @@ class UnholdJudgmentView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(UnholdJudgmentView, self).get_context_data(**kwargs)
 
-        judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
+        judgment = get_document_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
         context = set_document_type_and_link(context, judgment_uri)
@@ -100,7 +100,7 @@ class UnholdJudgmentSuccessView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(UnholdJudgmentSuccessView, self).get_context_data(**kwargs)
 
-        judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
+        judgment = get_document_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
         context = set_document_type_and_link(context, judgment_uri)
@@ -118,7 +118,7 @@ class UnholdJudgmentSuccessView(TemplateView):
 
 def unhold(request):
     judgment_uri = request.POST.get("judgment_uri", "")
-    judgment = get_judgment_by_uri_or_404(judgment_uri)
+    judgment = get_document_by_uri_or_404(judgment_uri)
     judgment.unhold()
     invalidate_caches(judgment.uri)
     messages.success(request, gettext("judgment.hold.unhold_success_flash_message"))

--- a/judgments/views/judgment_publish.py
+++ b/judgments/views/judgment_publish.py
@@ -7,7 +7,7 @@ from django.views.generic import TemplateView
 from judgments.utils import editors_dict, set_document_type_and_link
 from judgments.utils.aws import invalidate_caches
 from judgments.utils.link_generators import build_confirmation_email_link
-from judgments.utils.view_helpers import get_judgment_by_uri_or_404
+from judgments.utils.view_helpers import get_document_by_uri_or_404
 
 
 class PublishJudgmentView(TemplateView):
@@ -15,7 +15,7 @@ class PublishJudgmentView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(PublishJudgmentView, self).get_context_data(**kwargs)
-        judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
+        judgment = get_document_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
         context = set_document_type_and_link(context, judgment_uri)
@@ -38,17 +38,17 @@ class PublishJudgmentSuccessView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(PublishJudgmentSuccessView, self).get_context_data(**kwargs)
 
-        judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
-        judgment_uri = kwargs["judgment_uri"]
+        document = get_document_by_uri_or_404(kwargs["judgment_uri"])
+        document_uri = kwargs["judgment_uri"]
 
-        context = set_document_type_and_link(context, judgment_uri)
+        context = set_document_type_and_link(context, document_uri)
 
         context.update(
             {
-                "page_title": judgment.name,
-                "judgment": judgment,
+                "page_title": document.name,
+                "judgment": document,
                 "email_confirmation_link": build_confirmation_email_link(
-                    judgment=judgment,
+                    document=document,
                     signature=(
                         self.request.user.get_full_name()
                         if self.request.user.is_authenticated
@@ -64,7 +64,7 @@ class PublishJudgmentSuccessView(TemplateView):
 
 def publish(request):
     judgment_uri = request.POST.get("judgment_uri")
-    judgment = get_judgment_by_uri_or_404(judgment_uri)
+    judgment = get_document_by_uri_or_404(judgment_uri)
     judgment.publish()
     invalidate_caches(judgment.uri)
     messages.success(request, gettext("judgment.publish.publish_success_flash_message"))
@@ -79,7 +79,7 @@ class UnpublishJudgmentView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(UnpublishJudgmentView, self).get_context_data(**kwargs)
 
-        judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
+        judgment = get_document_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
         context = set_document_type_and_link(context, judgment_uri)
@@ -102,7 +102,7 @@ class UnpublishJudgmentSuccessView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(UnpublishJudgmentSuccessView, self).get_context_data(**kwargs)
 
-        judgment = get_judgment_by_uri_or_404(kwargs["judgment_uri"])
+        judgment = get_document_by_uri_or_404(kwargs["judgment_uri"])
         judgment_uri = kwargs["judgment_uri"]
 
         context = set_document_type_and_link(context, judgment_uri)
@@ -120,7 +120,7 @@ class UnpublishJudgmentSuccessView(TemplateView):
 
 def unpublish(request):
     judgment_uri = request.POST.get("judgment_uri", None)
-    judgment = get_judgment_by_uri_or_404(judgment_uri)
+    judgment = get_document_by_uri_or_404(judgment_uri)
     judgment.unpublish()
     invalidate_caches(judgment.uri)
     messages.success(

--- a/judgments/views/unlock.py
+++ b/judgments/views/unlock.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils.translation import gettext
 from django.views.decorators.http import require_http_methods
 
-from judgments.utils.view_helpers import get_judgment_by_uri_or_404
+from judgments.utils.view_helpers import get_document_by_uri_or_404
 
 
 @require_http_methods(["POST", "GET", "HEAD"])
@@ -35,7 +35,7 @@ def unlock_post(request):
 
     judgment_uri = request.POST.get("judgment_uri")
     try:
-        judgment = get_judgment_by_uri_or_404(judgment_uri)
+        judgment = get_document_by_uri_or_404(judgment_uri)
         api_client.break_checkout(judgment.uri)
     except MarklogicResourceUnmanagedError as exc:
         raise Http404(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==13.1.0
+ds-caselaw-marklogic-api-client==13.2.1
 ds-caselaw-utils~=1.0.2
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
## Changes in this PR:

- Make NCNs show in press summary documents' metadata panels 
- Make "press summary" show as document type for press summaries

## Trello card / Rollbar error (etc)
- https://trello.com/c/inj3m6KV/1230-eui-apiclient-bug-no-ncn-showing-for-press-summaries
- https://trello.com/c/xM8Yxtx7/1228-eui-apclient-bug-incorrect-document-type-showing-for-press-summaries

## Screenshots of UI changes:

### Before
<img width="1144" alt="Screenshot 2023-08-07 at 15 36 34" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/44ec4f75-b3e5-4d36-9bba-c5d4c40c015e">

### After
<img width="1061" alt="Screenshot 2023-08-07 at 15 36 02" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/f6f19f8b-48d3-43cc-b0b4-a2f23eb4c59e">
