### PR TITLE
Add banner to highlight staging environment

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -192,6 +192,7 @@ TEMPLATES = [
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
                 "judgments.context_processors.cookie_consent",
+                "judgments.context_processors.environment",
             ],
         },
     }

--- a/ds_caselaw_editor_ui/sass/includes/_environment_banner.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_environment_banner.scss
@@ -1,0 +1,33 @@
+.environment-banner {
+  background-color: $color__information;
+  color: $color__black;
+
+  &__notice {
+    padding: 0;
+
+    a {
+      color: $color__black;
+      font-weight: bold;
+
+      &:focus {
+        outline: 0.125rem solid $color__black;
+        background-color: $color__white;
+        color: $color__black;
+      }
+    }
+  }
+
+  &__environment {
+    background-color: $color__white;
+    color: $color__black;
+    text-transform: uppercase;
+    padding: 0 calc($spacer__unit / 4);
+    margin-right: $spacer__unit;
+    font-weight: 700;
+  }
+
+  &__message {
+    margin: 0;
+    display: inline;
+  }
+}

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -37,6 +37,7 @@
 @import "includes/colour_swatches";
 @import "includes/summary-panels";
 @import "includes/labs";
+@import "includes/environment_banner";
 @import "includes/style_guide";
 @import "includes/tabs";
 @import "includes/notification_message";

--- a/ds_caselaw_editor_ui/templates/includes/environment_banner.html
+++ b/ds_caselaw_editor_ui/templates/includes/environment_banner.html
@@ -1,0 +1,12 @@
+{% if environment == "staging" %}
+  <div class="environment-banner">
+    <div class="container py-1">
+      <div class="environment-banner__notice">
+        <strong class="environment-banner__environment">Staging</strong>
+        <p class="environment-banner__message">
+          This environment may have features which are not yet available on production.
+        </p>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/ds_caselaw_editor_ui/templates/layouts/base.html
+++ b/ds_caselaw_editor_ui/templates/layouts/base.html
@@ -21,9 +21,10 @@
     {% include "includes/gtm/gtm_head.html" %}
   </head>
   <body>
-    {% include "includes/cookie_consent/cookie_banner.html" %}
     {% include "includes/gtm/gtm_body.html" %}
+    {% include "includes/cookie_consent/cookie_banner.html" %}
     <a id="skip-to-main-content" href="#main-content">{% translate "skiplink" %}</a>
+    {% include "includes/environment_banner.html" %}
     <header class="page-header">
       {% include "includes/breadcrumbs.html" with current=page_title title=page_title link=request.get_full_path %}
     </header>

--- a/judgments/context_processors.py
+++ b/judgments/context_processors.py
@@ -1,6 +1,8 @@
 import json
 from urllib.parse import unquote
 
+from config.settings.base import env
+
 
 def cookie_consent(request):
     showGTM = False
@@ -17,3 +19,7 @@ def cookie_consent(request):
         dontShowCookieNotice = True
 
     return {"showGTM": showGTM, "dontShowCookieNotice": dontShowCookieNotice}
+
+
+def environment(request):
+    return {"environment": env("ROLLBAR_ENV", None)}


### PR DESCRIPTION
To give added confidence to people interacting with Staging, show a banner when in a staging environment.

This uses the `ROLLBAR_ENV` environment variable, since this _must_ be set on an environment using a production config (ie staging and production).

## Screenshots

![localhost_3000_](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/579d2054-1b98-4b02-bccb-7f3b7decd002)
