### PR TITLE
Add test for document history page

### DIFF
--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -62,7 +62,16 @@ class JudgmentFactory:
             else:
                 setattr(judgment_mock.return_value, map_to, map_from[1])
 
-        return judgment_mock()
+        judgment = judgment_mock()
+        version = judgment.copy()
+        version.version_number = 1
+        version.get_latest_manifestation_datetime = datetime.datetime(2023, 9, 26, 12)
+        uri = judgment.uri
+        id = uri.split("/")[-1]
+        version.uri.return_value = "%s/_xml_versions/1-%s.xml" % (uri, id)
+        judgment.versions_as_documents.append(version)
+
+        return judgment
 
 
 class SimpleFactory:

--- a/judgments/tests/test_document_history.py
+++ b/judgments/tests/test_document_history.py
@@ -33,3 +33,10 @@ class TestDocumentHistory(TestCase):
         )
 
         assert response.status_code == 200
+
+        decoded_response = response.content.decode("utf-8")
+        dt = document.versions_as_documents[0].get_latest_manifestation_datetime
+
+        assert "Version 1" in decoded_response
+        assert dt.strftime("%d %b %Y") in decoded_response
+        assert dt.strftime("%H:%M") in decoded_response


### PR DESCRIPTION
## Changes in this PR:
...which asserts that the document history shows the correct details.

This involved a little update to the judgment factory to give each judgment a version, by default version 1 with a creation time of now().

## Trello card / Rollbar error (etc)

https://trello.com/c/QvHFqt2v/1370-add-a-test-for-version-dates-times
