### PR TITLE
Add more headers to the access log

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -7,4 +7,4 @@ set -o nounset
 npm run build
 python /app/manage.py collectstatic --noinput
 cd /app
-/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s"'
+/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s "%({cloudfront-viewer-address}i)s" "%({x-amz-cf-id}i)s" "%({x-amzn-trace-id}i)s"'


### PR DESCRIPTION
This adds header which give us more information about the request. This is
useful for debugging and monitoring.
It will give us the viewer's IP address, the CloudFront request ID, and the
trace ID from ALB if present.