### PR TITLE
Add template code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
-include = judgments/**/*.py, judgments/*.py, ds_caselaw_editor_ui/**/*.py, ds_caselaw_editor_ui/*.py
+omit = */migrations/*, config/*
+plugins = django_coverage_plugin
 
 [report]
 omit =

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -3,6 +3,7 @@ With these settings, tests run faster.
 """
 
 from .base import *  # noqa
+from .base import TEMPLATES
 
 # GENERAL
 # ------------------------------------------------------------------------------
@@ -23,3 +24,5 @@ EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
 # Your stuff...
 # ------------------------------------------------------------------------------
+
+TEMPLATES[0]["OPTIONS"]["debug"] = True  # type: ignore[index]


### PR DESCRIPTION
We have a fair amount of template logic going on. Switching on `django_coverage_plugin` (which was installed but never used) lets coverage see how much of our templates are being exercised by testing, so we can identify holes.

**Coverage changes are an expected consequence of this PR. There should be no functional changes.**