### PR TITLE
Re-order Tools list lonks in More menu

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
@@ -104,7 +104,7 @@
           margin-top: 0;
           list-style: none;
           font-size: 0.8rem;
-          line-height: 1.4rem;
+          line-height: 1.8rem;
         }
         flex-grow: 1;
       }

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
@@ -11,20 +11,20 @@
     <h4>Tools</h4>
     <ul>
       <li>
-        <a href="{% url 'document-history' document.uri %}">Document history</a>
-      </li>
-      <li>
         <a href="{{ jira_create_link }}"
            target="_blank"
            rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a>
       </li>
       <li>
-        <a href="{% url 'unlock' %}?judgment_uri={{ document.uri }}">{% translate "judgment.unlock_judgment_title" %}</a>
+        <a href="{% url 'document-history' document.uri %}">Document history</a>
       </li>
       <li>
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSckmLdeUAEoEoBc55ybFVmOsXPEM7CG2VbN2YNwsX6kL9UZ4Q/viewform?usp=pp_url&entry.2047884653=Yes&entry.6716552=A+specific+judgment+or+decision&entry.481919886={{ request.build_absolute_uri|urlencode }}&entry.350152829={{ document.consignment_reference|urlencode }}"
            target="_blank"
            rel="noopener noreferrer">{% translate "judgment.report_blocking_problem" %}</a>
+      </li>
+      <li>
+        <a href="{% url 'unlock' %}?judgment_uri={{ document.uri }}">{% translate "judgment.unlock_judgment_title" %}</a>
       </li>
     </ul>
   </div>

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-10 11:19+0000\n"
+"POT-Creation-Date: 2023-08-16 16:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -152,14 +152,14 @@ msgid "judgment.create_in_jira"
 msgstr "Create in Jira"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
+msgid "judgment.report_blocking_problem"
+msgstr "Report a technical issue"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
 #: ds_caselaw_editor_ui/templates/judgment/confirm-unlock.html
 #: judgments/views/unlock.py
 msgid "judgment.unlock_judgment_title"
 msgstr "Unlock document"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
-msgid "judgment.report_blocking_problem"
-msgstr "Report a technical issue"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
 msgid "judgment.download_docx"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Re-order Tools list links in More menu
## Trello card / Rollbar error (etc)
https://trello.com/c/yf3mIF8K/1258-eui-re-order-tools-list-in-more-menu
## Screenshots of UI changes:

### Before
![before](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/bb3b31fa-c671-4541-a45f-8d5751fe6a83)

### After
![after](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/bba535de-acb4-4b71-a47f-6daf746f73aa)

- [ ] Requires env variable(s) to be updated
