### PR TITLE
Check that users are editors or devs before deleting

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n user_permissions %}
 <hr>
 <div class="judgment-toolbar__more__menu">
   <div class="judgment-toolbar__more__menu__group">
@@ -46,9 +46,9 @@
       </li>
     </ul>
   </div>
-  {% if user.is_superuser %}
+  {% if user|is_superuser_or_editor %}
     <div class="judgment-toolbar__more__menu__group">
-      <h4>Superuser tools</h4>
+      <h4>Editor tools</h4>
       <form action="{% url 'delete' %}" method="post">
         {% csrf_token %}
         <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/judgments/templatetags/user_permissions.py
+++ b/judgments/templatetags/user_permissions.py
@@ -1,0 +1,10 @@
+from django import template
+
+from judgments.utils.view_helpers import user_is_superuser_or_editor
+
+register = template.Library()
+
+
+@register.filter(name="is_superuser_or_editor")
+def is_superuser_or_editor(user):
+    return user_is_superuser_or_editor(user)

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -43,6 +43,7 @@ class JudgmentFactory:
         "versions": ("versions", []),
         "versions_as_documents": ("versions_as_documents", []),
         "content_as_xml": ("xml", "<akomaNtoso>This is a document's XML.</akomaNtoso>"),
+        "safe_to_delete": ("safe_to_delete", False),
     }
 
     @classmethod

--- a/judgments/tests/test_document_delete.py
+++ b/judgments/tests/test_document_delete.py
@@ -1,12 +1,21 @@
 from unittest.mock import patch
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.test import TestCase
 from django.urls import reverse
 from factories import JudgmentFactory
 
 
 class TestDocumentDelete(TestCase):
+    def setUp(self):
+        editor_group = Group(name="Editors")
+        editor_group.save()
+        self.editor_user = User.objects.get_or_create(username="ed")[0]
+        self.editor_user.groups.add(editor_group)
+        self.editor_user.save()
+        self.standard_user = User.objects.get_or_create(username="alice")[0]
+        self.super_user = User.objects.create_superuser(username="clark")
+
     @patch("judgments.views.delete.invalidate_caches")
     @patch("judgments.views.delete.get_document_by_uri_or_404")
     def test_document_delete_flow_if_safe(self, mock_document, mock_invalidate_caches):
@@ -14,11 +23,11 @@ class TestDocumentDelete(TestCase):
             uri="deltest/4321/123",
             name="Hold Test",
             is_published=False,
+            safe_to_delete=True,
         )
         mock_document.return_value = document
-        mock_document.return_value.safe_to_delete = True
 
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+        self.client.force_login(self.editor_user)
 
         response = self.client.post(
             reverse("delete"),
@@ -34,6 +43,34 @@ class TestDocumentDelete(TestCase):
 
     @patch("judgments.views.delete.invalidate_caches")
     @patch("judgments.views.delete.get_document_by_uri_or_404")
+    def test_document_delete_flow_if_not_editor(
+        self,
+        mock_document,
+        mock_invalidate_caches,
+    ):
+        document = JudgmentFactory.build(
+            uri="deltest/4321/123",
+            name="Hold Test",
+            is_published=False,
+            safe_to_delete=True,
+        )
+        mock_document.return_value = document
+
+        self.client.force_login(self.standard_user)
+
+        response = self.client.post(
+            reverse("delete"),
+            data={
+                "document_uri": document.uri,
+            },
+        )
+
+        assert response.status_code == 403
+        mock_document.return_value.delete.assert_not_called()
+        mock_invalidate_caches.assert_not_called()
+
+    @patch("judgments.views.delete.invalidate_caches")
+    @patch("judgments.views.delete.get_document_by_uri_or_404")
     def test_document_delete_flow_if_not_safe(
         self,
         mock_document,
@@ -43,9 +80,9 @@ class TestDocumentDelete(TestCase):
             uri="deltest/4321/123",
             name="Hold Test",
             is_published=True,
+            safe_to_delete=False,
         )
         mock_document.return_value = document
-        mock_document.return_value.safe_to_delete = False
 
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])
 

--- a/judgments/tests/test_view_helpers.py
+++ b/judgments/tests/test_view_helpers.py
@@ -2,10 +2,15 @@ from unittest.mock import patch
 
 import pytest
 from caselawclient.errors import DocumentNotFoundError
+from django.contrib.auth.models import Group, User
 from django.http import Http404
+from django.test import TestCase
 from factories import JudgmentFactory
 
-from judgments.utils.view_helpers import get_document_by_uri_or_404
+from judgments.utils.view_helpers import (
+    get_document_by_uri_or_404,
+    user_is_superuser_or_editor,
+)
 
 
 class TestGetDocumentByURIOr404:
@@ -28,3 +33,19 @@ class TestGetDocumentByURIOr404:
     def test_judgment_missing(self, mock_judgment):
         with pytest.raises(Http404):
             get_document_by_uri_or_404("not-a-judgment")
+
+
+class TestGroupCheck(TestCase):
+    def setUp(self):
+        editor_group = Group(name="Editors")
+        editor_group.save()
+        self.editor_user = User.objects.get_or_create(username="ed")[0]
+        self.editor_user.groups.add(editor_group)
+        self.editor_user.save()
+        self.standard_user = User.objects.get_or_create(username="alice")[0]
+        self.super_user = User.objects.create_superuser(username="clark")
+
+    def test_editor_or_superuser(self):
+        assert user_is_superuser_or_editor(self.standard_user) is False
+        assert user_is_superuser_or_editor(self.super_user) is True
+        assert user_is_superuser_or_editor(self.editor_user) is True

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -15,6 +15,15 @@ from judgments.utils.paginator import paginator
 ALLOWED_ORDERS = ["date", "-date"]
 
 
+def user_is_superuser_or_editor(user):
+    """
+    return: True if the User is an editor or superuser
+    """
+    editor = user.groups.filter(name="Editors").exists()
+    superuser = user.is_superuser
+    return editor or superuser
+
+
 def get_search_parameters(
     params,
     default_page=1,

--- a/judgments/views/delete.py
+++ b/judgments/views/delete.py
@@ -4,10 +4,17 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 
 from judgments.utils.aws import invalidate_caches
-from judgments.utils.view_helpers import get_document_by_uri_or_404
+from judgments.utils.view_helpers import (
+    get_document_by_uri_or_404,
+    user_is_superuser_or_editor,
+)
 
 
 def delete(request):
+    if not user_is_superuser_or_editor(request.user):
+        msg = "Only superusers and editors can delete documents"
+        raise PermissionDenied(msg)
+
     document_uri = request.POST.get("judgment_uri", None)
     document = get_document_by_uri_or_404(document_uri)
     if not document.safe_to_delete:


### PR DESCRIPTION
Delete button should always appear in More for editors and superusers
/delete action should fail for non-editor, non-superusers

https://linear.app/tna/issue/FCL-102/make-delete-button-available-for-all-editors

