### PR TITLE
Update ruff config to use ruff.lint instead of ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [project]
+name = "National Archives Find Case Law: Editor UI"
 requires-python = ">=3.12"
 
 [tool.djlint]
@@ -6,8 +7,6 @@ ignore="H021,H023,H030,H031"
 profile="django"
 indent=2
 custom_blocks="flag"
-
-[tool.ruff]
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # long lines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
@@ -29,6 +28,8 @@ unfixable = ["ERA"]
 # ERA: lots of false positives, not a good autofix
 # PD, NPY, AIR: ignored, panda / numpy / airflow specific
 # FURB: not yet out of preview
+
+
 
 [tool.ruff.lint.extend-per-file-ignores]
 "config/*" = ["PGH004", # vague NOQA


### PR DESCRIPTION
Fixes errors like

pyproject.toml:1:1: RUF200 Failed to parse pyproject.toml: missing field `name` warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'isort' -> 'lint.isort'
