### PR TITLE
Remove `get_judgment_root` from utils

### DIFF
--- a/judgments/tests/utils/test_utils.py
+++ b/judgments/tests/utils/test_utils.py
@@ -14,7 +14,6 @@ from judgments.utils import (
     editors_dict,
     ensure_local_referer_url,
     extract_version,
-    get_judgment_root,
     render_versions,
     update_document_uri,
 )
@@ -88,25 +87,6 @@ class TestPaginator:
 
 
 class TestUtils(TestCase):
-    def test_get_judgment_root_error(self):
-        xml = "<error>parser.log contents</error>"
-        assert get_judgment_root(xml) == "error"
-
-    def test_get_judgment_root_akomantoso(self):
-        xml = (
-            "<akomaNtoso xmlns:uk='https://caselaw.nationalarchives.gov.uk/akn' "
-            "xmlns='http://docs.oasis-open.org/legaldocml/ns/akn/3.0'>judgment</akomaNtoso>"
-        )
-        assert (
-            get_judgment_root(xml)
-            == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
-        )
-
-    def test_get_judgment_root_malformed_xml(self):
-        # Should theoretically never happen but test anyway
-        xml = "<error>malformed xml"
-        assert get_judgment_root(xml) == "error"
-
     @patch("judgments.utils.api_client")
     @patch("boto3.session.Session.client")
     def test_update_document_uri_success(self, fake_boto3_client, fake_api_client):

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-import xml.etree.ElementTree as ET
 from datetime import datetime
 from operator import itemgetter
 from typing import TYPE_CHECKING
@@ -71,14 +70,6 @@ def format_date(date):
 
     time = datetime.strptime(date, "%Y-%m-%d")
     return time.strftime("%d-%m-%Y")
-
-
-def get_judgment_root(judgment_xml) -> str:
-    try:
-        parsed_xml = ET.XML(bytes(judgment_xml, encoding="utf-8"))
-    except ET.ParseError:
-        return "error"
-    return parsed_xml.tag
 
 
 def update_document_uri(old_uri, new_citation):


### PR DESCRIPTION
This is no longer used anywhere within the EUI, all related functionality has been abstracted away into the API document class.