### PR TITLE
Add notification about cookie setting to labs page.

### DIFF
--- a/ds_caselaw_editor_ui/templates/pages/labs.html
+++ b/ds_caselaw_editor_ui/templates/pages/labs.html
@@ -4,6 +4,10 @@
   <div class="standard-text-template">
     <h1>Labs</h1>
     <p>Labs let you try out new features. We're always open to your feedback on them - good or bad!</p>
+    <p>
+      Toggling these features will set a session cookie starting with "dwft_" with a value of True
+      or False to let us know whether you want a particular lab feature or not.
+    </p>
     <h2>Current experiments</h2>
     {% for experiment in experiments %}
       <h3>{{ experiment.title }}</h3>


### PR DESCRIPTION
It feels inappropriate to add this to the public cookie page.

It also feels like a lot of work that would be difficult to test (cookies don't work properly in staging) to have this respect the global setting, so hopefully this is enough to fulfil regulatory requirements with a minimum of effort.