### PR TITLE
gitignore Cypress screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,6 @@ docker/*
 /ds_caselaw_editor_ui/static/css/main.css
 /ds_caselaw_editor_ui/static/css/main.css.map
 /ds_caselaw_editor_ui/static/js/dist/app.js
+
+# Cypress end-to-end tests create screenshots
+/cypress/screenshots


### PR DESCRIPTION
Running the end-to-end tests creates a `cypress/screenshots` folder. Git should ignore it.