### PR TITLE
build(Reparse): Bump api-client to 24 to fix reparse cronjob

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=5.2.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==23.0.2
+ds-caselaw-marklogic-api-client==24.0.0
 ds-caselaw-utils~=1.5.1
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
v24 sets the last reparse time regardless of whether a reparse occured, fixing the issue of the cronjob hitting the same files again and again. 
