### PR TITLE
Reinstate delete button for failures

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
@@ -31,13 +31,13 @@
   }
 
   &__delete {
-    border-color: $color__red !important;
-    color: $color__red !important;
+    border-color: $color__failure !important;
+    color: $color__failure !important;
     &:focus,
     &:hover {
-      background-color: $color__red !important;
+      background-color: $color__failure !important;
       color: $color__white !important;
-      outline-color: $color__red !important;
+      outline-color: $color__failure !important;
     }
   }
 

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -44,6 +44,16 @@
           <path d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z" />
         </svg>
       </a>
+      {% if judgment.is_failure %}
+        <form action="{% url 'delete' %}" method="post">
+          {% csrf_token %}
+          <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
+          <input type="submit"
+                 name="assign"
+                 class="button-secondary judgment-toolbar__delete"
+                 value="Delete" />
+        </form>
+      {% endif %}
     </div>
     <div class="judgment-toolbar__more">{% include "includes/judgment/toolbar_more.html" %}</div>
     {% if version %}

--- a/ds_caselaw_editor_ui/templates/judgment/deleted.html
+++ b/ds_caselaw_editor_ui/templates/judgment/deleted.html
@@ -1,8 +1,0 @@
-{% extends "layouts/base.html" %}
-{% load static i18n %}
-{% block content %}
-  <div class="delete-judgment">
-    <p class="delete-judgment__confirmation">{% translate "judgment.deleted" %}</p>
-    <a href="{% url 'home' %}">{% translate "judgment.return_home" %}</a>
-  </div>
-{% endblock content %}

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -30,6 +30,7 @@ class JudgmentFactory:
         "court": ("court", "Court of Testing"),
         "document_date_as_string": ("document_date_as_string", "2023-02-03"),
         "is_published": ("is_published", False),
+        "is_failure": ("is_failure", False),
         "failed_to_parse": ("failed_to_parse", False),
         "source_name": ("source_name", "Example Uploader"),
         "source_email": ("source_email", "uploader@example.com"),
@@ -100,5 +101,6 @@ class SearchResultFactory(SimpleFactory):
         "court": "Court of Testing",
         "date": datetime.date(2023, 2, 3),
         "metadata": SearchResultMetadataFactory.build(),
+        "is_failure": False,
         "failed_to_parse": False,
     }

