### PR TITLE
first iteration of "add a note" UI

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_note.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_note.scss
@@ -1,14 +1,20 @@
 .note-form {
   &__label {
-    margin-bottom: 1rem;
+    display: block;
+    margin-bottom: calc($spacer__unit / 4);
+    font-size: 0.9rem;
+    line-height: 1.2rem;
+    color: $color__dark-grey;
   }
 
   &__text-area {
     @include text_field;
+    margin-top: 0;
     display: block;
-    width: 100%;
+    width: calc(100% - $spacer__unit);
     font-size: 1rem;
     line-height: 1.25rem;
     border: 2px solid $color__almost-black;
+    box-sizing: border-box;
   }
 }

--- a/ds_caselaw_editor_ui/templates/includes/note-form.html
+++ b/ds_caselaw_editor_ui/templates/includes/note-form.html
@@ -1,11 +1,8 @@
 <div class="note-form">
-  <h2>
-    <label class="note-form__label" for="write-a-note">Write a note</label>
-  </h2>
+  <label class="note-form__label" for="write-a-note">Add a note for the editoral team (optional)</label>
   <textarea class="note-form__text-area"
             id="write-a-note"
             name="write-a-note"
             rows="8"
-            placeholder="Write your message..."
             aria-describedby="write-a-note"></textarea>
 </div>

--- a/ds_caselaw_editor_ui/templates/judgment/hold.html
+++ b/ds_caselaw_editor_ui/templates/judgment/hold.html
@@ -1,5 +1,5 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
-{% load i18n %}
+{% load i18n waffle_tags %}
 {% block judgment_header %}
   {% include "includes/judgment/metadata_panel_static.html" with judgment=judgment %}
 {% endblock judgment_header %}
@@ -10,9 +10,12 @@
     <div class="judgment-component__actions">
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
       <input type="hidden" name="hold" value="true" />
-      <input class="button-cta"
-             type="submit"
-             value="{% translate "judgment.hold_this_judgment" %}" />
-    </div>
-  </form>
+      {% flag "notes_on_state_change" %}
+      {% include "includes/note-form.html" %}
+    {% endflag %}
+    <input class="button-cta"
+           type="submit"
+           value="{% translate "judgment.hold_this_judgment" %}" />
+  </div>
+</form>
 {% endblock judgment_content %}

--- a/ds_caselaw_editor_ui/templates/judgment/publish.html
+++ b/ds_caselaw_editor_ui/templates/judgment/publish.html
@@ -1,5 +1,5 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
-{% load i18n %}
+{% load i18n waffle_tags %}
 {% block judgment_header %}
   {% include "includes/judgment/metadata_panel_static.html" with judgment=judgment %}
 {% endblock judgment_header %}
@@ -13,13 +13,16 @@
       {% csrf_token %}
       <div class="judgment-component__actions">
         <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
-        <input class="button-cta"
-               type="submit"
-               value="{% translate "judgment.publish_this_judgment" %}" />
-      </div>
-    </form>
-  {% else %}
-    <span class="judgment-toolbar__button button-secondary"
-          aria-disabled="true">{% translate "judgment.publish_this_judgment" %}</span>
-  {% endif %}
+        {% flag "notes_on_state_change" %}
+        {% include "includes/note-form.html" %}
+      {% endflag %}
+      <input class="button-cta"
+             type="submit"
+             value="{% translate "judgment.publish_this_judgment" %}" />
+    </div>
+  </form>
+{% else %}
+  <span class="judgment-toolbar__button button-secondary"
+        aria-disabled="true">{% translate "judgment.publish_this_judgment" %}</span>
+{% endif %}
 {% endblock judgment_content %}

--- a/ds_caselaw_editor_ui/templates/judgment/unhold.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold.html
@@ -1,4 +1,5 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
+{% load waffle_tags %}
 {% block judgment_header %}
   {% include "includes/judgment/metadata_panel_static.html" with judgment=judgment %}
 {% endblock judgment_header %}
@@ -10,9 +11,12 @@
     <div class="judgment-component__actions">
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
       <input type="hidden" name="unhold" value="false" />
-      <input class="button-cta"
-             type="submit"
-             value="{% translate "judgment.unhold.unhold_button" %}" />
-    </div>
-  </form>
+      {% flag "notes_on_state_change" %}
+      {% include "includes/note-form.html" %}
+    {% endflag %}
+    <input class="button-cta"
+           type="submit"
+           value="{% translate "judgment.unhold.unhold_button" %}" />
+  </div>
+</form>
 {% endblock judgment_content %}

--- a/ds_caselaw_editor_ui/templates/judgment/unpublish.html
+++ b/ds_caselaw_editor_ui/templates/judgment/unpublish.html
@@ -1,5 +1,5 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
-{% load i18n %}
+{% load i18n waffle_tags %}
 {% block judgment_header %}
   {% include "includes/judgment/metadata_panel_static.html" with judgment=judgment %}
 {% endblock judgment_header %}
@@ -8,7 +8,10 @@
   <form action="{% url 'unpublish' %}" method="post">
     {% csrf_token %}
     <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
-    <input type="submit"
-           value="{% translate "judgment.unpublish.unpublish_button" %}" />
-  </form>
+    {% flag "notes_on_state_change" %}
+    {% include "includes/note-form.html" %}
+  {% endflag %}
+  <input type="submit"
+         value="{% translate "judgment.unpublish.unpublish_button" %}" />
+</form>
 {% endblock judgment_content %}

--- a/judgments/views/labs.py
+++ b/judgments/views/labs.py
@@ -9,7 +9,12 @@ class Labs(TemplateView):
     #     "title": "Embedded PDF",
     #     "description": "View PDFs directly in the browser without needing to download them.",
     # },
-    EXPERIMENTS: dict[str, dict] = {}
+    EXPERIMENTS: dict[str, dict] = {
+        "notes_on_state_change": {
+            "title": "Add a note (on holding/publishing)",
+            "description": "Allow editors to add an explanatory note when holding or publishing a judgment.",
+        },
+    }
 
     def get_context_data(self, **kwargs):
         context = super(Labs, self).get_context_data(**kwargs)


### PR DESCRIPTION

## Changes in this PR:

This adds, a (currently non-functional) 'add a note' field on the confirmation page for the publish, unpublish, put on hold and take off hold actions, behind a feature flag, so that Rose can test it! I've modified the designs slightly based on the earlier wireframes to accomodate their new position on the confirmation page, and make the copy and style consistent with GDS guidelines on optional form field (as well our own form field styles elsewhere).

**After deploying, the feature flag `notes_on_state_change` will need to be added in the django admin UI, at which point the feature can be enabled in labs.**

## Trello card / Rollbar error (etc)

https://trello.com/c/Hvh7udC2/1355-eui-add-a-note-component-mvp-for-testing

## Screenshots of UI changes:
![Screenshot 2023-09-20 at 16 26 27](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/11defd70-7d38-44d1-a379-f4fb45ec8bd0)


