### PR TITLE
Reparse 8 documents per half-hour

### DIFF
--- a/judgments/management/commands/reparse_next_in_reparse_queue.py
+++ b/judgments/management/commands/reparse_next_in_reparse_queue.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand
 from judgments.utils import api_client
 from judgments.views.reports import get_rows_from_result
 
-NUMBER_TO_PARSE = 1
+NUMBER_TO_PARSE = 8
 MAX_DOCUMENTS_TO_TRY = 200
 
 


### PR DESCRIPTION
We want to speed up the processing of the reparsing, so increase the number we process each half-hour (should be about 200/night)