### PR TITLE
[FCL-400] Swap to using new in-API XSLT transformation

### DIFF
--- a/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_html.html
@@ -28,7 +28,7 @@
            class="document-navigation-links">
         <a class="up" href="#start-of-document">Back to start</a>
       </div>
-      {{ document_html_content }}
+      {{ document_html }}
       {% include "includes/judgment_end_document_marker.html" %}
       <div id="end-of-document">
       {% endautoescape %}

--- a/judgments/tests/test_judgments.py
+++ b/judgments/tests/test_judgments.py
@@ -19,8 +19,10 @@ class TestJudgmentView(TestCase):
 
         judgment = JudgmentFactory.build(
             uri="hvtest/4321/123",
-            html="<h1>Test Judgment</h1>",
-            body=DocumentBodyFactory.build(name="Test v Tested"),
+            body=DocumentBodyFactory.build(
+                name="Test v Tested",
+                xml_string="<akomantoso>This is our test judgment.</akomantoso>",
+            ),
         )
         judgment.body.document_date_as_date = date(1999, 10, 31)
         mock_judgment.return_value = judgment
@@ -35,7 +37,7 @@ class TestJudgmentView(TestCase):
 
         decoded_response = response.content.decode("utf-8")
         assert "Test v Tested" in decoded_response
-        assert "<h1>Test Judgment</h1>" in decoded_response
+        assert "This is our test judgment." in decoded_response
         assert "31 Oct 1999" in decoded_response
         assert response.status_code == 200
 
@@ -53,8 +55,7 @@ class TestJudgmentView(TestCase):
 
         judgment = JudgmentFactory.build(
             uri="hvtest/4321/123",
-            html="<h1>Test Judgment</h1>",
-            body=DocumentBodyFactory.build(html="<h1>Test Judgment</h1>", xml_string="<error>Error log</error>"),
+            body=DocumentBodyFactory.build(xml_string="<error>Error log</error>"),
         )
 
         assert judgment.body.failed_to_parse
@@ -72,9 +73,6 @@ class TestJudgmentView(TestCase):
 
         assert "&lt;error&gt;Error log&lt;/error&gt;" in decoded_response
         assert "<error>Error log</error>" not in decoded_response
-
-        assert "&lt;h1&gt;Test Judgment&lt;/h1&gt;" not in decoded_response
-        assert "<h1>Test Judgment</h1>" not in decoded_response
 
         assert response.status_code == 200
 

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -90,7 +90,9 @@ class DocumentView(TemplateView):
 
         if version_uri:
             context["current_version_number"] = extract_version_number_from_filename(version_uri)
-            context["requested_version"] = get_document_by_uri_or_404(version_uri)
+            context["document_html"] = get_document_by_uri_or_404(version_uri).body.content_as_html
+        else:
+            context["document_html"] = document.body.content_as_html
 
         # TODO: Remove this once we fully deprecate 'judgment' contexts
         context["judgment"] = document

--- a/judgments/views/document_full_text.py
+++ b/judgments/views/document_full_text.py
@@ -13,13 +13,7 @@ class DocumentReviewHTMLView(DocumentView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        if not context["document"].body.failed_to_parse:
-            context["document_html_content"] = context["document"].content_as_html(
-                version_uri=context["requested_version"].uri if "requested_version" in context else None,
-            )
-
         context["view"] = "judgment_html"
-
         context["corrected_ncn_url"] = get_corrected_ncn_url(context["judgment"])
 
         return context


### PR DESCRIPTION
This now leans on using the XSLT for body transformation which exists within the API, rather than making a call out to MarkLogic.

## Jira

FCL-400