### PR TITLE
Reword technical issue reporting link

### DIFF
--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 09:03+0000\n"
+"POT-Creation-Date: 2023-08-10 11:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -159,7 +159,7 @@ msgstr "Unlock document"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
 msgid "judgment.report_blocking_problem"
-msgstr "Report a publication-blocking issue"
+msgstr "Report a technical issue"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
 msgid "judgment.download_docx"


### PR DESCRIPTION
Reword "Report a publication-blocking issue" to "Report a technical issue" as testing revealed it's not obvious if that's to the submitter or the digital team