### PR TITLE
Disable delete button where document is not deletable

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_buttons.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_buttons.scss
@@ -1,3 +1,11 @@
+.button {
+  &-small {
+    padding: 0.4rem 0.5rem !important;
+    margin-top: 0.5em !important;
+    font-size: 0.8rem !important;
+  }
+}
+
 .button-cta {
   @include call-to-action-button;
   border: 2px solid $color__cta-background;

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
@@ -54,8 +54,9 @@
         <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />
         <input type="submit"
                name="assign"
-               class="judgment-toolbar__delete"
-               value="Delete document" />
+               class="button-danger button-small"
+               value="Delete document"
+               {% if not document.safe_to_delete %}disabled{% endif %} />
       </form>
     </div>
   {% endif %}


### PR DESCRIPTION
## Changes in this PR:

The delete button is now disabled for documents which don't report themselves as being deletable (currently documents which are published). The CSS for this button didn't make this state apparent, so this now makes the button match other `danger` styling and introduces a new `button-small` class which trims down the padding etc.

## Screenshots of UI changes:

### Before

![localhost_3000_ukut_aac_2023_205 (1)](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/965b9b76-c2c6-47ea-9ec0-461098851d8d)

### After

![localhost_3000_ukut_aac_2023_205](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/63d029d9-5070-4899-9729-4373bdee2d5e)