### PR TITLE
Show version type in version table

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_typography.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_typography.scss
@@ -1,21 +1,3 @@
-a {
-  color: $color__link-blue;
-  text-decoration: underline;
-
-  &:hover {
-    color: $color__link-blue-hover;
-    text-decoration: none;
-  }
-
-  &:visited {
-    color: $color__link-blue-visited;
-  }
-
-  &:active {
-    color: $color__link-blue-active;
-  }
-
-  &:focus {
-    @include focus-default;
-  }
+.muted {
+  color: $color__dark-grey;
 }

--- a/ds_caselaw_editor_ui/sass/includes/_typography.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_typography.scss
@@ -1,3 +1,25 @@
+a {
+  color: $color__link-blue;
+  text-decoration: underline;
+
+  &:hover {
+    color: $color__link-blue-hover;
+    text-decoration: none;
+  }
+
+  &:visited {
+    color: $color__link-blue-visited;
+  }
+
+  &:active {
+    color: $color__link-blue-active;
+  }
+
+  &:focus {
+    @include focus-default;
+  }
+}
+
 .muted {
   color: $color__dark-grey;
 }

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -8,6 +8,7 @@
 @import "includes/header";
 @import "includes/footer";
 @import "includes/tables";
+@import "includes/typography";
 
 // Shared CSS
 @import "../../node_modules/@nationalarchives/ds-caselaw-frontend/src/main";

--- a/ds_caselaw_editor_ui/templates/judgment/history.html
+++ b/ds_caselaw_editor_ui/templates/judgment/history.html
@@ -10,9 +10,8 @@
       <thead>
         <tr>
           <th scope="col">Version</th>
-          <th scope="col">Date submitted</th>
-          <th scope="col">Time</th>
-          <th scope="col">Type</th>
+          <th scope="col">Date created</th>
+          <th scope="col">Details</th>
         </tr>
       </thead>
       <tbody>
@@ -21,9 +20,16 @@
             <td>
               <a href="{% url 'full-text-html' document_uri %}?version_uri={{ version.uri }}">Version {{ version.version_number }}</a>
             </td>
-            <td>{{ version.get_latest_manifestation_datetime|display_datetime_date }}</td>
-            <td>{{ version.get_latest_manifestation_datetime|display_datetime_time }}</td>
-            <td>{{ version.get_latest_manifestation_type|display_friendly_version_type }}</td>
+            <td>{{ version.version_created_datetime|display_datetime }}</td>
+            <td>
+              {% with annotation=version.annotation %}
+                {% if annotation %}
+                  {{ annotation }}
+                {% else %}
+                  <span class="muted">Unknown</span>
+                {% endif %}
+              {% endwith %}
+            </td>
           </tr>
         {% endfor %}
       </tbody>

--- a/ds_caselaw_editor_ui/templates/judgment/history.html
+++ b/ds_caselaw_editor_ui/templates/judgment/history.html
@@ -23,7 +23,7 @@
             </td>
             <td>{{ version.get_latest_manifestation_datetime|display_datetime_date }}</td>
             <td>{{ version.get_latest_manifestation_datetime|display_datetime_time }}</td>
-            <td>{{ judgment.document_noun|title }}</td>
+            <td>{{ version.get_latest_manifestation_type|display_friendly_version_type }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/ds_caselaw_editor_ui/templates/judgment/history.html
+++ b/ds_caselaw_editor_ui/templates/judgment/history.html
@@ -24,7 +24,7 @@
             <td>
               {% with annotation=version.annotation %}
                 {% if annotation %}
-                  {{ annotation }}
+                  {{ annotation|display_annotation_type }}
                 {% else %}
                   <span class="muted">Unknown</span>
                 {% endif %}

--- a/judgments/templatetags/document_utils.py
+++ b/judgments/templatetags/document_utils.py
@@ -1,3 +1,5 @@
+import json
+
 from django import template
 
 register = template.Library()
@@ -12,7 +14,21 @@ def get_title_to_display_in_html(document_title, document_type):
 
 @register.filter
 def display_datetime(dt):
-    if dt is not None:
-        return dt.strftime("%d %b %Y %H:%M")
-    else:
-        return None
+    return dt.strftime("%d %b %Y %H:%M")
+
+
+VERSION_TYPE_LABELS = {
+    "submission": "Submitted",
+    "enrichment": "Enriched",
+    "edit": "Edited",
+}
+
+
+@register.filter
+def display_annotation_type(annotation):
+    try:
+        annotation_data = json.loads(annotation)
+        version_type = annotation_data.get("type")
+        return VERSION_TYPE_LABELS.get(version_type, version_type)
+    except (TypeError, json.JSONDecodeError):
+        return annotation

--- a/judgments/templatetags/document_utils.py
+++ b/judgments/templatetags/document_utils.py
@@ -11,20 +11,8 @@ def get_title_to_display_in_html(document_title, document_type):
 
 
 @register.filter
-def display_datetime_date(datetime):
-    return datetime.strftime("%d %b %Y")
-
-
-@register.filter
-def display_datetime_time(datetime):
-    return datetime.strftime("%H:%M")
-
-
-@register.filter
-def display_friendly_version_type(string):
-    if string == "transform":
-        return "Submission"
-    elif string == "tna-enriched":
-        return "Enrichment"
+def display_datetime(dt):
+    if dt is not None:
+        return dt.strftime("%d %b %Y %H:%M")
     else:
-        return ""
+        return None

--- a/judgments/templatetags/document_utils.py
+++ b/judgments/templatetags/document_utils.py
@@ -18,3 +18,13 @@ def display_datetime_date(datetime):
 @register.filter
 def display_datetime_time(datetime):
     return datetime.strftime("%H:%M")
+
+
+@register.filter
+def display_friendly_version_type(string):
+    if string == "transform":
+        return "Submission"
+    elif string == "tna-enriched":
+        return "Enrichment"
+    else:
+        return ""

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import Mock
 
 import factory
+from caselawclient.client_helpers import VersionAnnotation, VersionType
 from caselawclient.models.judgments import Judgment
 from caselawclient.responses.search_result import SearchResult, SearchResultMetadata
 from django.contrib.auth import get_user_model
@@ -65,9 +66,11 @@ class JudgmentFactory:
 
         judgment = judgment_mock()
         version = judgment.copy()
+        annotation = VersionAnnotation(VersionType.SUBMISSION)
+        annotation.set_calling_function("factory build")
         version.version_number = 1
         version.version_created_datetime = datetime.datetime(2023, 9, 26, 12)
-        version.annotation = "edited by save_judgment_xml"
+        version.annotation = annotation.as_json
         uri = judgment.uri
         _id = uri.split("/")[-1]
         version.uri.return_value = f"{uri}/_xml_versions/1-{_id}.xml"

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -67,6 +67,7 @@ class JudgmentFactory:
         version = judgment.copy()
         version.version_number = 1
         version.get_latest_manifestation_datetime = datetime.datetime(2023, 9, 26, 12)
+        version.get_latest_manifestation_type = "transform"
         uri = judgment.uri
         _id = uri.split("/")[-1]
         version.uri.return_value = f"{uri}/_xml_versions/1-{_id}.xml"

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -66,8 +66,8 @@ class JudgmentFactory:
         judgment = judgment_mock()
         version = judgment.copy()
         version.version_number = 1
-        version.get_latest_manifestation_datetime = datetime.datetime(2023, 9, 26, 12)
-        version.get_latest_manifestation_type = "transform"
+        version.version_created_datetime = datetime.datetime(2023, 9, 26, 12)
+        version.annotation = "edited by save_judgment_xml"
         uri = judgment.uri
         _id = uri.split("/")[-1]
         version.uri.return_value = f"{uri}/_xml_versions/1-{_id}.xml"

--- a/judgments/tests/test_document_history.py
+++ b/judgments/tests/test_document_history.py
@@ -40,3 +40,4 @@ class TestDocumentHistory(TestCase):
         assert "Version 1" in decoded_response
         assert dt.strftime("%d %b %Y") in decoded_response
         assert dt.strftime("%H:%M") in decoded_response
+        assert "Submission" in decoded_response

--- a/judgments/tests/test_document_history.py
+++ b/judgments/tests/test_document_history.py
@@ -35,9 +35,9 @@ class TestDocumentHistory(TestCase):
         assert response.status_code == 200
 
         decoded_response = response.content.decode("utf-8")
-        dt = document.versions_as_documents[0].get_latest_manifestation_datetime
-
+        dt = document.versions_as_documents[0].version_created_datetime
+        annotation = document.versions_as_documents[0].annotation
         assert "Version 1" in decoded_response
         assert dt.strftime("%d %b %Y") in decoded_response
         assert dt.strftime("%H:%M") in decoded_response
-        assert "Submission" in decoded_response
+        assert annotation in decoded_response

--- a/judgments/tests/test_document_history.py
+++ b/judgments/tests/test_document_history.py
@@ -36,8 +36,7 @@ class TestDocumentHistory(TestCase):
 
         decoded_response = response.content.decode("utf-8")
         dt = document.versions_as_documents[0].version_created_datetime
-        annotation = document.versions_as_documents[0].annotation
         assert "Version 1" in decoded_response
         assert dt.strftime("%d %b %Y") in decoded_response
         assert dt.strftime("%H:%M") in decoded_response
-        assert annotation in decoded_response
+        assert "Submitted" in decoded_response

--- a/judgments/tests/test_templatetags.py
+++ b/judgments/tests/test_templatetags.py
@@ -1,9 +1,13 @@
+import json
+
 from caselawclient.models.documents import (
     DOCUMENT_STATUS_HOLD,
     DOCUMENT_STATUS_IN_PROGRESS,
     DOCUMENT_STATUS_PUBLISHED,
 )
+from django.test import TestCase
 
+from judgments.templatetags.document_utils import display_annotation_type
 from judgments.templatetags.status_tag_css import status_tag_colour
 
 
@@ -19,3 +23,33 @@ class TestStatusTagColour:
 
     def test_colour_undefined(self):
         assert status_tag_colour("undefined") == "grey"
+
+
+class TestDisplayAnnotationType(TestCase):
+    def test_allows_empty_annotation(self):
+        assert display_annotation_type(None) is None
+
+    def test_displays_string_annotation(self):
+        annotation = "This is an annotation"
+        assert display_annotation_type(annotation) == annotation
+
+    def test_displays_submission_type(self):
+        annotation = json.dumps({"type": "submission"})
+        assert display_annotation_type(annotation) == "Submitted"
+
+    def test_displays_enrichment_type(self):
+        annotation = json.dumps({"type": "enrichment"})
+        assert display_annotation_type(annotation) == "Enriched"
+
+    def test_displays_edit_type(self):
+        annotation = json.dumps({"type": "edit"})
+        assert display_annotation_type(annotation) == "Edited"
+
+    def test_displays_other_type(self):
+        version_type = "Another type"
+        annotation = json.dumps({"type": version_type})
+        assert display_annotation_type(annotation) == version_type
+
+    def test_returns_none_for_json_with_no_type(self):
+        annotation = json.dumps({})
+        assert display_annotation_type(annotation) is None

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==15.1.2
+ds-caselaw-marklogic-api-client==16.0.0
 ds-caselaw-utils~=1.0.2
 rollbar
 django-stronghold==0.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==15.1.0
+ds-caselaw-marklogic-api-client==15.1.2
 ds-caselaw-utils~=1.0.2
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION

## Changes in this PR:

Previously the document history table showed the document type (ie Judgment or Press Summary) when what we wanted to show was the type of _version_ (ie submission or enrichment). This PR fixes, that, pending a new release of the API client (with [this currently open branch merged](https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/402)

## Trello card / Rollbar error (etc)

https://trello.com/c/jyTZaNMi/1359-eui-version-history-add-column-to-table-to-indicate-type-of-version

## Screenshots of UI changes:

### Before
<img width="533" alt="Screenshot 2023-09-27 at 14 15 41" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/4cf08b8b-807f-4bf5-b1b6-217d1c1491be">

### After
<img width="533" alt="Screenshot 2023-09-27 at 14 15 11" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/0db08d6d-c88c-4ef1-abe0-78812dfdce79">

