### PR TITLE
[FCL-401] Change how EUI retrieves document versions so it's cleaner

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/toolbar/version.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/toolbar/version.html
@@ -1,9 +1,9 @@
-{% if version %}
+{% if current_version_number %}
   <div class="page-notification--info">
     <div class="judgment-toolbar__version">
       <span class="icon icon__circle-info"></span>
       <span>
-        You are viewing <strong>version {{ version }}</strong> of this document.
+        You are viewing <strong>version {{ current_version_number }}</strong> of this document.
       </span>
     </div>
   </div>

--- a/judgments/tests/utils/test_utils.py
+++ b/judgments/tests/utils/test_utils.py
@@ -13,7 +13,7 @@ from judgments.utils import api_client as api_client_real
 from judgments.utils import (
     editors_dict,
     ensure_local_referer_url,
-    extract_version,
+    extract_version_number_from_filename,
     render_versions,
     update_document_uri,
 )
@@ -204,17 +204,17 @@ class TestReferrerUrlHelper(TestCase):
 
 
 class TestVersionUtils:
-    def test_extract_version_uri(self):
+    def test_extract_version_number_from_filename_uri(self):
         uri = "/ewhc/ch/2022/1178_xml_versions/2-1178.xml"
-        assert extract_version(uri) == 2
+        assert extract_version_number_from_filename(uri) == 2
 
-    def test_extract_version_failure(self):
+    def test_extract_version_number_from_filename_failure(self):
         uri = "/failures/TDR-2022-DBF_xml_versions/1-TDR-2022-DBF.xml"
-        assert extract_version(uri) == 1
+        assert extract_version_number_from_filename(uri) == 1
 
-    def test_extract_version_not_found(self):
+    def test_extract_version_number_from_filename_not_found(self):
         uri = "some-other-string"
-        assert extract_version(uri) == 0
+        assert extract_version_number_from_filename(uri) == 0
 
     def test_render_versions(self):
         version_parts = (

--- a/judgments/tests/utils/test_utils.py
+++ b/judgments/tests/utils/test_utils.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import ds_caselaw_utils
 import pytest
@@ -14,7 +14,6 @@ from judgments.utils import (
     editors_dict,
     ensure_local_referer_url,
     extract_version_number_from_filename,
-    render_versions,
     update_document_uri,
 )
 from judgments.utils.aws import build_new_key, invalidate_caches
@@ -215,23 +214,6 @@ class TestVersionUtils:
     def test_extract_version_number_from_filename_not_found(self):
         uri = "some-other-string"
         assert extract_version_number_from_filename(uri) == 0
-
-    def test_render_versions(self):
-        version_parts = (
-            Mock(text="/ewhc/ch/2022/1178_xml_versions/3-1178.xml"),
-            Mock(text="/ewhc/ch/2022/1178_xml_versions/2-1178.xml"),
-            Mock(text="/ewhc/ch/2022/1178_xml_versions/1-1178.xml"),
-        )
-        requests_toolbelt = Mock()
-        requests_toolbelt.multipart.decoder.BodyPart.return_value = version_parts
-
-        expected_result = [
-            {"uri": "/ewhc/ch/2022/1178_xml_versions/3-1178", "version": 3},
-            {"uri": "/ewhc/ch/2022/1178_xml_versions/2-1178", "version": 2},
-            {"uri": "/ewhc/ch/2022/1178_xml_versions/1-1178", "version": 1},
-        ]
-
-        assert render_versions(version_parts) == expected_result
 
 
 class TestEditorsDict:

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -141,17 +141,6 @@ def set_metadata(old_uri, new_uri):
     api_client.set_boolean_property(new_uri, "published", bool(published))
 
 
-def render_versions(decoded_versions):
-    versions = [
-        {
-            "uri": part.text.rstrip(".xml"),
-            "version": extract_version_number_from_filename(part.text),
-        }
-        for part in decoded_versions
-    ]
-    return sorted(versions, key=lambda d: -d["version"])
-
-
 def extract_version_number_from_filename(version_string: str) -> int:
     result = re.search(VERSION_REGEX, version_string)
     return int(result.group(1)) if result else 0

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -145,14 +145,14 @@ def render_versions(decoded_versions):
     versions = [
         {
             "uri": part.text.rstrip(".xml"),
-            "version": extract_version(part.text),
+            "version": extract_version_number_from_filename(part.text),
         }
         for part in decoded_versions
     ]
     return sorted(versions, key=lambda d: -d["version"])
 
 
-def extract_version(version_string: str) -> int:
+def extract_version_number_from_filename(version_string: str) -> int:
     result = re.search(VERSION_REGEX, version_string)
     return int(result.group(1)) if result else 0
 

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -8,7 +8,7 @@ from caselawclient.search_parameters import SearchParameters
 from django.http import Http404
 from django.views.generic import TemplateView
 
-from judgments.utils import api_client, editors_dict, get_linked_document_uri
+from judgments.utils import api_client, editors_dict, extract_version_number_from_filename, get_linked_document_uri
 from judgments.utils.link_generators import build_jira_create_link
 from judgments.utils.paginator import paginator
 
@@ -85,6 +85,12 @@ class DocumentView(TemplateView):
         context["document_uri"] = document_uri
 
         context["document"] = document
+
+        version_uri = self.request.GET.get("version_uri", None)
+
+        if version_uri:
+            context["current_version_number"] = extract_version_number_from_filename(version_uri)
+            context["requested_version"] = get_document_by_uri_or_404(version_uri)
 
         # TODO: Remove this once we fully deprecate 'judgment' contexts
         context["judgment"] = document

--- a/judgments/views/document_full_text.py
+++ b/judgments/views/document_full_text.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 
-from judgments.utils import extract_version, get_corrected_ncn_url
+from judgments.utils import extract_version_number_from_filename, get_corrected_ncn_url
 from judgments.utils.view_helpers import DocumentView, get_document_by_uri_or_404
 
 
@@ -20,7 +20,7 @@ class DocumentReviewHTMLView(DocumentView):
             )
 
         if version_uri:
