### PR TITLE
add type column to version history

### DIFF
--- a/ds_caselaw_editor_ui/templates/judgment/history.html
+++ b/ds_caselaw_editor_ui/templates/judgment/history.html
@@ -12,6 +12,7 @@
           <th scope="col">Version</th>
           <th scope="col">Date submitted</th>
           <th scope="col">Time</th>
+          <th scope="col">Type</th>
         </tr>
       </thead>
       <tbody>
@@ -22,6 +23,7 @@
             </td>
             <td>{{ version.get_latest_manifestation_datetime|display_datetime_date }}</td>
             <td>{{ version.get_latest_manifestation_datetime|display_datetime_time }}</td>
+            <td>{{ judgment.document_noun|title }}</td>
           </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Add type column to version history
## Trello card / Rollbar error (etc)
https://trello.com/c/jyTZaNMi/1359-eui-version-history-add-column-to-table-to-indicate-type-of-version
## Screenshots of UI changes:

### Before
![before-judgment](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/88bedb7d-e13e-4e90-9b41-fc116a84d33f)
![before-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/d0e72d4c-9813-4544-b524-c0d0fc06bd5b)

### After
![after-judgment](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/b27ab50d-d529-4a83-9bd9-77ba77ddc7e8)
![after-press-summary](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/fd5311ae-cd6f-4258-8888-f41d3ae69286)

- [ ] Requires env variable(s) to be updated