--- a/judgments/tests/test_document_delete.py
+++ b/judgments/tests/test_document_delete.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from factories import JudgmentFactory
+
+
+class TestDocumentDelete(TestCase):
+    @patch("judgments.views.delete.invalidate_caches")
+    @patch("judgments.views.delete.get_document_by_uri_or_404")
+    def test_document_delete_flow_if_safe(self, mock_document, mock_invalidate_caches):
+        document = JudgmentFactory.build(
+            uri="deltest/4321/123",
+            name="Hold Test",
+            is_published=False,
+        )
+        mock_document.return_value = document
+        mock_document.return_value.safe_to_delete = True
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.post(
+            reverse("delete"),
+            data={
+                "document_uri": document.uri,
+            },
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == reverse("home")
+        mock_document.return_value.delete.assert_called_once()
+        mock_invalidate_caches.assert_called_once()
+
+    @patch("judgments.views.delete.invalidate_caches")
+    @patch("judgments.views.delete.get_document_by_uri_or_404")
+    def test_document_delete_flow_if_not_safe(
+        self, mock_document, mock_invalidate_caches
+    ):
+        document = JudgmentFactory.build(
+            uri="deltest/4321/123",
+            name="Hold Test",
+            is_published=True,
+        )
+        mock_document.return_value = document
+        mock_document.return_value.safe_to_delete = False
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.post(
+            reverse("delete"),
+            data={
+                "document_uri": document.uri,
+            },
+        )
+
+        assert response.status_code == 403
+        mock_document.return_value.delete.assert_not_called()
+        mock_invalidate_caches.assert_not_called()

--- a/judgments/tests/test_document_toolbar.py
+++ b/judgments/tests/test_document_toolbar.py
@@ -1,0 +1,94 @@
+import re
+from unittest.mock import patch
+
+from caselawclient.models.judgments import Judgment
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from judgments.tests.factories import JudgmentFactory
+
+
+class TestDocumentToolbar(TestCase):
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    @patch("django.template.context_processors.get_token")
+    def test_delete_button_when_failure(
+        self, mock_get_token, document_type, document_exists, mock_judgment
+    ):
+        mock_get_token.return_value = "predicabletoken"
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri="failures/TDR-ref",
+            is_failure=True,
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(
+            reverse("full-text-html", kwargs={"document_uri": judgment.uri})
+        )
+
+        decoded_response = response.content.decode("utf-8")
+        delete_button_html = """
+        <form action="/delete" method="post">
+            <input type="hidden" name="csrfmiddlewaretoken" value="predicabletoken">
+            <input type="hidden" name="judgment_uri" value="failures/TDR-ref" />
+            <input type="submit"
+            name="assign"
+            class="button-secondary judgment-toolbar__delete"
+            value="Delete" />
+        </form>
+        """
+        self.assertIn(
+            self.preprocess_html(delete_button_html),
+            self.preprocess_html(decoded_response),
+        )
+
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    @patch("django.template.context_processors.get_token")
+    def test_no_delete_button_when_not_failure(
+        self, mock_get_token, document_type, document_exists, mock_judgment
+    ):
+        mock_get_token.return_value = "predicabletoken"
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri="good-document",
+            is_failure=False,
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(
+            reverse("full-text-html", kwargs={"document_uri": judgment.uri})
+        )
+
+        decoded_response = response.content.decode("utf-8")
+        delete_button_html = """
+        <form action="/delete" method="post">
+            <input type="hidden" name="csrfmiddlewaretoken" value="predicabletoken">
+            <input type="hidden" name="judgment_uri" value="good-document" />
+            <input type="submit"
+            name="assign"
+            class="button-secondary judgment-toolbar__delete"
+            value="Delete" />
+        </form>
+        """
+        self.assertNotIn(
+            self.preprocess_html(delete_button_html),
+            self.preprocess_html(decoded_response),
+        )
+
+    def preprocess_html(self, html):
+        """Removes leading and trailing whitespace, tabs, and line breaks"""
+        cleaned_html = re.sub(r"\s+", " ", html).strip()
+        return cleaned_html

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path
 
+from judgments.views.delete import delete
+
 from .views.button_handlers import (
     assign_judgment_button,
     hold_judgment_button,
@@ -53,6 +55,7 @@ urlpatterns = [
     path("unpublish", unpublish, name="unpublish"),
     path("hold", hold, name="hold"),
     path("unhold", unhold, name="unhold"),
+    path("delete", delete, name="delete"),
     path("unlock", unlock, name="unlock"),
     path("assign", assign_judgment_button, name="assign"),
     path("prioritise", prioritise_judgment_button, name="prioritise"),

--- a/judgments/views/delete.py
+++ b/judgments/views/delete.py
@@ -1,0 +1,24 @@
+from django.contrib import messages
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+
+from judgments.utils.aws import invalidate_caches
+from judgments.utils.view_helpers import get_document_by_uri_or_404
+
+
+def delete(request):
+    document_uri = request.POST.get("judgment_uri", None)
+    document = get_document_by_uri_or_404(document_uri)
+    if not document.safe_to_delete:
+        raise PermissionDenied(
+            f"The document at URI {document.uri} is not safe to delete."
+        )
+
+    document.delete()
+    invalidate_caches(document.uri)
+
+    messages.success(
+        request, f"The document at URI {document.uri} was successfully deleted."
+    )
+    return HttpResponseRedirect(reverse("home"))

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -223,14 +223,6 @@ msgstr ""
 msgid "judgment.back_to_judgment"
 msgstr "Back to document"
 
-#: ds_caselaw_editor_ui/templates/judgment/deleted.html
-msgid "judgment.deleted"
-msgstr "Document successfully deleted"
-
-#: ds_caselaw_editor_ui/templates/judgment/deleted.html
-msgid "judgment.return_home"
-msgstr "Return to Find and manage case law"
-
 #: ds_caselaw_editor_ui/templates/judgment/hold-success.html
 msgid "judgment.hold.success"
 msgstr "This document has been put on hold"


### PR DESCRIPTION
## Changes in this PR:
In https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/1103/files we removed the delete button that was accessible on "failure" URI documents when we shouldn't have as it was still in use.

This adds it back. Only difference to the original is that it now just takes you to the home page/unpublished list when you confirm deletion with the green message banner telling you it has been deleted as opposed to previously where there was an interim "delete.html" page which said the same thing and had a link to take you back to the homepage.

There was a different design where deleting a document would not have this big red button, it would be in the more toolbar and take you to a new page to delete but we decided against changing that just yet so that things dont change too much for the editors. Reference for that work here: https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/1112/files

## Trello card / Rollbar error (etc)
https://trello.com/c/FIuUf94n/1246-eui-reinstate-the-delete-button


## Screenshots of UI changes:

### Before
<img width="1294" alt="Screenshot 2023-08-17 at 17 07 46" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/c94e1605-8667-4920-b6bf-12c726656055">

### After
<img width="1278" alt="Screenshot 2023-08-17 at 17 13 17" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/42998618/09d8daa5-4247-4e4c-a10d-b6d20819620c">
