### PR TITLE
Add identifier inspection view for documents

### DIFF
--- a/ds_caselaw_editor_ui/templates/judgment/identifiers.html
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers.html
@@ -1,0 +1,60 @@
+{% extends "layouts/judgment.html" %}
+{% load i18n document_utils user_permissions %}
+{% block content %}
+  {% include "includes/judgment/metadata_panel_static.html" with judgment=document %}
+  <div class="container">
+    <h1 class="judgment-component__confirmation-title">Identifiers for:</h1>
+    <h2 class="judgment-component__confirmation-subtitle">{{ document.body.name }}</h2>
+    {% if document.identifiers %}
+      <table class="table">
+        <tr>
+          <th>Type</th>
+          <th>Value</th>
+          <th>URL</th>
+        </tr>
+        {% for identifier in document.identifiers.values %}
+          <tr>
+            <td>
+              {{ identifier.schema.name }}
+              {% if user|is_developer %}
+                <br>
+                <small class="muted"><code>{{ identifier.schema.namespace }}</code></small>
+              {% endif %}
+            </td>
+            <td>
+              <code>{{ identifier.value }}</code>
+              {% if user|is_developer %}
+                <br>
+                <small class="muted"><code>{{ identifier.uuid }}</code></small>
+              {% endif %}
+            </td>
+            <td>
+              <code>/{{ identifier.url_slug }}</code>
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
+    {% else %}
+      <div class="page-notification--info">
+        <div class="judgment-toolbar__version">
+          <span class="icon icon__circle-info"></span> This document does not have any stored identifiers.
+        </div>
+      </div>
+    {% endif %}
+    {% if user|is_developer %}
+      <h3>System identifiers</h3>
+      <table class="table">
+        <tr>
+          <th>Type</th>
+          <th>Value</th>
+        </tr>
+        <tr>
+          <td>MarkLogic URI</td>
+          <td>
+            <code>{{ document.uri }}</code>
+          </td>
+        </tr>
+      </table>
+    {% endif %}
+  </div>
+{% endblock content %}

--- a/judgments/templatetags/navigation_tags.py
+++ b/judgments/templatetags/navigation_tags.py
@@ -78,6 +78,15 @@ def get_associated_documents_navigation_item(view, document):
     }
 
 
+def get_identifiers_navigation_item(view, document):
+    return {
+        "id": "identifiers",
+        "selected": view == "document_identifiers",
+        "label": "Identifiers",
+        "url": get_document_url("document-identifiers", document),
+    }
+
+
 @register.simple_tag(takes_context=True)
 def get_navigation_items(context):
     view, document, linked_document_uri = (
@@ -90,6 +99,7 @@ def get_navigation_items(context):
         get_review_navigation_item(view, document),
         get_hold_navigation_item(view, document),
         get_publishing_navigation_item(view, document),
+        get_identifiers_navigation_item(view, document),
         get_history_navigation_item(view, document),
         get_download_navigation_item(view, document),
     ]

--- a/judgments/tests/test_navigation_tags.py
+++ b/judgments/tests/test_navigation_tags.py
@@ -19,6 +19,7 @@ class TestNavigationTags(TestCase):
             {"id": "review", "selected": True, "label": "Review", "url": "/test/2023/123"},
             {"id": "put-on-hold", "selected": False, "label": "Put on hold", "url": "/test/2023/123/hold"},
             {"id": "publish", "selected": False, "label": "Publish", "url": "/test/2023/123/publish"},
+            {"id": "identifiers", "selected": False, "label": "Identifiers", "url": "/test/2023/123/identifiers"},
             {"id": "history", "selected": False, "label": "History", "url": "/test/2023/123/history"},
             {"id": "downloads", "selected": False, "label": "Downloads", "url": "/test/2023/123/downloads"},
         ]

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -17,6 +17,7 @@ from .views.document_full_text import (
     xml_view_redirect,
 )
 from .views.document_history import DocumentHistoryView
+from .views.document_identifiers import DocumentIdentifiersView
 from .views.document_reparse import reparse
 from .views.index import index
 from .views.judgment_edit import EditJudgmentView, edit_view_redirect
@@ -97,6 +98,11 @@ urlpatterns = [
         "<path:document_uri>/history",
         DocumentHistoryView.as_view(),
         name="document-history",
+    ),
+    path(
+        "<path:document_uri>/identifiers",
+        DocumentIdentifiersView.as_view(),
+        name="document-identifiers",
     ),
     path(
         "<path:document_uri>/publish",

--- a/judgments/views/document_identifiers.py
+++ b/judgments/views/document_identifiers.py
@@ -1,0 +1,14 @@
+from judgments.utils import get_corrected_ncn_url
+from judgments.utils.view_helpers import DocumentView
+
+
+class DocumentIdentifiersView(DocumentView):
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context["corrected_ncn_url"] = get_corrected_ncn_url(context["judgment"])
+        context["view"] = "document_identifiers"
+
+        return context
+
+    template_name = "judgment/identifiers.html"


### PR DESCRIPTION
This adds a new view to a document, which allows editors to inspect (but not edit) the document's identifiers and URLs. Developers can also inspect the underlying object identifiers.

## Screenshots

![LEE JAMES BOOTLE v GHL PROPERTY MANAGEMENT AND DEVELOPMENT LIMITED - Find and ma](https://github.com/user-attachments/assets/5b20e022-2b72-4970-afd0-c830569227cf)

![LIDL GREAT BRITAIN LIMITED v TESCO STORES LIMITED - Find and manage case law](https://github.com/user-attachments/assets/0b9b02ae-27cb-4459-ab83-f32deb4f7a99)


## Jira

FCL-495