### PR TITLE
Add a new timeline view to Labs, replacing the history page

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_document_timeline.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_document_timeline.scss
@@ -1,0 +1,62 @@
+.document-timeline {
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 0 0 32px 32px;
+  border-left: 2px solid $color__dark-grey;
+
+  &__item {
+    display: flex;
+    gap: 24px;
+    margin-top: 24px;
+
+    &__icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      margin-left: -52px;
+      flex-shrink: 0;
+      overflow: hidden;
+      box-shadow: 0 0 0 6px #fff;
+      svg {
+        width: 20px;
+        height: 20px;
+
+        &.small {
+          width: 10px;
+          height: 10px;
+        }
+      }
+
+      background-color: $color__light-grey;
+      color: $color__dark-grey;
+    }
+
+    &__description {
+      display: flex;
+      padding-top: 6px;
+      gap: 8px;
+
+      img {
+        flex-shrink: 0;
+      }
+
+      a {
+        font-weight: bold;
+      }
+    }
+
+    &__comment {
+      margin-top: 12px;
+      border: 1px solid $color__light-grey;
+      box-shadow: 0 4px 4px 0 $color__light-grey;
+      border-radius: 6px;
+      padding: 16px;
+      font-size: 1rem;
+    }
+  }
+}

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -49,3 +49,4 @@
 @import "includes/judgment_view_controls";
 @import "includes/note";
 @import "includes/document_version_history";
+@import "includes/document_timeline";

--- a/ds_caselaw_editor_ui/static/js/src/app.js
+++ b/ds_caselaw_editor_ui/static/js/src/app.js
@@ -62,6 +62,10 @@ $("#judgment-toolbar__more-button").on("click", function () {
   $("#judgment-toolbar__more-button").toggleClass("toggled");
 });
 
