### PR TITLE
Fix press summarry ncn in metadata panel

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==14.0.1
+ds-caselaw-marklogic-api-client==14.0.2
 ds-caselaw-utils~=1.0.2
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
## Changes in this PR:
Update to marklogic apiclient version 14.0.2 to fix press summary ncn not showing in metadata panel for new version of press summary xml.

The parser changed the location of the related neutral citation number for a parsed press summary xml compared to the original prototype for press summaries therefore we had to update the apiclient to point to that location and thus we released a new version of the apiclient and use it here.

## Trello card / Rollbar error (etc)
https://trello.com/c/uJiohuAM/1269-eui-the-ncn-number-does-not-appear-in-document-metadata-panel-for-updated-version-of-press-summaries

## Screenshots of UI changes:

### Before
<img width="1312" alt="Screenshot 2023-08-16 at 13 11 12" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/69863dde-9ec0-4468-8ded-ab70e0cacb8e">

### After
<img width="1219" alt="Screenshot 2023-08-16 at 13 09 49" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/59d4fd36-6282-425a-95b8-7cb3f903a1af">