### PR TITLE
Remove obsolete version string from docker compose configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
   django:
     platform: linux/amd64

--- a/production.yml
+++ b/production.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 volumes:
   production_postgres_data: {}
   production_postgres_data_backups: {}


### PR DESCRIPTION
It now comes up with an error when you run the config, so let's silence that.

https://github.com/docker/compose/issues/11628

