### PR TITLE
Reimplement the ability to delete documents.

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -28,11 +28,6 @@
     display: block;
   }
 
-  input[type="submit"] {
-    @include call-to-action-button;
-    display: block;
-  }
-
   &__metadata_name-input {
     @include text_field;
     width: 80%;

--- a/ds_caselaw_editor_ui/sass/includes/_links.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_links.scss
@@ -18,6 +18,16 @@ a {
   &:focus {
     @include focus-default;
   }
+
+  &.link-danger {
+    color: darken($color__red, 10);
+    &:visited {
+      color: darken($color__red, 10);
+    }
+    &:hover {
+      color: darken($color__red, 20);
+    }
+  }
 }
 
 #skip-to-main-content {

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
@@ -26,6 +26,11 @@
            target="_blank"
            rel="noopener noreferrer">{% translate "judgment.report_blocking_problem" %}</a>
       </li>
+      {% if document.safe_to_delete %}
+        <li>
+          <a href="{% url 'delete-document' document.uri %}" class="link-danger">Delete document</a>
+        </li>
+      {% endif %}
     </ul>
   </div>
   <div class="judgment-toolbar__more__menu__group">

--- a/ds_caselaw_editor_ui/templates/judgment/delete.html
+++ b/ds_caselaw_editor_ui/templates/judgment/delete.html
@@ -1,0 +1,30 @@
+{% extends "layouts/judgment_with_sidebar.html" %}
+{% load i18n %}
+{% block judgment_header %}
+  {% include "includes/judgment/metadata_panel_static.html" with judgment=judgment %}
+{% endblock judgment_header %}
+{% block judgment_content %}
+  <h2>Delete this {{ document.document_noun }}</h2>
+  {% if document.safe_to_delete %}
+    <p>
+      If this {{ document.document_noun }} has previously been made public, you must follow the process for informing data reusers of a takedown.
+    </p>
+    <p>
+      <b>Deleting this {{ document.document_noun }} cannot be undone.</b>
+    </p>
+    <form aria-label="publish {{ document.document_noun }}"
+          action="{% url 'delete' %}"
+          method="post">
+      {% csrf_token %}
+      <div class="judgment-component__actions">
+        <input type="hidden" name="document_uri" value="{{ document.uri }}" />
+        <input class="button-danger"
+               type="submit"
+               value="Delete {{ document.document_noun }} at {{ document.uri }}" />
+      </div>
+    </form>
+  {% else %}
+    <p>This {{ document.document_noun }} is not safe to delete.</p>
+    <span class="button-danger" aria-disabled="true">Delete {{ document.document_noun }} at URI {{ document.uri }}</span>
+  {% endif %}
+{% endblock judgment_content %}

--- a/ds_caselaw_editor_ui/templates/judgment/deleted.html
+++ b/ds_caselaw_editor_ui/templates/judgment/deleted.html
@@ -1,8 +1,0 @@
-{% extends "layouts/base.html" %}
-{% load static i18n %}
-{% block content %}
-  <div class="delete-judgment">
-    <p class="delete-judgment__confirmation">{% translate "judgment.deleted" %}</p>
-    <a href="{% url 'home' %}">{% translate "judgment.return_home" %}</a>
-  </div>
-{% endblock content %}

--- a/judgments/tests/test_document_delete.py
+++ b/judgments/tests/test_document_delete.py
@@ -1,0 +1,85 @@
+from unittest.mock import patch
+
+from caselawclient.models.judgments import Judgment
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from factories import JudgmentFactory
+
+
+class TestDocumentDelete(TestCase):
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_document_delete_view(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        document = JudgmentFactory.build(
+            uri="deltest/4321/123",
+            name="Test v Tested",
+        )
+        mock_judgment.return_value = document
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        delete_uri = reverse("delete-document", kwargs={"document_uri": document.uri})
+
+        assert delete_uri == "/deltest/4321/123/delete"
+
+        response = self.client.get(delete_uri)
+
+        decoded_response = response.content.decode("utf-8")
+        self.assertIn("Delete this", decoded_response)
+        assert response.status_code == 200
+
+    @patch("judgments.views.document_delete.invalidate_caches")
+    @patch("judgments.views.document_delete.get_document_by_uri_or_404")
+    def test_document_delete_flow_if_safe(self, mock_document, mock_invalidate_caches):
+        document = JudgmentFactory.build(
+            uri="deltest/4321/123",
+            name="Hold Test",
+            is_published=False,
+        )
+        mock_document.return_value = document
+        mock_document.return_value.safe_to_delete = True
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.post(
+            reverse("delete"),
+            data={
+                "document_uri": document.uri,
+            },
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == reverse("home")
+        mock_document.return_value.delete.assert_called_once()
+        mock_invalidate_caches.assert_called_once()
+
+    @patch("judgments.views.document_delete.invalidate_caches")
+    @patch("judgments.views.document_delete.get_document_by_uri_or_404")
+    def test_document_delete_flow_if_not_safe(
+        self, mock_document, mock_invalidate_caches
+    ):
+        document = JudgmentFactory.build(
+            uri="deltest/4321/123",
+            name="Hold Test",
+            is_published=True,
+        )
+        mock_document.return_value = document
+        mock_document.return_value.safe_to_delete = False
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.post(
+            reverse("delete"),
+            data={
+                "document_uri": document.uri,
+            },
+        )
+
+        assert response.status_code == 403
+        mock_document.return_value.delete.assert_not_called()
+        mock_invalidate_caches.assert_not_called()

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -5,6 +5,7 @@ from .views.button_handlers import (
     hold_judgment_button,
     prioritise_judgment_button,
 )
+from .views.document_delete import DeleteDocumentView, delete
 from .views.document_full_text import (
     DocumentReviewHTMLView,
     DocumentReviewPDFView,
@@ -54,6 +55,7 @@ urlpatterns = [
     path("hold", hold, name="hold"),
     path("unhold", unhold, name="unhold"),
     path("unlock", unlock, name="unlock"),
+    path("delete", delete, name="delete"),
     path("assign", assign_judgment_button, name="assign"),
     path("prioritise", prioritise_judgment_button, name="prioritise"),
     path("hold", hold_judgment_button, name="hold"),
@@ -120,6 +122,11 @@ urlpatterns = [
         "<path:document_uri>/unheld",
         UnholdDocumentSuccessView.as_view(),
         name="unhold-document-success",
+    ),
+    path(
+        "<path:document_uri>/delete",
+        DeleteDocumentView.as_view(),
+        name="delete-document",
     ),
     path(
         "<path:document_uri>/pdf", DocumentReviewPDFView.as_view(), name="full-text-pdf"

--- a/judgments/views/document_delete.py
+++ b/judgments/views/document_delete.py
@@ -1,0 +1,28 @@
+from django.contrib import messages
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+
+from judgments.utils.aws import invalidate_caches
+from judgments.utils.view_helpers import get_document_by_uri_or_404
+
+from ..utils.view_helpers import DocumentView
+
+
+class DeleteDocumentView(DocumentView):
+    template_name = "judgment/delete.html"
+
+
+def delete(request):
+    document_uri = request.POST.get("document_uri", None)
+    document = get_document_by_uri_or_404(document_uri)
+    if not document.safe_to_delete:
+        raise PermissionDenied(
+            f"The document at URI {document.uri} is not safe to delete."
+        )
+    document.delete()
+    invalidate_caches(document.uri)
+    messages.success(
+        request, f"The document at URI {document.uri} was successfully deleted."
+    )
+    return HttpResponseRedirect(reverse("home"))

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-10 11:19+0000\n"
+"POT-Creation-Date: 2023-08-10 14:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -222,14 +222,6 @@ msgstr ""
 #: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
 msgid "judgment.back_to_judgment"
 msgstr "Back to document"
-
-#: ds_caselaw_editor_ui/templates/judgment/deleted.html
-msgid "judgment.deleted"
-msgstr "Document successfully deleted"
-
-#: ds_caselaw_editor_ui/templates/judgment/deleted.html
-msgid "judgment.return_home"
-msgstr "Return to Find and manage case law"
 
 #: ds_caselaw_editor_ui/templates/judgment/hold-success.html
 msgid "judgment.hold.success"


### PR DESCRIPTION
**This PR needs known extra work to restrict scope of document deletion.**

Re-implement the ability for editors to delete documents. This is done via a link in the 'more drawer', which is only visible if the document is in a safe to delete state (currently the document is unpublished).