### PR TITLE
Tidy up margins on page notification banner

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
@@ -3,11 +3,6 @@
   padding: 0.5rem 1rem;
 }
 
-.page-notification__container {
-  @include container;
-  margin-top: calc(1.5 * $spacer__unit);
-}
-
 .page-notification {
   &--success {
     @include notification;

--- a/ds_caselaw_editor_ui/templates/includes/notifications.html
+++ b/ds_caselaw_editor_ui/templates/includes/notifications.html
@@ -1,8 +1,8 @@
 {% if messages %}
   {% for message in messages %}
     {% spaceless %}
-      <div class="page-notification__container">
-        <div class="page-notification--{% if message.tags %}{{ message.tags }}{% else %}success{% endif %}">{{ message }}</div>
+      <div class="page-notification--{% if message.tags %}{{ message.tags }}{% else %}success{% endif %}">
+        <div class="container">{{ message }}</div>
       </div>
     {% endspaceless %}
   {% endfor %}


### PR DESCRIPTION
## Changes in this PR

Some adjustments to margins/containers for the page-wide notification banner so it flows better as part of the page.

## Screenshots of UI changes:

### Before

![localhost_3000_](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/c4501ed0-a6fb-4aa8-81be-6c7e8c271205)


### After

![localhost_3000_ (1)](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/c5be0c27-25e5-4118-bc20-54340225bc57)
