### PR TITLE
No dots in am/pm

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgments_list_item.html
@@ -89,7 +89,7 @@
   <div class="judgments-list__judgment-submitted">
     {{ item.metadata.submission_datetime|date:"d M Y" }}
     <br />
-    {{ item.metadata.submission_datetime|time:"h:i a" }}
+    {{ item.metadata.submission_datetime|time:"h:i A"|lower }}
   </div>
   <div class="judgments-list__judgment-assigned">
     {% if item.metadata.assigned_to %}


### PR DESCRIPTION
https://dxw.slack.com/archives/C04FQ3GFGUQ/p1692624366581049
https://stackoverflow.com/questions/12218620/in-django-how-to-display-times-with-lowercase-am-pm-in-templates
### Before:
<img width="125" alt="Screenshot 2023-08-21 at 14 40 08" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/85497046/0465d621-e0b3-4530-854e-c6fcafbe14e0">

### After:
<img width="114" alt="Screenshot 2023-08-21 at 14 40 37" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/85497046/4fab9344-8a13-4150-a886-9c9c061feacb">
