### PR TITLE
EWCR not EWCRC

### DIFF
--- a/judgments/converters.py
+++ b/judgments/converters.py
@@ -25,7 +25,7 @@ class DateConverter:
 
 
 class CourtConverter:
-    regex = "ewhc|uksc|ukpc|ewca|ewcop|ewfc|ukut|eat|ukftt|ukait|ukiptrib|ukcc|ukcrc"
+    regex = "ewhc|uksc|ukpc|ewca|ewcop|ewfc|ukut|eat|ukftt|ukait|ukiptrib|ukcc|ukcr"
 
     def to_python(self, value):
         return value


### PR DESCRIPTION


https://dxw.slack.com/archives/C04FQ3GFGUQ/p1725269335416609

> Jim's parser change for crown court (Changing EWCRC to EWCR) is going to go through at midday, is is possible to make the other changes (EUI, regex) to change the crown court code today so that the judgment can be published?

