### PR TITLE
FCL-300 | update navigation behaviour to hide unusable buttons

### DIFF
--- a/judgments/templatetags/navigation_tags.py
+++ b/judgments/templatetags/navigation_tags.py
@@ -5,47 +5,38 @@ register = template.Library()
 
 
 def get_document_url(view, document):
-    return reverse(view, kwargs={"document_uri": document.uri})
+    if view:
+        return reverse(view, kwargs={"document_uri": document.uri})
+    else:
+        return None
 
 
 def get_hold_navigation_item(view, document):
-    if document.is_published:
-        return {
-            "id": "put-on-hold",
-            "selected": view == "hold_judgment",
-            "label": "Put on hold",
-        }
-    elif document.is_held:
-        return {
-            "id": "take-off-hold",
-            "selected": view == "unhold_judgment",
-            "label": "Take off hold",
-            "url": get_document_url("unhold-document", document),
-        }
-    else:
-        return {
-            "id": "put-on-hold",
-            "selected": view == "hold_judgment",
-            "label": "Put on hold",
-            "url": get_document_url("hold-document", document),
-        }
+    identifier = "take-off-hold" if document.is_held else "put-on-hold"
+    label = "Take off hold" if document.is_held else "Put on hold"
+    selected = view in ("hold_judgment", "unhold_judgment")
+    path = None if document.is_published else "unhold-document" if document.is_held else "hold-document"
+
+    return {
+        "id": identifier,
+        "selected": selected,
+        "label": label,
+        "url": get_document_url(path, document),
+    }
 
 
 def get_publishing_navigation_item(view, document):
-    if document.is_published:
-        return {
-            "id": "unpublish",
-            "selected": view == "unpublish_judgment",
-            "label": "Unpublish",
-            "url": get_document_url("unpublish-document", document),
-        }
-    else:
-        return {
-            "id": "publish",
-            "selected": view == "publish_judgment",
-            "label": "Publish",
-            "url": get_document_url("publish-document", document),
-        }
+    selected = view in ("unpublish_judgment", "publish_judgment")
+    label = "Unpublish" if document.is_published else "Publish"
+    identifier = "unpublished" if document.is_published else "publish"
+    path = None if document.is_held else "unpublish-document" if document.is_published else "publish-document"
+
+    return {
+        "id": identifier,
+        "selected": selected,
+        "label": label,
+        "url": get_document_url(path, document),
+    }
 
 
 def get_download_navigation_item(view, document):

--- a/judgments/tests/test_navigation_tags.py
+++ b/judgments/tests/test_navigation_tags.py
@@ -1,0 +1,79 @@
+from django.test import TestCase
+from factories import JudgmentFactory
+
+from judgments.templatetags.navigation_tags import get_navigation_items
+
+
+class TestNavigationTags(TestCase):
+    def test_get_navigation_items(self):
+        judgment = JudgmentFactory.build(is_published=False)
+
+        context = {
+            "view": "judgment_html",
+            "document": judgment,
+        }
+
+        navigation_items = get_navigation_items(context)
+
+        assert navigation_items == [
+            {"id": "review", "label": "Review", "selected": True, "url": "/test/2023/123"},
+            {"id": "take-off-hold", "label": "Take off hold", "selected": False, "url": "/test/2023/123/unhold"},
+            {"id": "publish", "label": "Publish", "selected": False, "url": None},
+            {"id": "history", "label": "History", "selected": False, "url": "/test/2023/123/history"},
+            {"id": "downloads", "label": "Downloads", "selected": False, "url": "/test/2023/123/downloads"},
+        ]
+
+    def test_get_navigation_items_published(self):
+        judgment = JudgmentFactory.build(is_published=True)
+
+        context = {
+            "view": "judgment_html",
+            "document": judgment,
+        }
+
+        navigation_items = get_navigation_items(context)
+
+        for item in navigation_items:
+            if item["id"] == "take-off-hold":
+                assert item["url"] is None
+
+    def test_get_navigation_items_onhold(self):
+        judgment = JudgmentFactory.build(is_published=False)
+
+        judgment.is_held = True
+
+        context = {
+            "view": "judgment_html",
+            "document": judgment,
+        }
+
+        navigation_items = get_navigation_items(context)
+
+        for item in navigation_items:
+            if item["id"] == "publish":
+                assert item["url"] is None
+
+    def test_get_navigation_items_selected_pages(self):
+        judgment = JudgmentFactory.build(is_published=False)
+
+        base_context = {
+            "document": judgment,
+        }
+
+        tests = [
+            {"expected_selected_id": "review", "view": "judgment_html"},
+            {"expected_selected_id": "review", "view": "judgment_pdf"},
+            {"expected_selected_id": "history", "view": "document_history"},
+            {"expected_selected_id": "publish", "view": "publish_judgment"},
+            {"expected_selected_id": "publish", "view": "unpublish_judgment"},
+            {"expected_selected_id": "downloads", "view": "document_downloads"},
+            {"expected_selected_id": "take-off-hold", "view": "hold_judgment"},
+            {"expected_selected_id": "take-off-hold", "view": "unhold_judgment"},
+        ]
+
+        for test in tests:
+            navigation_items = get_navigation_items({**base_context, "view": test["view"]})
+
+            for item in navigation_items:
+                if item["id"] == test["expected_selected_id"]:
+                    assert item["selected"] is True


### PR DESCRIPTION
## Changes in this PR:

When a nav item isn't usable in judgment state, don't show the nav item.

Added some tests to reflect what the states should show.

The templatetag determines whether the navigation item has a link or not based off the document attributes, and the template decides whether to show the navigation item based on that. If we decide to change our mind, it'll be easy to switch this around in the template rather than changing all the logic.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-300

## Screenshots of UI changes:

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/407a02fd-2301-4f3e-97d4-6a3806c7df58">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/09929965-207c-4af8-98e6-254d3d742741">
