### PR TITLE
Stop trying to copy in judgment_text.scss from PUI since its been moved out to the shared FE repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,6 +280,3 @@ docker/*
 /ds_caselaw_editor_ui/static/css/main.css
 /ds_caselaw_editor_ui/static/css/main.css.map
 /ds_caselaw_editor_ui/static/js/dist/app.js
-
-# This is pulled in automaically by `fab run` from the ds-caselaw-public-ui repo.
-/ds_caselaw_editor_ui/sass/includes/_judgment_text.scss

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,11 +79,6 @@ COPY --chown=django:django . ${APP_HOME}
 # make django owner of the WORKDIR directory as well.
 RUN chown django:django ${APP_HOME}
 
-# Use Github API to get latest tag for public-ui, then use the tag to get the Judgment CSS
-# This Judgment CSS is the "source of truth" for displaying judgments
-RUN apt-get update && apt-get install -y jq curl
-RUN curl https://raw.githubusercontent.com/nationalarchives/ds-caselaw-public-ui/$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/nationalarchives/ds-caselaw-public-ui/releases/latest | jq -r .tag_name)/ds_judgements_public_ui/sass/includes/_judgment_text.scss -o ds_caselaw_editor_ui/sass/includes/_judgment_text.scss
-
 USER django
 
 ENTRYPOINT ["/entrypoint"]

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -10,7 +10,7 @@
 @import "includes/tables";
 
 // Shared CSS
-@import "../../node_modules/@nationalarchives/ds-caselaw-frontend/src/main.scss";
+@import "../../node_modules/@nationalarchives/ds-caselaw-frontend/src/main";
 
 @import "includes/animations";
 @import "includes/search";

--- a/fabfile.py
+++ b/fabfile.py
@@ -75,15 +75,6 @@ def run(c):
     django_exec("python manage.py migrate")
     django_exec("rm -rf /app/staticfiles")
     django_exec("python manage.py collectstatic")
-    # Get the public-ui version of _judgment_text.scss
-    django_exec("apt-get update && apt-get install -y jq curl")
-    django_exec(
-        "curl https://raw.githubusercontent.com/nationalarchives/ds-caselaw-public-ui/"
-        "$(curl -H 'Accept: application/vnd.github+json' "
-        "https://api.github.com/repos/nationalarchives/ds-caselaw-public-ui/releases/latest | jq -r .tag_name)"
-        "/ds_judgements_public_ui/sass/includes/_judgment_text.scss "
-        "-o ds_caselaw_editor_ui/sass/includes/_judgment_text.scss"
-    )
     # Piping Marklogic logs to marklogic.log
     try:
         local("docker logs marklogic > marklogic.log")


### PR DESCRIPTION
EUI was working in deployment but it was still trying to copy the old file in

## Changes in this PR:

- Stop trying to copy in `judgment_text.scss` from PUI since it has been moved out to the shared frontend repo
- Remove unnecessary .scss in scss import

## Trello card / Rollbar error (etc)
https://trello.com/c/WkhvV1VO/1223-eui-pui-set-up-shared-front-end-code-repo-and-add-documenttext-css-to-it