### PR TITLE
[FCL-493] Fix NCN/URI mismatch detector incorrectly raising false positives

### DIFF
--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -177,11 +177,11 @@ def _build_related_document_uri(document: Document) -> str:
     return document.uri + press_summary_suffix
 
 
-def get_corrected_ncn_url(document) -> str | None:
+def get_corrected_ncn_url(document: Document) -> str | None:
     ncn_uri = caselawutils.neutral_url(document.neutral_citation)
 
     if "press-summary" in document.uri:
         return None
-    if "/" + document.uri != ncn_uri:
+    if document.uri != ncn_uri:
         return ncn_uri
     return None


### PR DESCRIPTION
Now we have fully standardised our approach to document URI strings our NCN/URI mismatch detector is incorrectly applying a leading forward slash during comparisons; stop doing this.

There is a change to the existing test for the banner being correctly shown so that both the positive and negative case are testing for (or against) the same thing using the same method, reducing the chances of accidentally introducing a false pass for the negative case.

## Jira card / Rollbar error (etc)

FCL-493