### PR TITLE
Remove redundant global sass install in dockerfile and instruction in readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
-RUN npm i -g sass --engine-strict=true
 
 # All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
 # copy python dependency wheels from python-build-stage

--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ Included in this repository is:
 ### Working with SASS/CSS
 
 - Ensure you have NodeJS & NPM installed.
-- Install SASS globally by running `npm install -g sass`.
 - To watch and build the site SASS, run `npm run start-sass`
 - To modify styles, navigate to the `sass` folder in your editor.
 


### PR DESCRIPTION
## Changes in this PR:
- Removed redundant global sass install in dockerfile and instruction in readme

Since https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/1115 was merged in, we no longer need to manually install sass, we install it through our package.json!

## Trello card / Rollbar error (etc)
https://trello.com/c/WkhvV1VO/1223-eui-pui-set-up-shared-front-end-code-repo-and-add-documenttext-css-to-it