### PR TITLE
FCL-336 | update status colours

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/components/_judgment_status_indicator.scss
+++ b/ds_caselaw_editor_ui/sass/includes/components/_judgment_status_indicator.scss
@@ -25,12 +25,12 @@
   }
 
   &--published {
-    color: mix(black, $govuk-green, 60%);
-    background: mix(white, $govuk-green, 70%);
+    color: mix(black, $govuk-green, 20%);
+    background: mix(white, $govuk-green, 80%);
   }
 
   &--on-hold {
-    color: mix(black, $govuk-red, 60%);
-    background: mix(white, $govuk-red, 70%);
+    color: mix(black, $govuk-red, 80%);
+    background: mix(white, $govuk-red, 75%);
   }
 }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Adjusting the status colours.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-336

## Screenshots of UI changes:

### Before

<img width="196" alt="image" src="https://github.com/user-attachments/assets/e9ed029c-2bc2-4c0f-98d0-66470e7d4bc8">


<img width="205" alt="image" src="https://github.com/user-attachments/assets/8a936e97-96f0-49ae-bf46-51ce755d6737">


### After

<img width="63" alt="image" src="https://github.com/user-attachments/assets/8aee0223-e9d5-43d7-82ed-312b2363a1a2">

<img width="201" alt="image" src="https://github.com/user-attachments/assets/79fdc8b0-a26b-4a40-a206-71e5f142a1b1">


- [ ] Requires env variable(s) to be updated
