### PR TITLE
Always download docx

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar.html
@@ -30,7 +30,8 @@
       {% endif %}
       {% if document.docx_url %}
         <a class="judgment-toolbar__button button-secondary"
-           href="{{ document.docx_url }}">{% translate "judgment.toolbar.download_docx" %}</a>
+           href="{{ document.docx_url }}"
+           download>{% translate "judgment.toolbar.download_docx" %}</a>
       {% else %}
         <span class="judgment-toolbar__button button-secondary"
               aria-disabled="true">{% translate "judgment.toolbar.download_docx" %}</span>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar_more.html
@@ -30,7 +30,7 @@
     <ul>
       {% if document.docx_url %}
         <li>
-          <a href="{{ document.docx_url }}">{% translate "judgment.download_docx" %}</a>
+          <a href="{{ document.docx_url }}" download>{% translate "judgment.download_docx" %}</a>
         </li>
       {% endif %}
       {% if document.pdf_url %}


### PR DESCRIPTION
S3 sets mimetypes if files are uploaded in the console, unlike the ingester. This can prompt editor's PCs to instead load the documents up in an online version of Office, which fails for some reason. Force the files to be downloaded when clicking on the links by setting the `download` attribute; tested concept by adding download to other links.