### PR TITLE
Do not enrich if enriched recently

### DIFF
--- a/judgments/tests/test_document_enrich.py
+++ b/judgments/tests/test_document_enrich.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -13,6 +14,7 @@ class TestDocumentEnrich(TestCase):
     @patch("judgments.views.enrich.get_document_by_uri_or_404")
     def test_document_enrich_flow(self, mock_document):
         document = DocumentFactory.build(uri="test/4321/123", name="Enrichment Test")
+        document.enrichment_datetime = None
         mock_document.return_value = document
 
         self.client.force_login(self.user)
@@ -30,3 +32,51 @@ class TestDocumentEnrich(TestCase):
             kwargs={"document_uri": document.uri},
         )
         mock_document.return_value.enrich.assert_called_once()
+
+    @patch("judgments.views.enrich.get_document_by_uri_or_404")
+    def test_stop_if_enriched_recently(self, mock_document):
+        document = DocumentFactory.build(uri="test/4321/123", name="Enrichment Test")
+        document.enrichment_datetime = datetime.datetime.now(
+            tz=datetime.UTC,
+        ) - datetime.timedelta(minutes=1)
+        mock_document.return_value = document
+
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse("enrich"),
+            data={
+                "document_uri": document.uri,
+            },
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == reverse(
+            "full-text-html",
+            kwargs={"document_uri": document.uri},
+        )
+        mock_document.return_value.enrich.assert_not_called()
+
+    @patch("judgments.views.enrich.get_document_by_uri_or_404")
+    def test_enrich_if_not_enriched_recently(self, mock_document):
+        document = DocumentFactory.build(uri="test/4321/123", name="Enrichment Test")
+        document.enrichment_datetime = datetime.datetime.now(
+            tz=datetime.UTC,
+        ) - datetime.timedelta(days=1)
+        mock_document.return_value = document
+
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse("enrich"),
+            data={
+                "document_uri": document.uri,
+            },
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == reverse(
+            "full-text-html",
+            kwargs={"document_uri": document.uri},
+        )
+        mock_document.return_value.enrich.assert_called()

--- a/judgments/views/enrich.py
+++ b/judgments/views/enrich.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -8,12 +10,19 @@ from judgments.utils.view_helpers import get_document_by_uri_or_404
 def enrich(request):
     document_uri = request.POST.get("document_uri", None)
     document = get_document_by_uri_or_404(document_uri)
-    document.enrich()
-
-    messages.success(
-        request,
-        f"Enrichment requested for {document.name}.",
-    )
+    last_enrichment = document.enrichment_datetime
+    now = datetime.datetime.now(tz=datetime.UTC)
+    if last_enrichment and now - last_enrichment < datetime.timedelta(hours=2):
+        messages.error(
+            request,
+            f"Enrichment has been recently requested for {document.name}. Not resubmitted.",
+        )
+    else:
+        document.enrich()
+        messages.success(
+            request,
+            f"Enrichment requested for {document.name}.",
+        )
     return HttpResponseRedirect(
         reverse("full-text-html", kwargs={"document_uri": document.uri}),
     )


### PR DESCRIPTION
Some of the problems recently encountered might have been caused by two enrichment processess occurring simultanously. Avoid triggering enrichment f it has been enriched recently.