### PR TITLE
Make factoryboy a global dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,7 @@ django-model-utils==4.5.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.63.6  # https://github.com/pennersr/django-allauth
 django-waffle==4.1.0  # https://github.com/django-waffle/django-waffle
 django-widget-tweaks==1.5.0  # https://github.com/jazzband/django-widget-tweaks
+factory-boy==3.3.0  # https://github.com/FactoryBoy/factory_boy
 
 requests~=2.32.3
 xmltodict~=0.13.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -20,8 +20,6 @@ pre-commit==3.7.1  # https://github.com/pre-commit/pre-commit
 
 # Django
 # ------------------------------------------------------------------------------
-factory-boy==3.3.0  # https://github.com/FactoryBoy/factory_boy
-
 django-debug-toolbar==4.4.6  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.2.3  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==3.1.0  # https://github.com/nedbat/django_coverage_plugin


### PR DESCRIPTION
For the style guide we don't want a real judgment sourced from the database, so we wind up wanting a fake Judgment. Currently factoryboy isn't installed in prod, so that breaks the deployment.