### PR TITLE
Fcl 257 banner bad uri

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
@@ -22,6 +22,15 @@
       color: $color-dark-blue;
     }
   }
+
+  &--warning {
+    @include notification;
+    background-color: $color-yellow;
+    color: $color-almost-black;
+    a {
+      color: $color-dark-blue;
+    }
+  }
 }
 
 .inline-notification {

--- a/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
@@ -1,4 +1,16 @@
 {% load status_tag_css %}
+<form aria-label="Edit judgment"
+      method="post"
+      action="{% url 'edit-document' judgment.uri %}">
+  {% csrf_token %}
+  {% if corrected_ncn_url %}
+    <div class="page-notification--warning">
+      This document is at {{ judgment.uri }} but has an NCN of <a href="{{ corrected_ncn_url }}">{{ judgment.best_human_identifier }}</a>. Move it to {{ corrected_ncn_url }} ?
+      <input type="hidden" name="judgment_uri" value="{{ document_uri }}" />
+      <input type="submit" name="move_document" value="Move it" />
+    </div>
+  {% endif %}
+</form>
 <div class="metadata-header__block">
   <div class="metadata-component">
     <form aria-label="Edit judgment"

--- a/fabfile.py
+++ b/fabfile.py
@@ -163,6 +163,7 @@ def test(c):
             "exec",
             "django",
             "pytest",
+            "-v",
         ],
     )
 

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -31,6 +31,7 @@ class DocumentFactory:
         "name": ("name", "Judgment v Judgement"),
         "document_noun": ("document_noun", "judgment"),
         "neutral_citation": ("neutral_citation", "[2023] Test 123"),
+        "best_human_identifier": ("best_human_identifier", "[2023] Test 123"),
         "court": ("court", "Court of Testing"),
         "document_date_as_string": ("document_date_as_string", "2023-02-03"),
         "document_date_as_date": ("document_date_as_date", datetime.date(2023, 2, 3)),

--- a/judgments/views/document_full_text.py
+++ b/judgments/views/document_full_text.py
@@ -2,6 +2,7 @@ from urllib.parse import urlencode
 
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
+from ds_caselaw_utils import neutral_url
 
 from judgments.utils import extract_version
 from judgments.utils.view_helpers import DocumentView, get_document_by_uri_or_404
@@ -24,6 +25,10 @@ class DocumentReviewHTMLView(DocumentView):
             context["version"] = extract_version(version_uri)
 
         context["view"] = "judgment_text"
+
+        ncn_uri = neutral_url(context["judgment"].neutral_citation)
+        if "/" + context["judgment"].uri != ncn_uri:
+            context["corrected_ncn_url"] = ncn_uri
 
         return context
 

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -1,7 +1,6 @@
 import datetime
 
 from caselawclient.Client import MarklogicAPIError
-from caselawclient.models.judgments import Judgment
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
@@ -28,7 +27,8 @@ class EditJudgmentView(View):
         judgment_uri = request.POST["judgment_uri"]
         judgment = get_document_by_uri_or_404(judgment_uri)
         if request.POST.get("move_document", False):
-            if isinstance(judgment, Judgment):
+            if judgment.document_noun == "judgment":
+                # should be .neutral_citation
                 new_judgment_uri = update_document_uri(judgment_uri, judgment.best_human_identifier)
                 return redirect(
                     reverse("edit-document", kwargs={"document_uri": new_judgment_uri}),

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -26,6 +26,11 @@ class EditJudgmentView(View):
     def post(self, request, *args, **kwargs):
         judgment_uri = request.POST["judgment_uri"]
         judgment = get_document_by_uri_or_404(judgment_uri)
+        if request.POST.get("move_document", False):
+            new_judgment_uri = update_document_uri(judgment_uri, judgment.best_human_identifier)
+            return redirect(
+                reverse("edit-document", kwargs={"document_uri": new_judgment_uri}),
+            )
 
         return_to = request.POST.get("return_to", None)
 

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -30,11 +30,14 @@ class EditJudgmentView(View):
         if request.POST.get("move_document", False):
             if isinstance(judgment, Judgment):
                 new_judgment_uri = update_document_uri(judgment_uri, judgment.best_human_identifier)
+                return redirect(
+                    reverse("edit-document", kwargs={"document_uri": new_judgment_uri}),
+                )
             else:
                 messages.error(request, "Unable to move non-judgments at this time.")
-            return redirect(
-                reverse("edit-document", kwargs={"document_uri": new_judgment_uri}),
-            )
+                return redirect(
+                    reverse("edit-document", kwargs={"document_uri": judgment_uri}),
+                )
 
         return_to = request.POST.get("return_to", None)
 

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -1,6 +1,7 @@
 import datetime
 
 from caselawclient.Client import MarklogicAPIError
+from caselawclient.models.judgments import Judgment
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
@@ -27,7 +28,10 @@ class EditJudgmentView(View):
         judgment_uri = request.POST["judgment_uri"]
         judgment = get_document_by_uri_or_404(judgment_uri)
         if request.POST.get("move_document", False):
-            new_judgment_uri = update_document_uri(judgment_uri, judgment.best_human_identifier)
+            if isinstance(judgment, Judgment):
+                new_judgment_uri = update_document_uri(judgment_uri, judgment.best_human_identifier)
+            else:
+                messages.error(request, "Unable to move non-judgments at this time.")
             return redirect(
                 reverse("edit-document", kwargs={"document_uri": new_judgment_uri}),
             )


### PR DESCRIPTION
We had a think about how we were doing https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/1592 and changed it so the UI only existed if there was a mismatch at all.

https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136

<img width="1270" alt="image" src="https://github.com/user-attachments/assets/75050b9e-1a28-455f-ac37-909c88f9b981">
