### PR TITLE
Revert case changes to titles in listings

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgments_list.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgments_list.scss
@@ -150,7 +150,6 @@
   }
 
   &__judgment-details-name {
-    text-transform: uppercase;
     font-size: 19px;
   }
 }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Revert case changes to titles in listings
## Trello card / Rollbar error (etc)
https://trello.com/c/6SUqtJGI/1444-eui-design-review-of-current-site
## Screenshots of UI changes:

### Before
![after-css-capitals-judgment-url-list-name](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/fa6d960a-3ffd-4d45-9f75-26eee4337e09)

### After
![before-css-capitals-judgment-url-list-name](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/75584408/0c346d2a-b72c-4830-b257-bf522be759cb)


- [ ] Requires env variable(s) to be updated
