### PR TITLE
Signed out page now matches format of sign in page

### DIFF
--- a/ds_caselaw_editor_ui/templates/account/base.html
+++ b/ds_caselaw_editor_ui/templates/account/base.html
@@ -1,1 +1,0 @@
-{% extends "layouts/base.html" %}

--- a/ds_caselaw_editor_ui/templates/account/login.html
+++ b/ds_caselaw_editor_ui/templates/account/login.html
@@ -1,5 +1,8 @@
-{% extends "account/base.html" %}
-{% load i18n widget_tweaks %}
+{% extends "layouts/base.html" %}
+{% load widget_tweaks %}
+{% block breadcrumbs %}
+  <li>Sign in</li>
+{% endblock breadcrumbs %}
 {% block content %}
   <div class="login-background">
     <div class="login-container">

--- a/ds_caselaw_editor_ui/templates/registration/logged_out.html
+++ b/ds_caselaw_editor_ui/templates/registration/logged_out.html
@@ -1,0 +1,15 @@
+{% extends "layouts/base.html" %}
+{% block breadcrumbs %}
+  <li>Signed out</li>
+{% endblock breadcrumbs %}
+{% block content %}
+  <div class="login-background">
+    <div class="login-container">
+      <h1>Signed out</h1>
+      <p>You have been signed out of the Find Case Law service.</p>
+      <p>
+        <a href="{% url 'home' %}">Sign in again</a>
+      </p>
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
A couple of cleanups to the sign in page (like not loading/extending unnecessarily), but most importantly the "signed out" page now fits the style.

![localhost_3000_admin_logout_](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/619082/85d5cd77-2f55-4427-a4c2-1b141b055d54)
