### PR TITLE
Refactor and extend test factories for documents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: "3.9"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: |
             requirements/base.txt

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ building of the project's containers, one for each each service:
 ### `django`
 
 Our custom container responsible for running the application. Built from the
-official [python 3.9](https://hub.docker.com/_/python/) base image
+official [python 3.12](https://hub.docker.com/_/python/) base image
 
 ### `postgres`
 

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Any, TypeAlias
 from unittest.mock import Mock
 
 import factory
@@ -6,10 +7,6 @@ from caselawclient.client_helpers import VersionAnnotation, VersionType
 from caselawclient.models.judgments import Judgment
 from caselawclient.responses.search_result import SearchResult, SearchResultMetadata
 from django.contrib.auth import get_user_model
-from typing_extensions import (
-    Any,
-    TypeAlias,
-)
 
 User = get_user_model()
 

--- a/judgments/views/document_full_text.py
+++ b/judgments/views/document_full_text.py
@@ -35,7 +35,9 @@ class DocumentReviewPDFView(DocumentView):
         context = super().get_context_data(**kwargs)
 
         if not context["document"].pdf_url:
-            msg = f"Document \"{context['document'].name}\" does not have a PDF."
+            msg = 'Document "{document_name}" does not have a PDF.'.format(
+                document_name=context["document"].name,
+            )
             raise Http404(
                 msg,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = ">=3.12"
+
 [tool.djlint]
 ignore="H021,H023,H030,H031"
 profile="django"
@@ -5,8 +8,7 @@ indent=2
 custom_blocks="flag"
 
 [tool.ruff]
-ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012"] # long lines, fstrings in logs, magic values, consider not concat, mutable classbits
-target-version = "py39"
+ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # long lines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
 extend-select = ["W", "B", "Q", "C90", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "PTH",
                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ force_grid_wrap = 0
 use_parentheses = true
 
 [mypy]
-python_version = 3.9
 check_untyped_defs = True
 ignore_missing_imports = True
 warn_unused_ignores = True


### PR DESCRIPTION
**This should be merged after https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/1290**

To support robust testing of version history behaviour, refactor `JudgmentFactory` into a more generic `DocumentFactory`, and a new `DocumentVersionFactory` which can handle version-specific functionality.