### PR TITLE
Improve handling of parser failure states

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -7,13 +7,8 @@
       </div>
     {% endif %}
     <div class="judgment-toolbar__edit">
-      {% if document.is_editable %}
-        <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
-           href="{% url 'full-text-html' document.uri %}">{% translate "judgment.toolbar.review_document" %}</a>
-      {% else %}
-        <span class="judgment-toolbar__button button-secondary"
-              aria-disabled="true">{% translate "judgment.toolbar.review_document" %}</span>
-      {% endif %}
+      <a class="judgment-toolbar__button {% if view == 'judgment_text' %}button-cta{% else %}button-secondary{% endif %}"
+         href="{% url 'full-text-html' document.uri %}">{% translate "judgment.toolbar.review_document" %}</a>
       {% if document.is_published %}
         <span class="judgment-toolbar__button button-secondary"
               aria-disabled="true">{% translate "judgment.toolbar.hold" %}</span>

--- a/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -3,10 +3,10 @@
   <div class="judgments-list__judgment-details">
     <div class="judgments-list__judgment-details-name">
       <a href="{% url 'full-text-html' item.uri %}">
-        {% if not item.is_failure %}
+        {% if not item.failed_to_parse %}
           {{ item.name | default:"[Untitled Judgment]" }}
         {% else %}
-          <span class="judgments-list__failed">Failed processing:</span> {{ item.uri }}
+          <span class="judgments-list__failed">Failed to parse:</span> {{ item.uri }}
         {% endif %}
       </a>
     </div>

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
@@ -6,21 +6,18 @@
     {% include "includes/judgment/metadata_panel_static.html" with return_to="html" %}
   {% endif %}
   {% include "includes/judgment/view_controls.html" with selected_tab=1 %}
-  {% if judgment_content %}
-    {% if judgment.is_failure %}
-      <div class="container">
-        <div class="page-notification--failure">This document is in a 'failure' state.</div>
-        <pre style="white-space:pre-wrap;
-                    background:#F6F6F6;
-                    border:1px solid #AAA;
-                    padding:1em">{{ judgment_content }}</pre>
-      </div>
-    {% else %}
-      {% autoescape off %}
-        {{ judgment_content }}
-      {% endautoescape %}
-    {% endif %}
+  {% if document.failed_to_parse %}
+    <div class="container">
+      <div class="page-notification--failure">This document has failed to parse.</div>
+      <h2>Error log</h2>
+      <pre style="white-space:pre-wrap;
+                  background:#F6F6F6;
+                  border:1px solid #AAA;
+                  padding:1em">{{ document.content_as_xml }}</pre>
+    </div>
   {% else %}
-    {{ content }}
+    {% autoescape off %}
+      {{ document_html_content }}
+    {% endautoescape %}
   {% endif %}
 {% endblock content %}

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
@@ -8,9 +8,13 @@
   {% include "includes/judgment/view_controls.html" with selected_tab=1 %}
   {% if judgment_content %}
     {% if judgment.is_failure %}
-      <pre>
-        {{ judgment_content }}
-      </pre>
+      <div class="container">
+        <div class="page-notification--failure">This document is in a 'failure' state.</div>
+        <pre style="white-space:pre-wrap;
+                    background:#F6F6F6;
+                    border:1px solid #AAA;
+                    padding:1em">{{ judgment_content }}</pre>
+      </div>
     {% else %}
       {% autoescape off %}
         {{ judgment_content }}

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -30,12 +30,13 @@ class JudgmentFactory:
         "court": ("court", "Court of Testing"),
         "document_date_as_string": ("document_date_as_string", "2023-02-03"),
         "is_published": ("is_published", False),
-        "is_failure": ("is_failure", False),
+        "failed_to_parse": ("failed_to_parse", False),
         "source_name": ("source_name", "Example Uploader"),
         "source_email": ("source_email", "uploader@example.com"),
         "consignment_reference": ("consignment_reference", "TDR-12345"),
         "assigned_to": ("assigned_to", ""),
         "versions": ("versions", []),
+        "content_as_xml": ("xml", "<akomaNtoso>This is a document's XML.</akomaNtoso>"),
     }
 
     @classmethod
@@ -99,5 +100,5 @@ class SearchResultFactory(SimpleFactory):
         "court": "Court of Testing",
         "date": datetime.date(2023, 2, 3),
         "metadata": SearchResultMetadataFactory.build(),
-        "is_failure": False,
+        "failed_to_parse": False,
     }

--- a/judgments/tests/test_document_edit.py
+++ b/judgments/tests/test_document_edit.py
@@ -39,13 +39,13 @@ class TestDocumentEdit(TestCase):
             },
         )
 
-        api_client.set_judgment_name.assert_called_with(
+        api_client.set_document_name.assert_called_with(
             "/edittest/4321/123", "New Name"
         )
         api_client.set_judgment_citation.assert_called_with(
             "/edittest/4321/123", "[4321] TEST 123"
         )
-        api_client.set_judgment_court.assert_called_with(
+        api_client.set_document_court.assert_called_with(
             "/edittest/4321/123", "Court of Testing"
         )
         api_client.set_judgment_date.assert_called_with(

--- a/judgments/views/document_full_text.py
+++ b/judgments/views/document_full_text.py
@@ -17,14 +17,10 @@ class DocumentReviewHTMLView(DocumentView):
 
         version_uri = self.request.GET.get("version_uri", None)
 
-        if not context["document"].is_editable:
-            context["judgment_content"] = context["document"].content_as_xml
-            context["metadata_name"] = context["document"].uri
-        else:
-            context["judgment_content"] = context["document"].content_as_html(
+        if not context["document"].failed_to_parse:
+            context["document_html_content"] = context["document"].content_as_html(
                 version_uri=version_uri
             )
-            context["metadata_name"] = context["document"].name
 
         if version_uri:
             context["version"] = extract_version(version_uri)

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -29,7 +29,7 @@ class EditJudgmentView(View):
         try:
             # Set name
             new_name = request.POST["metadata_name"]
-            api_client.set_judgment_name(judgment_uri, new_name)
+            api_client.set_document_name(judgment_uri, new_name)
 
             # Set neutral citation
             new_citation = request.POST["neutral_citation"]
@@ -37,7 +37,7 @@ class EditJudgmentView(View):
 
             # Set court
             new_court = request.POST["court"]
-            api_client.set_judgment_court(judgment_uri, new_court)
+            api_client.set_document_court(judgment_uri, new_court)
 
             # Date
             new_date = request.POST["judgment_date"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==13.2.1
+ds-caselaw-marklogic-api-client==14.0.0
 ds-caselaw-utils~=1.0.2
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
- Updates API Client to v14 and addresses breaking changes with metadata-setting operations
- Removes use of `is_failure` state flag
- Fixes review button not always being available
- Renders HTML where parsing has succeeded, but the document is at a failure URI because of an incorrect NCN
- Display of failure XML is now prettier, and has suitable coaching language to explain what you're actually looking at

## Screenshots

### Before

![editor staging caselaw nationalarchives gov uk_failures_TDR-2023-MQ6](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/d7270fe9-f68a-4163-a7a7-e748b4d04c2b)

### After

![localhost_3000_failures_TDR-2023-MQ6](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/ff33a779-544d-49d9-9901-3e3d8aade157)
