### PR TITLE
Working logout button

### DIFF
--- a/ds_caselaw_editor_ui/templates/layouts/base.html
+++ b/ds_caselaw_editor_ui/templates/layouts/base.html
@@ -72,7 +72,10 @@
             </li>
             {% if user.is_authenticated %}
               <li>
-                <a href="{% url 'admin:logout' %}">Sign out</a>
+                <form action="{% url 'admin:logout' %}" method="post">
+                  {% csrf_token %}
+                  <button type="submit">Sign out</button>
+                </form>
               </li>
             {% endif %}
           </ol>


### PR DESCRIPTION
## Changes in this PR:
Turn the logout link into a form/button to make it a POST request rather than GET.
Possibly related to https://dxw.slack.com/archives/C02TP2L2Z0F/p1726749793312689, discussed in standup, might be a change due to Django upgrade?
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-302

## Screenshots of UI changes:
<img width="278" alt="image" src="https://github.com/user-attachments/assets/3061f3af-b843-4590-95ec-3a4c686dbe66">
<img width="449" alt="image" src="https://github.com/user-attachments/assets/8d2bff63-e7b5-4aa0-b9d9-2d1e9464a497">

- [ ] Requires env variable(s) to be updated
The URL was also `/adminlogout`; we should change the `DJANGO_ADMIN_URL` env var to `admin/`
