### PR TITLE
re-order the static metadata panel

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -4,16 +4,8 @@
     <div class="judgment-metadata-panel">
       <ul class="judgment-metadata-panel__details">
         <li>
-          <span class="judgment-metadata-panel__key">{% translate "judgments.consignmentref" %}</span>
-          <span class="judgment-metadata-panel__value">{{ judgment.consignment_reference }}</span>
-        </li>
-        <li>
           <span class="judgment-metadata-panel__key">{% translate "judgments.ncn" %}</span>
           <span class="judgment-metadata-panel__value">{{ judgment.best_human_identifier }}</span>
-        </li>
-        <li>
-          <span class="judgment-metadata-panel__key">{% translate "judgments.court" %}</span>
-          <span class="judgment-metadata-panel__value">{{ judgment.court }}</span>
         </li>
         <li>
           <span class="judgment-metadata-panel__key">
@@ -27,12 +19,20 @@
                 datetime="{{ judgment.document_date_as_string }}">{{ judgment.document_date_as_string }}</time>
         </li>
         <li>
-          <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_name" %}</span>
-          <span class="judgment-metadata-panel__value">{{ judgment.name }}</span>
+          <span class="judgment-metadata-panel__key">{% translate "judgments.court" %}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.court }}</span>
         </li>
         <li>
           <span class="judgment-metadata-panel__key">{% translate "document.type" %}</span>
           <span class="judgment-metadata-panel__value">{{ judgment.document_noun|capfirst }}</span>
+        </li>
+        <li>
+          <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_name" %}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.name }}</span>
+        </li>
+        <li>
+          <span class="judgment-metadata-panel__key">{% translate "judgments.consignmentref" %}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.consignment_reference }}</span>
         </li>
       </ul>
     </div>

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-16 16:46+0000\n"
+"POT-Creation-Date: 2023-08-17 14:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -85,7 +85,7 @@ msgstr "Status"
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
 msgid "document.type"
-msgstr "Type"
+msgstr "Document type"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -93,13 +93,13 @@ msgid "judgments.ncn"
 msgstr "NCN"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+msgid "document.publication_date"
+msgstr "Publication date"
+
+#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
 msgid "judgments.court"
 msgstr "Court"
-
-#: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
-msgid "document.publication_date"
-msgstr "Publication date"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/sidebar.html
 msgid "judgments.associated_douments"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
re-order the static metadata panel to resemble order of metadata form
## Trello card / Rollbar error (etc)
https://trello.com/c/vwukCv33/1248-eui-re-order-the-static-metadata-panel-to-match-the-form-metadata-panel
## Screenshots of UI changes:
Metadata form order 
![form](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/85f87695-e4a5-40d5-89bc-bad9d0228815)

### Before

Judgment
![before-static](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/87e41b25-0588-418e-8d15-ab3d7923591e)

Press Summary
![before-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/50270d02-2ec9-4b57-bfad-bdfb118724c4)

### After
Judgment
![after-judgment](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/c1f4029f-f174-4cf0-9719-6a16606a03f8)

Press Summary
![press-summary-after](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/c11a6b4b-d19d-4e63-8d2e-a61e9d7d686c)

- [ ] Requires env variable(s) to be updated
