### PR TITLE
Fix option name for access log format in gunicorn

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -7,4 +7,4 @@ set -o nounset
 npm run build
 python /app/manage.py collectstatic --noinput
 cd /app
-/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access_log_format '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s"'
+/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s"'


### PR DESCRIPTION
The option name for the access log format in gunicorn is `--access-logformat`
and not `--access_log_format`.
https://docs.gunicorn.org/en/stable/settings.html#access-log-format