### PR TITLE
FCL-336 | add extra cases for status colors

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
@@ -1,4 +1,3 @@
-{% load status_tag_css %}
 <div class="metadata-header__block">
   <div class="metadata-component">
     <form aria-label="Edit judgment"

--- a/judgments/templatetags/status_tag_css.py
+++ b/judgments/templatetags/status_tag_css.py
@@ -12,9 +12,9 @@ register = template.Library()
 @register.filter
 @stringfilter
 def status_tag(status):
-    if status.lower() == DOCUMENT_STATUS_IN_PROGRESS.lower():
+    if status.lower() in (DOCUMENT_STATUS_IN_PROGRESS.lower(), "in progress"):
         return "in-progress"
-    if status.lower() == DOCUMENT_STATUS_HOLD.lower():
+    if status.lower() in (DOCUMENT_STATUS_HOLD.lower(), "hold"):
         return "on-hold"
     if status.lower() == DOCUMENT_STATUS_PUBLISHED.lower():
         return "published"

--- a/judgments/tests/test_templatetags.py
+++ b/judgments/tests/test_templatetags.py
@@ -16,11 +16,17 @@ class TestStatusTagColour:
     def test_colour_in_progress(self):
         assert status_tag(DOCUMENT_STATUS_IN_PROGRESS) == "in-progress"
 
+    def test_colour_in_progress_editor_status(self):
+        assert status_tag("In Progress") == "in-progress"
+
     def test_colour_published(self):
         assert status_tag(DOCUMENT_STATUS_PUBLISHED) == "published"
 
     def test_colour_hold(self):
         assert status_tag(DOCUMENT_STATUS_HOLD) == "on-hold"
+
+    def test_colour_hold_editor_status(self):
+        assert status_tag("Hold") == "on-hold"
 
     def test_colour_new(self):
         assert status_tag(DOCUMENT_STATUS_NEW) == "new"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Fix for statuses that don't match the judgment format (from the editor metadata)

Separate question on why they don't follow the same format? Couldn't figure out why this might be. Ideally they would be consistent.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-336

## Screenshots of UI changes:

### Before

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/73bb8b23-cead-4d67-8043-28b69f87bc54">


### After

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/2872e68e-60f5-4415-ab13-4fff9c31f6ef">
