### PR TITLE
Fix edit post view

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==14.0.0
+ds-caselaw-marklogic-api-client==14.0.1
 ds-caselaw-utils~=1.0.2
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
## Changes in this PR:
Fixed the edit post view by updating marklogicapclient to the new version without the set_document_court bug

## Trello card / Rollbar error (etc)
https://trello.com/c/1tnFOXfq/1261-bug-eui-apiclient-saving-court-metadata-broken

## Screenshots of UI changes:

### Before
<img width="1297" alt="Screenshot 2023-08-11 at 15 56 09" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/300264b8-488e-4884-9e72-4eca6424493a">

### After
<img width="1218" alt="Screenshot 2023-08-11 at 15 55 18" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/0626c773-24fd-486b-a085-3bcfa2533e85">
