### PR TITLE
Prototype reparse cronjob command

### DIFF
--- a/judgments/management/commands/reparse_next_in_reparse_queue.py
+++ b/judgments/management/commands/reparse_next_in_reparse_queue.py
@@ -25,6 +25,6 @@ class Command(BaseCommand):
 
             self.stdout.write(f"Attempting to reparse document {document.name}...")
             if document.reparse():
-                self.stdout.write("Success!")
+                self.stdout.write("Reparse request sent.")
             else:
-                self.stdout.write("Failed.")
+                self.stdout.write("Reparse not sent.")

--- a/judgments/management/commands/reparse_next_in_reparse_queue.py
+++ b/judgments/management/commands/reparse_next_in_reparse_queue.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand
+
+from judgments.utils import api_client
+from judgments.views.reports import get_rows_from_result
+
+NUMBER_TO_PARSE = 1
+
+
+class Command(BaseCommand):
+    help = "Sends the next document in the reparse queue to be reparsed"
+
+    def handle(self, *args, **options):
+        target_parser_version = api_client.get_highest_parser_version()
+
+        document_details_to_parse = get_rows_from_result(
+            api_client.get_pending_parse_for_version(
+                target_version=target_parser_version,
+            ),
+        )
+
+        for document_details in document_details_to_parse[:NUMBER_TO_PARSE]:
+            document_uri = document_details[0]
+
+            document = api_client.get_document_by_uri(document_uri.replace(".xml", ""))
+
+            self.stdout.write(f"Attempting to reparse document {document.name}...")
+            if document.reparse():
+                self.stdout.write("Success!")
+            else:
+                self.stdout.write("Failed.")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=5.2.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==22.1.0
+ds-caselaw-marklogic-api-client==23.0.1
 ds-caselaw-utils~=1.4.0
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
invoke via `python manage.py reparse_next_in_reparse_queue`

## Changes in this PR:

We add a new django management command, `reparse_next_in_reparse_queue`. It will call document.reparse() on the most-in-need-of-reparsing document.

Nothing new will happen when this PR is merged; we will need to add a cronjob to invoke this like we did for enrichment. That cronjob should only run at night. We should probably run much slower to start with (maybe 1/half hour?)

See https://github.com/dxw/dalmatian-config/blob/master/config/infrastructures/caselaw/editor.yml for what to add/change to install the crontab.

`0,30 19-23,0-7 * * *` is probably a good crontab?

https://github.com/dxw/dalmatian-config/pull/905