### PR TITLE
Revert Python to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.13-slim-bookworm
+ARG PYTHON_VERSION=3.12-slim-bookworm
 
 
 

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.13-slim-bullseye
+ARG PYTHON_VERSION=3.12-slim-bullseye
 
 # define an alias for the specfic python version used in this file.
 FROM python:${PYTHON_VERSION} AS python

--- a/compose/local/docs/Dockerfile
+++ b/compose/local/docs/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.13-slim-bullseye
+ARG PYTHON_VERSION=3.12-slim-bullseye
 
 # define an alias for the specfic python version used in this file.
 FROM python:${PYTHON_VERSION} AS python

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.13-slim-bullseye
+ARG PYTHON_VERSION=3.12-slim-bullseye
 
 
 


### PR DESCRIPTION
Python 3.13 isn't fully supported by some of our upstream dependencies; revert to 3.12 for the time being.