-            context["version"] = extract_version(version_uri)
+            context["version"] = extract_version_number_from_filename(version_uri)
 
         context["view"] = "judgment_html"
 
@@ -46,7 +46,7 @@ class DocumentReviewPDFView(DocumentView):
         version_uri = self.request.GET.get("version_uri", None)
 
         if version_uri:
-            context["version"] = extract_version(version_uri)
+            context["version"] = extract_version_number_from_filename(version_uri)
 
         context["view"] = "judgment_pdf"
 

--- a/judgments/views/document_full_text.py
+++ b/judgments/views/document_full_text.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 
-from judgments.utils import extract_version_number_from_filename, get_corrected_ncn_url
+from judgments.utils import get_corrected_ncn_url
 from judgments.utils.view_helpers import DocumentView, get_document_by_uri_or_404
 
 
@@ -13,14 +13,10 @@ class DocumentReviewHTMLView(DocumentView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        version_uri = self.request.GET.get("version_uri", None)
         if not context["document"].body.failed_to_parse:
             context["document_html_content"] = context["document"].content_as_html(
-                version_uri=version_uri,
+                version_uri=context["requested_version"].uri if "requested_version" in context else None,
             )
-
-        if version_uri:
-            context["version"] = extract_version_number_from_filename(version_uri)
 
         context["view"] = "judgment_html"
 
@@ -42,11 +38,6 @@ class DocumentReviewPDFView(DocumentView):
             raise Http404(
                 msg,
             )
-
-        version_uri = self.request.GET.get("version_uri", None)
-
-        if version_uri:
-            context["version"] = extract_version_number_from_filename(version_uri)
 
         context["view"] = "judgment_pdf"
 


### PR DESCRIPTION
Reduce duplication and make the way we collect a specific version of a document cleaner and more easily understood.

## Jira

FCL-401