### PR TITLE
(FCL-76) Add submission time and date to history

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_document_version_history.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_document_version_history.scss
@@ -1,0 +1,7 @@
+.document-version-history {
+  &__table {
+    border-color: $color__dark-grey;
+    width: auto;
+    border-collapse: collapse;
+  }
+}

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -45,3 +45,4 @@
 @import "includes/notification_message";
 @import "includes/judgment_view_controls";
 @import "includes/note";
+@import "includes/document_version_history";

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
@@ -16,7 +16,7 @@
            rel="noopener noreferrer">{% translate "judgment.create_in_jira" %}</a>
       </li>
       <li>
-        <a href="{% url 'document-history' document.uri %}">Document history</a>
+        <a href="{% url 'document-history' document.uri %}">Document version history</a>
       </li>
       <li>
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSckmLdeUAEoEoBc55ybFVmOsXPEM7CG2VbN2YNwsX6kL9UZ4Q/viewform?usp=pp_url&entry.2047884653=Yes&entry.6716552=A+specific+judgment+or+decision&entry.481919886={{ request.build_absolute_uri|urlencode }}&entry.350152829={{ document.consignment_reference|urlencode }}"

--- a/ds_caselaw_editor_ui/templates/judgment/history.html
+++ b/ds_caselaw_editor_ui/templates/judgment/history.html
@@ -1,23 +1,27 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
-{% load i18n %}
+{% load i18n document_utils %}
 {% block judgment_header %}
   {% include "includes/judgment/metadata_panel_static.html" with judgment=document %}
 {% endblock judgment_header %}
 {% block judgment_content %}
-  <div>
-    <h2>Document history</h2>
-    <table class="table">
+  <div class="document-version-history">
+    <h2>Document version history</h2>
+    <table class="document-version-history__table table">
       <thead>
         <tr>
           <th scope="col">Version</th>
+          <th scope="col">Date submitted</th>
+          <th scope="col">Time</th>
         </tr>
       </thead>
       <tbody>
-        {% for version in document.versions %}
+        {% for version in document.versions_as_documents %}
           <tr>
             <td>
-              <a href="{% url 'full-text-html' document_uri %}?version_uri={{ version.uri }}">Version {{ version.version }}</a>
+              <a href="{% url 'full-text-html' document_uri %}?version_uri={{ version.uri }}">Version {{ version.version_number }}</a>
             </td>
+            <td>{{ version.get_latest_manifestation_datetime|display_datetime_date }}</td>
+            <td>{{ version.get_latest_manifestation_datetime|display_datetime_time }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/judgments/templatetags/document_utils.py
+++ b/judgments/templatetags/document_utils.py
@@ -8,3 +8,13 @@ def get_title_to_display_in_html(document_title, document_type):
     if document_type == "press_summary":
         return document_title.removeprefix("Press Summary of ")
     return document_title
+
+
+@register.filter
+def display_datetime_date(datetime):
+    return datetime.strftime("%d %b %Y")
+
+
+@register.filter
+def display_datetime_time(datetime):
+    return datetime.strftime("%H:%M")

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -39,6 +39,7 @@ class JudgmentFactory:
         "consignment_reference": ("consignment_reference", "TDR-12345"),
         "assigned_to": ("assigned_to", ""),
         "versions": ("versions", []),
+        "versions_as_documents": ("versions_as_documents", []),
         "content_as_xml": ("xml", "<akomaNtoso>This is a document's XML.</akomaNtoso>"),
     }
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==15.0.1
+ds-caselaw-marklogic-api-client==15.1.0
 ds-caselaw-utils~=1.0.2
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
## Changes in this PR:

Adds the time and date to the document version history :-)

IMPORTANT! will require a version bump to the API client once https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/396 is merged in. Please don't merge 'til that's done :-)

## Trello card / Rollbar error (etc)

https://trello.com/c/Rlo1Spj5/1306-eui-adding-date-and-time-to-doc-version-history-awaiting-1321

## Screenshots of UI changes:


<img width="480" alt="Screenshot 2023-09-19 at 14 46 36" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/eb495a00-23fc-482d-b018-20b70aa10ccb">

