### PR TITLE
FCL-157 | extract judgment listing component

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgments_list.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgments_list.html
@@ -1,0 +1,5 @@
+<ul class="judgments-list__list">
+  {% for item in judgments %}
+    {% include "includes/judgments_list_item.html" %}
+  {% endfor %}
+</ul>

--- a/ds_caselaw_editor_ui/templates/includes/style_guide/judgments_list.html
+++ b/ds_caselaw_editor_ui/templates/includes/style_guide/judgments_list.html
@@ -1,0 +1,13 @@
+<h3 id="judgments-list">Judgments list</h3>
+<p>
+  This is a list of judgments that is used to show judgments on the homepage and on the search page. Judgments can be in various states - below shows:
+</p>
+<ol>
+  <li>A generic judgment</li>
+  <li>A judgment that failed to parse</li>
+  <li>A judgment assigned to an editor</li>
+  <li>A judgment on hold</li>
+</ol>
+<div class="style-guide__component-wrapper--large">
+  {% include "includes/judgments_list.html" with judgments=judgments %}
+</div>

--- a/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
+++ b/ds_caselaw_editor_ui/templates/includes/unpublished_judgments.html
@@ -12,11 +12,7 @@
     </div>
     <div class="judgments-list__table">
       {% include "includes/judgments_list_header.html" %}
-      <ul class="judgments-list__list">
-        {% for item in judgments %}
-          {% include "includes/judgments_list_item.html" %}
-        {% endfor %}
-      </ul>
+      {% include "includes/judgments_list.html" with judgments=judgments %}
       {% include "includes/pagination.html" %}
       <p class="judgments-list__more-info">
         <a href="{% url 'results' %}">{% translate "judgments.allrecent" %}</a>

--- a/ds_caselaw_editor_ui/templates/judgment/results.html
+++ b/ds_caselaw_editor_ui/templates/judgment/results.html
@@ -21,11 +21,7 @@
         </div>
         <div class="judgments-list__table">
           {% include "includes/judgments_list_header.html" %}
-          <ul class="judgments-list__list">
-            {% for item in judgments %}
-              {% include "includes/judgments_list_item.html" with item=item %}
-            {% endfor %}
-          </ul>
+          {% include "includes/judgments_list.html" with judgments=judgments %}
           {% include "includes/pagination.html" %}
           <p class="judgments-list__more-info">
             <a href="{% url 'results' %}">{% translate "judgments.allrecent" %}</a>

--- a/ds_caselaw_editor_ui/templates/pages/style_guide.html
+++ b/ds_caselaw_editor_ui/templates/pages/style_guide.html
@@ -30,8 +30,9 @@
         {% include "includes/style_guide/colours.html" %}
         <h2 id="components">Components</h2>
         {% include "includes/style_guide/buttons.html" %}
-        {% include "includes/style_guide/list_controls.html" %}
+        {% include "includes/style_guide/judgments_list.html" %}
         {% include "includes/style_guide/judgment_metadata_form.html" %}
+        {% include "includes/style_guide/list_controls.html" %}
         {% include "includes/style_guide/note.html" %}
         {% include "includes/style_guide/notification-messaging.html" %}
         {% include "includes/style_guide/search_form.html" %}

--- a/judgments/views/style_guide.py
+++ b/judgments/views/style_guide.py
@@ -10,6 +10,10 @@ class StyleGuide(TemplateView):
         context = super().get_context_data(**kwargs)
         judgment = SearchResultFactory.build()
         context["judgment"] = judgment
+        judgment_failed_to_parse = SearchResultFactory.build(failed_to_parse=True)
+        judgment_assigned = SearchResultFactory.build(metadata={"assigned_to": "An editor"})
+        judgment_on_hold = SearchResultFactory.build(metadata={"assigned_to": "An editor", "editor_hold": "true"})
+        context["judgments"] = [judgment, judgment_failed_to_parse, judgment_assigned, judgment_on_hold]
         context["menu_items"] = [
             {"label": "Colours", "href": "#colours"},
             {
@@ -18,6 +22,7 @@ class StyleGuide(TemplateView):
                 "children": [
                     {"label": "Buttons", "href": "#buttons"},
                     {"label": "Judgment metadata form", "href": "#judgment-metadata-form"},
+                    {"label": "Judgments list", "href": "#judgments-list"},
                     {"label": "List controls", "href": "#list-controls"},
                     {"label": "Note", "href": "#note"},
                     {"label": "Notification messaging", "href": "#notification-messaging"},


### PR DESCRIPTION
## Changes in this PR:

 - Extract listing component
 - Add to style guide
 - Improve factory (so I can use it for data on the styleguide)

## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

<img width="1089" alt="image" src="https://github.com/user-attachments/assets/4229b627-a702-46a7-baba-d538cc4dd557">

(Note it scrolls as the content doesn't fit on the styleguide otherwise - similar to the PUI)