### PR TITLE
Remove feature flag from stats link

### DIFF
--- a/ds_caselaw_editor_ui/templates/layouts/base.html
+++ b/ds_caselaw_editor_ui/templates/layouts/base.html
@@ -54,11 +54,9 @@
                 <a href="{% url 'admin:index' %}">Admin</a>
               </li>
             {% endif %}
-            {% flag "stats" %}
-              <li>
-                <a href="{% url 'stats' %}">Stats</a>
-              </li>
-            {% endflag %}
+            <li>
+              <a href="{% url 'stats' %}">Stats</a>
+            </li>
             <li>
               <a href="{% url 'labs' %}">Labs</a>
             </li>


### PR DESCRIPTION
Stats are now in general release, so remove the feature flag hiding the link.