### PR TITLE
Fix Cypress test for new login form

### DIFF
--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -8,7 +8,7 @@ describe("Login Test", () => {
     cy.get("#id_password").type(Cypress.env("PASSWORD"));
 
     // Click the login button
-    cy.get('button.primaryAction:contains("Sign In")').click();
+    cy.get('button.button-cta:contains("Sign in")').click();
 
     // Verify successful login
     cy.url().should("not.include", "/login");


### PR DESCRIPTION
We changed some of the classes used in the login form in https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/1259, which broke Cypress. Because this only runs first thing in a morning and on staging (ie after a branch has been merged) we didn't catch it as part of the PR's tests.

This PR fixes the broken integration test.