### PR TITLE
Expose press summaries in search results

### DIFF
--- a/judgments/tests/test_judgment_list.py
+++ b/judgments/tests/test_judgment_list.py
@@ -13,7 +13,7 @@ def assert_match(regex, string):
 
 
 class TestJudgmentView(TestCase):
-    @patch("judgments.utils.view_helpers.search_judgments_and_parse_response")
+    @patch("judgments.utils.view_helpers.search_and_parse_response")
     def test_judgment_list_smoketest(self, mock_search_results):
         mock_search_results.return_value.results = []
         mock_search_results.return_value.total = 0
@@ -24,7 +24,7 @@ class TestJudgmentView(TestCase):
 
         assert response.status_code == 200
 
-    @patch("judgments.utils.view_helpers.search_judgments_and_parse_response")
+    @patch("judgments.utils.view_helpers.search_and_parse_response")
     def test_judgment_list_total_count(self, mock_search_results):
         mock_search_results.return_value.results = [
             SearchResultFactory.build(),
@@ -40,7 +40,7 @@ class TestJudgmentView(TestCase):
 
         assert "{}: 2".format(gettext("home.recent")) in decoded_response
 
-    @patch("judgments.utils.view_helpers.search_judgments_and_parse_response")
+    @patch("judgments.utils.view_helpers.search_and_parse_response")
     def test_judgment_list_items(self, mock_search_results):
         mock_search_results.return_value.results = [
             SearchResultFactory.build(

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -12,7 +12,7 @@ def assert_match(regex, string):
 
 
 class TestSearchResults(TestCase):
-    @patch("judgments.utils.view_helpers.search_judgments_and_parse_response")
+    @patch("judgments.utils.view_helpers.search_and_parse_response")
     def test_oldest(self, mock_search):
         mock_search.results.return_value = []
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])
@@ -32,7 +32,7 @@ class TestSearchResults(TestCase):
             response.content,
         )
 
-    @patch("judgments.utils.view_helpers.search_judgments_and_parse_response")
+    @patch("judgments.utils.view_helpers.search_and_parse_response")
     def test_newest(self, mock_search):
         mock_search.results.return_value = []
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -1,9 +1,7 @@
 from typing import Any
 
 from caselawclient.Client import api_client
-from caselawclient.client_helpers.search_helpers import (
-    search_judgments_and_parse_response,
-)
+from caselawclient.client_helpers.search_helpers import search_and_parse_response
 from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.documents import Document
 from caselawclient.search_parameters import SearchParameters
@@ -38,7 +36,7 @@ def get_search_results(parameters: dict[str, Any]) -> dict[str, Any]:
         show_unpublished=True,
         page=parameters["page"],
     )
-    search_response = search_judgments_and_parse_response(api_client, search_parameters)
+    search_response = search_and_parse_response(api_client, search_parameters)
     return {
         "query": parameters,
         "total": search_response.total,


### PR DESCRIPTION
Currently we filter out docs so that only docs in the judgment collection are shown in the EUI search results, to be in line with the PUI where we have decided not to show press summaries in search results.

This doesn’t really make sense in EUI, as we want to see all unpublished judgments in the EUI (even though editors do normally just work from Jira and not the unpublished list/ search results)


## Changes in this PR:
- Expose press summaries in search results

## Trello card / Rollbar error (etc)
https://trello.com/c/GlNGCcIC/1240-eui-expose-press-summaries-in-eui-search-results

## Screenshots of UI changes:

### Before
<img width="1251" alt="Screenshot 2023-08-08 at 17 09 49" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/ef44754b-517c-4b83-a820-058c3a540d3f">

### After
<img width="1263" alt="Screenshot 2023-08-08 at 17 09 24" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/2e0a595a-b4f8-4d78-94dc-10f83b5e500f">
