### PR TITLE
Fix TDR spacing issue in metadata panel

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_view_controls.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_view_controls.scss
@@ -1,5 +1,5 @@
 .judgment-view-controls {
-  @media (min-width: 1400px) {
+  @media (min-width: 1500px) {
     width: 67.5%;
     margin: 0 auto;
   }

--- a/ds_caselaw_editor_ui/sass/includes/_metadata.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_metadata.scss
@@ -4,7 +4,7 @@
   border-color: #ffffff;
   padding: $spacer__unit;
 
-  @media (min-width: 1400px) {
+  @media (min-width: 1500px) {
     width: 65%;
     border-width: 1rem 20rem 1rem 20rem;
     position: relative;

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -71,7 +71,7 @@ msgstr "Status"
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
 msgid "document.type"
-msgstr "Doc type"
+msgstr "Type"
 
 #: ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
 #: ds_caselaw_editor_ui/templates/includes/judgments_list_item.html


### PR DESCRIPTION
## Changes in this PR:

This was a tricky one to track down but not to fix - when the TDR has four characters in the last position, and one of them is em-width (an 'm' or 'w'), at a very specific screensize (~1400px) it pops underneath the status badge and is illegible. 
([Here's an example](https://editor.caselaw.nationalarchives.gov.uk/ukut/lc/2023/271) in production that will replicate). The fix is to tweak the breakpoint at which the width of that metadata panel becomes constrained with a max-width, to give it a little more room. This is an exception to our standard breakpoints, but i think a good one to make - the current extra-large breakpoint is 1200px which would exacerbate the problem if we were using it here.

I've also changed the label for the document type from 'Doc type' to 'Type', as discussed on slack - we don't specify 'document' in any other labels here, and it's already unambiguous.

## Trello card / Rollbar error (etc)

https://trello.com/c/j2eb1fCH/1470-eui-tdr-spacing-issue

## Screenshots of UI changes:

### Before
<img width="220" alt="Screenshot 2023-11-15 at 11 24 00" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/e678feef-124c-4004-84b0-56ec83dd2254">

### After
<img width="220" alt="Screenshot 2023-11-15 at 11 29 02" src="https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/52f72527-78d5-45b0-9093-567711a0e695">


