### PR TITLE
Revert Django v5 and v5.0.1 upgrades

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ whitenoise==6.6.0  # https://github.com/evansd/whitenoise
 
 # Django
 # ------------------------------------------------------------------------------
-django==5.0.1  # pyup: < 4.0  # https://www.djangoproject.com/
+django==3.2.23  # pyup: < 4.0  # https://www.djangoproject.com/
 django-environ>=0.11.0  # https://github.com/joke2k/django-environ
 django-model-utils==4.3.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.59.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
Revert "Update dependency django to v5.0.1"

This reverts commit 7270bf6beffdc08192d69cb4553124040e653c6c.

Revert "Update dependency django to v5"

This reverts commit fc8592945b950619722f11f55f6e11eb0e7adb6a.

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
