### PR TITLE
bump api client and utils and use to set GRC jurisdictions

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_form.html
@@ -22,7 +22,7 @@
             <label for="court" class="metadata-component__main-labels">{% translate "judgment.court" %}</label>
             <input type="text"
                    class="metadata-component__court-input"
-                   value="{{ judgment.court }}"
+                   value="{{ judgment.court_and_jurisdiction_identifier_string }}"
                    name="court"
                    id="court"
                    list="court-ids" />

--- a/judgments/tests/test_document_edit.py
+++ b/judgments/tests/test_document_edit.py
@@ -49,7 +49,7 @@ class TestDocumentEdit(TestCase):
             "/edittest/4321/123",
             "[4321] TEST 123",
         )
-        api_client.set_document_court.assert_called_with(
+        api_client.set_document_court_and_jurisdiction.assert_called_with(
             "/edittest/4321/123",
             "Court of Testing",
         )

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -94,7 +94,7 @@ class DocumentView(TemplateView):
         context["judgment"] = document
 
         context["page_title"] = document.name
-        context["courts"] = caselawutils.courts.get_all()
+        context["courts"] = caselawutils.courts.get_all(with_jurisdictions=True)
 
         context["editors"] = editors_dict()
 

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -40,7 +40,7 @@ class EditJudgmentView(View):
 
             # Set court
             new_court = request.POST["court"]
-            api_client.set_document_court(judgment_uri, new_court)
+            api_client.set_document_court_and_jurisdiction(judgment_uri, new_court)
 
             # Date
             new_date = request.POST["judgment_date"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,8 +16,8 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=5.1.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==21.0.0
-ds-caselaw-utils~=1.3.3
+ds-caselaw-marklogic-api-client==22.0.0
+ds-caselaw-utils~=1.4.0
 rollbar
 django-stronghold==0.4.0
 boto3~=1.34.2


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:


Allow editors to autocomplete GRC jurisdictions in the court dropdown, and to set jurisdiction when editing

## Trello card / Rollbar error (etc)

https://trello.com/c/JDoWjYsa/1602-medium-grcfollow-logic-for-the-courts-and-expose-grc-subdivisions-on-pui-prototype-first

## Screenshots of UI changes:
![Screenshot 2024-02-01 at 16 37 06](https://github.com/nationalarchives/ds-caselaw-editor-ui/assets/4279/fd75f48f-ab20-440f-afbe-72b20b1edbff)