+$(".document-timeline__debug-toggle").on("click", function () {
+  $("#debug-v" + $(this).data("target-version")).toggle();
+});
+
 $(".judgments-list__judgment-assign-form").on("submit", function (event) {
   event.preventDefault();
   const form = $(this);

--- a/ds_caselaw_editor_ui/templates/includes/timeline/submission_structured_data.html
+++ b/ds_caselaw_editor_ui/templates/includes/timeline/submission_structured_data.html
@@ -1,0 +1,16 @@
+<table>
+  {% if structured_annotation.payload.tdr_reference %}
+    <tr>
+      <th scope"row">TDR Reference</th>
+      <td>{{ structured_annotation.payload.tdr_reference }}</td>
+    </tr>
+  {% endif %}
+  {% if structured_annotation.payload.submitter %}
+    <tr>
+      <th scope"row">Submitted by</th>
+      <td>
+        {{ structured_annotation.payload.submitter.name }} (<a href="mailto:{{ structured_annotation.payload.submitter.email }}">{{ structured_annotation.payload.submitter.email }}</a>)
+      </td>
+    </tr>
+  {% endif %}
+</table>

--- a/ds_caselaw_editor_ui/templates/includes/timeline/timeline_item.html
+++ b/ds_caselaw_editor_ui/templates/includes/timeline/timeline_item.html
@@ -1,0 +1,71 @@
+{% load document_utils user_permissions %}
+{% with annotation=version.annotation structured_annotation=version.annotation|unpack_structured_annotation %}
+  <li class="document-timeline__item">
+    <span class="document-timeline__item__icon">
+      {% if not annotation or not structured_annotation %}
+        <svg class="small"
+             xmlns="http://www.w3.org/2000/svg"
+             height="1em"
+             viewBox="0 0 512 512">
+          <!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      {% elif structured_annotation.type == "submission" %}
+        <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
+          <!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+          <path d="M121 32C91.6 32 66 52 58.9 80.5L1.9 308.4C.6 313.5 0 318.7 0 323.9V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V323.9c0-5.2-.6-10.4-1.9-15.5l-57-227.9C446 52 420.4 32 391 32H121zm0 64H391l48 192H387.8c-12.1 0-23.2 6.8-28.6 17.7l-14.3 28.6c-5.4 10.8-16.5 17.7-28.6 17.7H195.8c-12.1 0-23.2-6.8-28.6-17.7l-14.3-28.6c-5.4-10.8-16.5-17.7-28.6-17.7H73L121 96z" />
+        </svg>
+      {% else %}
+        <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 320 512">
+          <!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+          <path d="M80 160c0-35.3 28.7-64 64-64h32c35.3 0 64 28.7 64 64v3.6c0 21.8-11.1 42.1-29.4 53.8l-42.2 27.1c-25.2 16.2-40.4 44.1-40.4 74V320c0 17.7 14.3 32 32 32s32-14.3 32-32v-1.4c0-8.2 4.2-15.8 11-20.2l42.2-27.1c36.6-23.6 58.8-64.1 58.8-107.7V160c0-70.7-57.3-128-128-128H144C73.3 32 16 89.3 16 160c0 17.7 14.3 32 32 32s32-14.3 32-32zm80 320a40 40 0 1 0 0-80 40 40 0 1 0 0 80z" />
+        </svg>
+      {% endif %}
+    </span>
+    <div>
+      <div class="document-timeline__item__description">
+      <span><a href="{% url 'full-text-html' document_uri %}?version_uri={{ version.uri }}">Version {{ version.version_number }}</a>
+      {% if structured_annotation.type == "submission" %}
+        submitted
+      {% elif structured_annotation.type == "enrichment" %}
+        enriched
+      {% elif structured_annotation.type == "edit" %}
+        edited
+      {% endif %}
+      <span class="muted">on</span> <time datetime="{{ version.version_created_datetime|date:"c" }}">{{ version.version_created_datetime|display_datetime }}</time></span>
+    </div>
+    {% if structured_annotation %}
+      <div class="document-timeline__item__comment">
+        {% if structured_annotation.message %}<p>{{ structured_annotation.message }}</p>{% endif %}
+        {% if structured_annotation.type == "submission" %}
+          {% include "includes/timeline/submission_structured_data.html" %}
+        {% endif %}
+        {% if user|is_developer %}
+          <p>
+            <small>
+              {% if structured_annotation.calling_agent %}
+                {{ structured_annotation.calling_agent }}
+              {% else %}
+                Unknown agent
+              {% endif %}
+            • <a href="#"
+    class="document-timeline__debug-toggle"
+    data-target-version="{{ version.version_number }}">Debug</a></small>
+          </p>
+          <div id="debug-v{{ version.version_number }}" hidden>
+            <pre class="muted">{{ annotation|render_structured_annotation }}</pre>
+          </div>
+        {% endif %}
+      </div>
+    {% elif annotation %}
+      <div class="document-timeline__item__comment">
+        <p>
+          <small class="muted">Legacy annotation:</small>
+          <br>
+          {{ annotation }}
+        </p>
+      </div>
+    {% endif %}
+  </div>
+</li>
+{% endwith %}

--- a/ds_caselaw_editor_ui/templates/judgment/history.html
+++ b/ds_caselaw_editor_ui/templates/judgment/history.html
@@ -1,9 +1,17 @@
 {% extends "layouts/judgment_with_sidebar.html" %}
-{% load i18n document_utils %}
+{% load i18n document_utils waffle_tags %}
 {% block judgment_header %}
   {% include "includes/judgment/metadata_panel_static.html" with judgment=document %}
 {% endblock judgment_header %}
 {% block judgment_content %}
+  {% flag history_timeline %}
+  <h2>Document history</h2>
+  <ol class="document-timeline">
+    {% for version in document.versions_as_documents %}
+      {% include "includes/timeline/timeline_item.html" %}
+    {% endfor %}
+  </ol>
+{% else %}
   <div class="document-version-history">
     <h2>Document version history</h2>
     <table class="document-version-history__table table">
@@ -35,4 +43,5 @@
       </tbody>
     </table>
   </div>
+{% endflag %}
 {% endblock judgment_content %}

--- a/judgments/templatetags/document_utils.py
+++ b/judgments/templatetags/document_utils.py
@@ -25,6 +25,19 @@ VERSION_TYPE_LABELS = {
 
 
 @register.filter
+def unpack_structured_annotation(annotation):
+    try:
+        return json.loads(annotation)
+    except (TypeError, json.JSONDecodeError):
+        return None
+
+
+@register.filter
+def render_structured_annotation(annotation):
+    return json.dumps(unpack_structured_annotation(annotation), indent=2)
+
+
+@register.filter
 def display_annotation_type(annotation):
     try:
         annotation_data = json.loads(annotation)

--- a/judgments/templatetags/user_permissions.py
+++ b/judgments/templatetags/user_permissions.py
@@ -1,6 +1,6 @@
 from django import template
 
-from judgments.utils.view_helpers import user_is_superuser_or_editor
+from judgments.utils.view_helpers import user_is_developer, user_is_superuser_or_editor
 
 register = template.Library()
 
@@ -8,3 +8,8 @@ register = template.Library()
 @register.filter(name="is_superuser_or_editor")
 def is_superuser_or_editor(user):
     return user_is_superuser_or_editor(user)
+
+
+@register.filter(name="is_developer")
+def is_developer(user):
+    return user_is_developer(user)

--- a/judgments/tests/test_templatetags.py
+++ b/judgments/tests/test_templatetags.py
@@ -7,7 +7,10 @@ from caselawclient.models.documents import (
 )
 from django.test import TestCase
 
-from judgments.templatetags.document_utils import display_annotation_type
+from judgments.templatetags.document_utils import (
+    display_annotation_type,
+    unpack_structured_annotation,
+)
 from judgments.templatetags.status_tag_css import status_tag_colour
 
 
@@ -23,6 +26,19 @@ class TestStatusTagColour:
 
     def test_colour_undefined(self):
         assert status_tag_colour("undefined") == "grey"
+
+
+class TestUnpackStructuredAnnotation(TestCase):
+    def test_allows_empty_annotation(self):
+        assert unpack_structured_annotation(None) is None
+
+    def test_displays_string_annotation(self):
+        annotation = "This is an annotation"
+        assert unpack_structured_annotation(annotation) is None
+
+    def test_displays_submission_type(self):
+        annotation = json.dumps({"type": "submission"})
+        assert unpack_structured_annotation(annotation) == {"type": "submission"}
 
 
 class TestDisplayAnnotationType(TestCase):

--- a/judgments/tests/test_view_helpers.py
+++ b/judgments/tests/test_view_helpers.py
@@ -9,6 +9,7 @@ from factories import JudgmentFactory
 
 from judgments.utils.view_helpers import (
     get_document_by_uri_or_404,
+    user_is_developer,
     user_is_superuser_or_editor,
 )
 
@@ -39,9 +40,14 @@ class TestGroupCheck(TestCase):
     def setUp(self):
         editor_group = Group(name="Editors")
         editor_group.save()
+        developer_group = Group(name="Developers")
+        developer_group.save()
         self.editor_user = User.objects.get_or_create(username="ed")[0]
         self.editor_user.groups.add(editor_group)
         self.editor_user.save()
+        self.developer_user = User.objects.get_or_create(username="dev")[0]
+        self.developer_user.groups.add(developer_group)
+        self.developer_user.save()
         self.standard_user = User.objects.get_or_create(username="alice")[0]
         self.super_user = User.objects.create_superuser(username="clark")
 
@@ -49,3 +55,10 @@ class TestGroupCheck(TestCase):
         assert user_is_superuser_or_editor(self.standard_user) is False
         assert user_is_superuser_or_editor(self.super_user) is True
         assert user_is_superuser_or_editor(self.editor_user) is True
+        assert user_is_superuser_or_editor(self.developer_user) is False
+
+    def test_developer(self):
+        assert user_is_developer(self.standard_user) is False
+        assert user_is_developer(self.super_user) is False
+        assert user_is_developer(self.editor_user) is False
+        assert user_is_developer(self.developer_user) is True

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -24,6 +24,13 @@ def user_is_superuser_or_editor(user):
     return editor or superuser
 
 
+def user_is_developer(user):
+    """
+    return: True if the User is a developer
+    """
+    return user.groups.filter(name="Developers").exists()
+
+
 def get_search_parameters(
     params,
     default_page=1,

--- a/judgments/views/labs.py
+++ b/judgments/views/labs.py
@@ -9,7 +9,12 @@ class Labs(TemplateView):
     #     "title": "Embedded PDF",
     #     "description": "View PDFs directly in the browser without needing to download them.",
     # },
-    EXPERIMENTS: dict[str, dict] = {}
+    EXPERIMENTS: dict[str, dict] = {
+        "history_timeline": {
+            "title": "Document history timeline",
+            "description": "Display information about versions of a document as a timeline rather than a table",
+        },
+    }
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
This displays structured data from enriched `VersionAnnotation`s. Default view is still the existing table, this is available in Labs for testing.

## Screenshot

![localhost_3000_ewca_civ_2022_111_history](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/ef012fd0-736e-445a-8987-9148e89cbc05)
