### PR TITLE
Bump API to v27.4.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ xmltodict~=0.14.1
 requests-toolbelt~=1.0.0
 lxml~=5.3.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=27.3.0
+ds-caselaw-marklogic-api-client~=27.4.0
 ds-caselaw-utils~=2.0.0
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
This allows us to restrict bulk enrichment to only those documents that are already published.