### PR TITLE
Further desaturate disabled danger button

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_buttons.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_buttons.scss
@@ -6,21 +6,27 @@
   }
 }
 
+@mixin button-disabled {
+  color: $color__dark-grey;
+  background-color: transparent;
+  border-color: $color__grey;
+  &:focus,
+  &:hover {
+    outline: none;
+    background-color: transparent;
+    color: $color__dark-grey;
+    text-decoration: none;
+    cursor: not-allowed;
+  }
+}
+
 .button-cta {
   @include call-to-action-button;
   border: 2px solid $color__cta-background;
 
   &:disabled,
   &[aria-disabled="true"] {
-    background-color: $color__dark-grey;
-    &:focus,
-    &:hover {
-      outline: none;
-      background-color: $color__dark-grey;
-      color: $color__white;
-      text-decoration: none;
-      cursor: not-allowed;
-    }
+    @include button-disabled;
   }
 }
 
@@ -41,17 +47,7 @@
 
   &:disabled,
   &[aria-disabled="true"] {
-    color: $color__dark-grey;
-    background-color: transparent;
-    border-color: $color__grey;
-    &:focus,
-    &:hover {
-      outline: none;
-      background-color: transparent;
-      color: $color__dark-grey;
-      text-decoration: none;
-      cursor: not-allowed;
-    }
+    @include button-disabled;
   }
 }
 
@@ -75,17 +71,6 @@
 
   &:disabled,
   &[aria-disabled="true"] {
-    $color__desaturated-red: desaturate($color__red, 60%);
-    color: $color__desaturated-red;
-    background-color: $color__white;
-    border-color: lighten($color__desaturated-red, 30%);
-    &:focus,
-    &:hover {
-      outline: none;
-      background-color: $color__white;
-      color: $color__desaturated-red;
-      text-decoration: none;
-      cursor: not-allowed;
-    }
+    @include button-disabled;
   }
 }


### PR DESCRIPTION
## Changes in this PR:

Unify the 'disabled' states of all button types, so it's obvious that they're not for clicking.

## Screenshots of UI changes:

### Before

![localhost_3000_ukut_tcc_2023_61 (1)](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/0ddc1d53-09a6-4ae8-b60b-0b4fb67d59ae)


### After
![localhost_3000_ewhc_admin_2023_1249_](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/2b81c2e6-5cfd-4c9a-8c33-abb31881ccce)

## Future work

We should migrate all the button styles to the shared frontend and tweak them so we're not having to use `!important`.
