### PR TITLE
Update metadata static capitalisation added to press summary

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -64,7 +64,7 @@
           <aside for="metadata_name" class="metadata-component__main-labels">
             {% translate "document.type" %}
           </aside>
-          <p>{{ judgment.document_noun|capfirst }}</p>
+          <p>{{ judgment.document_noun|title }}</p>
         </div>
         <div class="metadata-component__actions">
           <input type="hidden" name="judgment_uri" value="{{ document_uri }}" />

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -24,7 +24,7 @@
         </li>
         <li>
           <span class="judgment-metadata-panel__key">{% translate "document.type" %}</span>
-          <span class="judgment-metadata-panel__value">{{ judgment.document_noun|capfirst }}</span>
+          <span class="judgment-metadata-panel__value">{{ judgment.document_noun|title }}</span>
         </li>
         <li>
           <span class="judgment-metadata-panel__key">{% translate "judgment.judgment_name" %}</span>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Update metadata static capitalisation added to press summary
## Trello card / Rollbar error (etc)
https://trello.com/c/ij7KgWga/1293-eui-update-metadata-for-press-summary-so-it-renders-with-a-capital-s-on-summary
## Screenshots of UI changes:

### Before
![before-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/d0720a63-fc17-43ad-b66a-404cc58eb3b7)

### After
![after-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/9ab1a452-9ee4-4a4a-8ca0-45749f81ecf4)

- [ ] Requires env variable(s) to be updated
