### PR TITLE
Run automated style fixes for stylelint to reduce future noise

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_basic_search_form.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_basic_search_form.scss
@@ -3,18 +3,21 @@
 
   &__container {
     @include container;
-    text-align: center;
+
     padding: $space-8;
+    text-align: center;
   }
 
   &__header {
-    font-size: $typography-md-text-size;
-    line-height: $typography-3xl-line-height;
     display: inline-block;
-    font-family: $font-roboto;
-    font-weight: $typography-normal-font-weight;
-    color: $color-almost-black;
+
     margin: 0 $space-6;
+
+    font-family: $font-roboto;
+    font-size: $typography-md-text-size;
+    font-weight: $typography-normal-font-weight;
+    line-height: $typography-3xl-line-height;
+    color: $color-almost-black;
 
     &--sr-only {
       @include sr-only;
@@ -27,8 +30,9 @@
 
   input[type="submit"] {
     @include call-to-action-button;
-    padding-left: $space-12;
+
     padding-right: $space-12;
+    padding-left: $space-12;
   }
 
   &__search-term-label {
@@ -37,9 +41,10 @@
 
   &__search-term-input {
     @include text_field;
+
     width: 80%;
-    margin-top: $space-4;
     min-height: $space-12;
+    margin-top: $space-4;
     font-size: $typography-lg-text-size;
 
     @media (min-width: $grid-breakpoint-small) {
@@ -56,11 +61,12 @@
   }
 
   form {
-    max-width: 47rem;
     display: flex;
     gap: $space-4;
-    margin: 0 auto;
     justify-content: center;
+
+    max-width: 47rem;
+    margin: 0 auto;
   }
 
   input[type="checkbox"] {

--- a/ds_caselaw_editor_ui/sass/includes/_buttons.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_buttons.scss
@@ -1,9 +1,9 @@
 .button {
   &-small {
-    padding: $space-1 $space-2 !important;
     margin-top: $space-2 !important;
-    font-size: $typography-sm-text-size !important;
     margin-bottom: $space-2 !important;
+    padding: $space-1 $space-2 !important;
+    font-size: $typography-sm-text-size !important;
   }
 }
 
@@ -11,18 +11,22 @@
   color: $color-dark-grey;
   background-color: transparent;
   border-color: $color-grey;
+
   &:focus,
   &:hover {
-    outline: none;
-    background-color: transparent;
+    cursor: not-allowed;
+
     color: $color-dark-grey;
     text-decoration: none;
-    cursor: not-allowed;
+
+    background-color: transparent;
+    outline: none;
   }
 }
 
 .button-cta {
   @include call-to-action-button;
+
   border: 2px solid $color-cta-background;
 
   &:disabled,
@@ -33,8 +37,9 @@
 
 .button-secondary {
   @include call-to-action-button;
-  background-color: $color-white;
+
   color: $color-cta-background;
+  background-color: $color-white;
   border: 2px solid $color-cta-background;
 
   &:visited {
@@ -54,17 +59,18 @@
 
 .button-danger {
   @include call-to-action-button;
+
+  color: $color-white;
   background-color: $color-red;
   border: 2px solid $color-red;
-  color: $color-white;
 
   &:visited,
   &:focus,
   &:hover {
-    background-color: $color-red;
     color: $color-white;
-    outline-color: $color-red;
+    background-color: $color-red;
     border-color: $color-red;
+    outline-color: $color-red;
   }
 
   &:disabled,

--- a/ds_caselaw_editor_ui/sass/includes/_colour_swatches.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_colour_swatches.scss
@@ -1,7 +1,7 @@
 @mixin label {
   p {
-    text-align: center;
     padding: $space-6;
+    text-align: center;
   }
 }
 
@@ -22,78 +22,92 @@
 }
 
 .swatch {
-  width: 200px;
   display: inline-block;
+  width: 200px;
   margin-right: $space-4;
   padding: 0;
 
   &--yellow {
     background-color: $color-yellow;
+
     @include label-dark;
   }
 
   &--almost-black {
     background-color: $color-almost-black;
+
     @include label-light;
   }
 
   &--aqua-blue {
     background-color: $color-aqua-blue;
+
     @include label-light;
   }
 
   &--dark-blue {
     background-color: $color-dark-blue;
+
     @include label-light;
   }
 
   &--light-grey {
     background-color: $color-light-grey;
+
     @include label-dark;
   }
 
   &--grey {
     background-color: $color-grey;
+
     @include label-dark;
   }
 
   &--dark-grey {
     background-color: $color-dark-grey;
+
     @include label-light;
   }
 
   &--success {
     background-color: $color-success;
+
     @include label-light;
   }
 
   &--failure {
     background-color: $color-failure;
+
     @include label-light;
   }
 
   &--green {
     background-color: $color-green;
+
     @include label-light;
   }
 
   &--red {
     background-color: $color-red;
+
     @include label-light;
   }
 
   &--in-progress {
     background-color: $colour-in-progress;
+
     @include label-dark;
   }
 
   &--on-hold {
     background-color: $colour-on-hold;
+
     @include label-dark;
   }
 
   &--published {
     background-color: $colour-published;
+
     @include label-dark;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_document_history.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_document_history.scss
@@ -20,8 +20,9 @@
   &__submission-header {
     display: flex;
     flex-direction: row;
-    width: 100%;
     column-gap: $space-4;
+
+    width: 100%;
     margin-bottom: $space-4;
 
     h2,
@@ -32,49 +33,57 @@
 
     &__show-link {
       display: flex;
-      align-items: flex-end;
       flex-grow: 1;
+      align-items: flex-end;
     }
 
     &__reference {
-      text-align: right;
       display: flex;
       align-items: flex-end;
+      text-align: right;
     }
   }
 
   &__data-panel {
     display: flex;
     flex-direction: row;
-    width: 100%;
+
     box-sizing: border-box;
-    background-color: $color-light-grey;
+    width: 100%;
     padding: $space-4;
 
+    background-color: $color-light-grey;
+
     &__details {
-      list-style-type: none;
-      padding: 0;
       float: left;
+
       width: 100%;
-      line-height: $typography-lg-line-height;
       margin-top: $space-4;
+      padding: 0;
+
       font-size: $typography-sm-text-size;
+      line-height: $typography-lg-line-height;
+      list-style-type: none;
+
       li {
         float: left;
-        width: 100%;
-        @media (min-width: $grid-breakpoint-medium) {
-          width: 50%;
-        }
         box-sizing: border-box;
+        width: 100%;
+
         span:nth-child(odd) {
           float: left;
           width: 19%;
           margin-right: 0;
         }
+
         span:nth-child(even) {
           float: left;
           width: 66%;
           margin-left: 0;
+        }
+
+        @media (min-width: $grid-breakpoint-medium) {
+          width: 50%;
         }
       }
     }

--- a/ds_caselaw_editor_ui/sass/includes/_document_navigation_links.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_document_navigation_links.scss
@@ -1,38 +1,43 @@
 .document-navigation-links {
   a {
+    position: sticky;
+    top: 0;
     display: inline-block;
     margin: $space-4 $space-6;
-    top: 0;
-    position: -webkit-sticky;
-    position: sticky;
 
     &.up {
       &::before {
         content: " ";
+
+        position: sticky;
+        top: 0;
+
+        display: inline-block;
+
+        width: $space-4;
+        height: $space-4;
+        margin: 0 $space-2 0 0;
+
         background: url($fa_chevron_up_link_blue) left no-repeat;
         background-size: contain;
-        height: $space-4;
-        width: $space-4;
-        display: inline-block;
-        margin: 0 $space-2 0 0;
-        top: 0;
-        position: -webkit-sticky;
-        position: sticky;
       }
     }
 
     &.down {
       &::before {
         content: " ";
+
+        position: sticky;
+        top: 0;
+
+        display: inline-block;
+
+        width: $space-4;
+        height: $space-4;
+        margin: 0 $space-2 0 0;
+
         background: url($fa_chevron_down_link_blue) right no-repeat;
         background-size: contain;
-        height: $space-4;
-        width: $space-4;
-        display: inline-block;
-        margin: 0 $space-2 0 0;
-        top: 0;
-        position: -webkit-sticky;
-        position: sticky;
       }
     }
 
@@ -61,15 +66,18 @@
     display: none;
 
     &.show {
-      display: flex;
-      margin: auto;
       position: fixed;
       top: 0;
-      background-color: $color-white;
-      width: 100%;
+
+      display: flex;
       justify-content: space-between;
+
+      width: 100%;
+      margin: auto;
       margin: 0;
       padding: 0;
+
+      background-color: $color-white;
       box-shadow: $color-dark-grey 1px 1px 6px;
 
       @media (min-width: $grid-breakpoint-medium) {
@@ -77,13 +85,13 @@
       }
 
       @media (min-width: $grid-breakpoint-extra-large) {
-        width: auto;
         display: inline-block;
+        width: auto;
+        box-shadow: none;
 
         a {
           display: block;
         }
-        box-shadow: none;
       }
     }
   }

--- a/ds_caselaw_editor_ui/sass/includes/_document_version_history.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_document_version_history.scss
@@ -1,7 +1,7 @@
 .document-version-history {
   &__table {
-    border-color: $color-dark-grey;
-    width: auto;
     border-collapse: collapse;
+    width: auto;
+    border-color: $color-dark-grey;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_edit.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_edit.scss
@@ -3,13 +3,15 @@
   padding: 0 $space-4;
 
   &__header {
-    font-size: $typography-md-text-size;
-    line-height: $typography-3xl-line-height;
     display: inline-block;
-    font-family: $font-roboto;
-    font-weight: $typography-normal-font-weight;
-    color: $color-almost-black;
+
     margin: 0 $space-6;
+
+    font-family: $font-roboto;
+    font-size: $typography-md-text-size;
+    font-weight: $typography-normal-font-weight;
+    line-height: $typography-3xl-line-height;
+    color: $color-almost-black;
   }
 
   &__more-options {
@@ -30,11 +32,13 @@
 
   input[type="submit"] {
     @include call-to-action-button;
+
     display: block;
   }
 
   &__metadata_name-input {
     @include text_field;
+
     width: 80%;
     font-size: $typography-lg-text-size;
 
@@ -66,7 +70,7 @@
   padding: $space-2 0;
 }
 
-@media (max-width: 800px) {
+@media (width <= 800px) {
   .edit-component__actions {
     display: block;
   }

--- a/ds_caselaw_editor_ui/sass/includes/_environment_banner.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_environment_banner.scss
@@ -1,33 +1,35 @@
 .environment-banner {
-  background-color: $color-information;
   color: $color-black;
+  background-color: $color-information;
 
   &__notice {
     padding: 0;
 
     a {
-      color: $color-black;
       font-weight: $typography-bold-font-weight;
+      color: $color-black;
 
       &:focus {
-        outline: 0.125rem solid $color-black;
-        background-color: $color-white;
         color: $color-black;
+        background-color: $color-white;
+        outline: 0.125rem solid $color-black;
       }
     }
   }
 
   &__environment {
-    background-color: $color-white;
+    margin-right: $space-4;
+    padding: 0 $space-1;
+
+    font-weight: $typography-bold-font-weight;
     color: $color-black;
     text-transform: uppercase;
-    padding: 0 $space-1;
-    margin-right: $space-4;
-    font-weight: $typography-bold-font-weight;
+
+    background-color: $color-white;
   }
 
   &__message {
-    margin: 0;
     display: inline;
+    margin: 0;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_footer.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_footer.scss
@@ -1,19 +1,21 @@
 .judgments-footer {
   margin-top: auto;
-  background-color: $color-almost-black;
-  color: $color-white;
   padding: $space-4;
+
   font-size: $typography-sm-text-size;
+  color: $color-white;
+
+  background-color: $color-almost-black;
 
   &__heading {
     @include sr-only;
   }
 
   &__links {
-    padding: 0;
-    list-style-type: none;
     display: flex;
     justify-content: space-between;
+    padding: 0;
+    list-style-type: none;
   }
 
   &__link {

--- a/ds_caselaw_editor_ui/sass/includes/_header.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_header.scss
@@ -1,26 +1,27 @@
 .page-header {
-  background-color: $color-almost-black;
-
   display: flex;
   flex-direction: row;
   align-items: center;
 
   padding: 0;
 
-  &__navbar {
-    flex-grow: 1;
+  background-color: $color-almost-black;
 
-    display: block;
+  &__navbar {
     position: relative;
+    display: block;
+    flex-grow: 1;
     padding: $space-2 $space-8;
 
     ol {
-      margin: 0 $space-2;
-      list-style-type: none;
-      padding: 0;
-      font-family: $font-roboto;
       display: inline-block;
+
+      margin: 0 $space-2;
+      padding: 0;
+
+      font-family: $font-roboto;
       font-size: $typography-sm-text-size;
+      list-style-type: none;
 
       a {
         color: $color-white;
@@ -28,8 +29,8 @@
     }
 
     li {
-      display: inline-block;
       position: relative;
+      display: inline-block;
       margin-right: $space-2;
       color: $color-white;
     }
@@ -46,33 +47,36 @@
 
         &::before {
           content: "";
-          display: block;
+
           position: absolute;
           top: 0;
           bottom: 0;
           left: -3.31px;
+          transform: rotate(45deg);
+
+          display: block;
+
           width: 7px;
           height: 7px;
           margin: auto 0;
-          -webkit-transform: rotate(45deg);
-          -ms-transform: rotate(45deg);
-          transform: rotate(45deg);
+
           border: solid;
-          border-width: 0.125rem 0.125rem 0 0;
           border-color: $color-white;
+          border-width: 0.125rem 0.125rem 0 0;
         }
       }
     }
 
     &-you-are-in {
-      color: $color-white;
-      font-size: $typography-sm-text-size;
       margin-right: $space-2;
+      font-size: $typography-sm-text-size;
+      color: $color-white;
     }
   }
 
   &__container {
     @include container;
+
     @media (min-width: $grid-breakpoint-medium) {
       text-align: center;
     }

--- a/ds_caselaw_editor_ui/sass/includes/_icons.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_icons.scss
@@ -27,22 +27,18 @@
   }
 
   &__circle-check {
-    -webkit-mask-image: url($fa_circle_check);
     mask-image: url($fa_circle_check);
   }
 
   &__triangle-exclamation {
-    -webkit-mask-image: url($fa_triangle_exclamation);
     mask-image: url($fa_triangle_exclamation);
   }
 
   &__arrow-up-right-square {
-    -webkit-mask-image: url($fa_arrow_up_right_square);
     mask-image: url($fa_arrow_up_right_square);
   }
 
   &__circle-info {
-    -webkit-mask-image: url($fa_circle_info);
     mask-image: url($fa_circle_info);
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_judgment_component.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_component.scss
@@ -8,8 +8,9 @@
   &__button-actions {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
     gap: $space-8;
+    align-items: flex-start;
+
     padding: $space-8 0;
 
     input.button-cta[type="submit"] {
@@ -45,22 +46,24 @@
     }
 
     label {
-      display: inline-block;
       position: relative;
       left: $space-8;
+      display: inline-block;
     }
   }
 
   input[type="submit"] {
-    display: inline-block;
     position: relative;
+    display: inline-block;
   }
 
   &__metadata_name-input {
     @include text_field;
+
     width: 80%;
     min-height: $space-12;
     font-size: $typography-lg-text-size;
+
     @media (min-width: $grid-breakpoint-small) {
       width: 20rem;
     }
@@ -76,19 +79,19 @@
 }
 
 .email-confirm-publish {
-  border: 2px #ffb952 solid;
   display: inline-block;
-  padding: 0px $space-2 0px 0;
+  padding: 0 $space-2 0 0;
+  border: 2px #ffb952 solid;
 
   &__list-header {
-    padding-left: $space-2;
     margin: $space-2 0;
+    padding-left: $space-2;
   }
 
   &__list {
-    list-style: none;
-    padding-left: $space-2;
     margin: $space-1 0;
+    padding-left: $space-2;
+    list-style: none;
   }
 
   &__list-link {
@@ -97,19 +100,19 @@
 }
 
 .email-hold-publish {
-  border: 2px #ffb952 solid;
   display: inline-block;
-  padding: 0px $space-2 0px 0;
+  padding: 0 $space-2 0 0;
+  border: 2px #ffb952 solid;
 
   &__list-header {
-    padding-left: $space-2;
     margin: $space-2 0;
+    padding-left: $space-2;
   }
 
   &__list {
-    list-style: none;
-    padding-left: $space-2;
     margin: $space-1 0;
+    padding-left: $space-2;
+    list-style: none;
   }
 
   &__list-link {
@@ -123,7 +126,7 @@
   padding: $space-2 0;
 }
 
-@media (max-width: 800px) {
+@media (width <= 800px) {
   .edit-component__actions {
     display: block;
   }

--- a/ds_caselaw_editor_ui/sass/includes/_judgment_metadata_panel.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_metadata_panel.scss
@@ -1,18 +1,20 @@
 .judgment-metadata-panel {
   display: flex;
-  gap: $space-4;
   flex-direction: row;
+  gap: $space-4;
+
   padding: $space-4 $space-2 0;
-  border-bottom: 1px solid $color-almost-black;
+
   border-top: 1px solid $color-almost-black;
+  border-bottom: 1px solid $color-almost-black;
 
   &__primary-details {
     flex: 60%;
 
     li {
       span:nth-child(odd) {
-        text-align: right;
         width: 55px;
+        text-align: right;
       }
     }
   }
@@ -22,28 +24,30 @@
 
     li {
       span:nth-child(odd) {
-        text-align: right;
         width: 110px;
+        text-align: right;
       }
     }
   }
 
   &__primary-details,
   &__secondary-details {
-    list-style-type: none;
-    padding: 0 0 $space-4 0;
-    margin: 0;
-    width: 100%;
-    line-height: $typography-lg-line-height;
-    font-size: $typography-sm-text-size;
     display: flex;
     flex-direction: column;
     row-gap: $space-2;
 
+    width: 100%;
+    margin: 0;
+    padding: 0 0 $space-4;
+
+    font-size: $typography-sm-text-size;
+    line-height: $typography-lg-line-height;
+    list-style-type: none;
+
     li {
-      width: 100%;
       display: flex;
       gap: $space-4;
+      width: 100%;
     }
   }
 

--- a/ds_caselaw_editor_ui/sass/includes/_judgment_navigation.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_navigation.scss
@@ -1,16 +1,18 @@
 .judgment-navigation {
   all: unset;
+
+  display: flex;
+  gap: $space-10;
+  justify-content: center;
+
   background: $color-light-grey;
   border-bottom: 1px solid $color-dark-grey;
-  display: flex;
-  justify-content: center;
-  gap: $space-10;
 
   &__item {
     all: unset;
     padding: $space-4 0;
-    border-bottom: 5px solid transparent;
     font-size: $typography-md-text-size;
+    border-bottom: 5px solid transparent;
 
     a {
       text-decoration: none;
@@ -27,8 +29,8 @@
   }
 
   &__item--active {
-    border-bottom-color: $color-link-blue;
     font-weight: $typography-bold-font-weight;
+    border-bottom-color: $color-link-blue;
   }
 
   &__item--disabled {

--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_end_document_marker.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_end_document_marker.scss
@@ -1,25 +1,20 @@
 .judgment-end-document-marker {
   width: 100%;
-  border: 1px dashed $color-black;
-  border-top: none;
-  height: $space-4;
   max-width: 90%;
+  height: $space-4;
   margin: auto;
   margin-bottom: $space-28;
-  text-align: center;
-  @media (min-width: $grid-breakpoint-medium) {
-    max-width: 40rem;
-  }
 
-  @media (min-width: $grid-breakpoint-medium) {
-    max-width: 46rem;
-  }
+  text-align: center;
+
+  border: 1px dashed $color-black;
+  border-top: none;
 
   &__top-link {
     display: inline-block;
-    background-color: white;
     padding: $space-2;
     padding-top: $space-1;
+    background-color: white;
 
     a {
       display: none;
@@ -27,14 +22,18 @@
 
       &::before {
         content: " ";
+
+        position: relative;
+        top: 2px;
+
+        display: inline-block;
+
+        width: $space-4;
+        height: $space-4;
+        margin: 0 $space-2 0 0;
+
         background: url($fa_chevron_up_link_blue) left no-repeat;
         background-size: contain;
-        height: $space-4;
-        width: $space-4;
-        display: inline-block;
-        margin: 0 $space-2 0 0;
-        top: 2px;
-        position: relative;
       }
 
       &:visited {
@@ -43,6 +42,7 @@
 
       &:hover {
         color: $color-link-blue-hover;
+
         &::before {
           background-image: url($fa_chevron_up_link_hover_blue);
         }
@@ -52,5 +52,13 @@
         display: inline-block;
       }
     }
+  }
+
+  @media (min-width: $grid-breakpoint-medium) {
+    max-width: 40rem;
+  }
+
+  @media (min-width: $grid-breakpoint-medium) {
+    max-width: 46rem;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_source.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_source.scss
@@ -1,11 +1,21 @@
 .judgment-text-source {
-  background-color: $color-light-grey;
   padding: $space-2;
+  background-color: $color-light-grey;
   border-bottom: 0.125rem solid $color-grey;
 
   &__container {
     margin: auto;
     text-align: center;
+
+    p {
+      font-family: $font-roboto;
+      font-size: $typography-lg-text-size;
+      line-height: $typography-xl-line-height;
+    }
+
+    a {
+      display: block;
+    }
 
     @media (min-width: $grid-breakpoint-medium) {
       max-width: 40rem;
@@ -13,15 +23,6 @@
 
     @media (min-width: $grid-breakpoint-medium) {
       max-width: 46rem;
-    }
-
-    p {
-      font-size: $typography-lg-text-size;
-      line-height: $typography-xl-line-height;
-      font-family: $font-roboto;
-    }
-    a {
-      display: block;
     }
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_toolbar.scss
@@ -1,6 +1,6 @@
 .judgment-toolbar {
-  color: $color-black;
   padding: $space-2 0;
+  color: $color-black;
 
   &__button {
     display: inline-block;
@@ -10,6 +10,7 @@
 
   &__button-more {
     margin-left: $space-12 !important;
+
     svg {
       fill: $color-cta-background;
     }
@@ -29,33 +30,37 @@
   }
 
   &__delete {
-    border-color: $color-failure !important;
     color: $color-failure !important;
+    border-color: $color-failure !important;
+
     &:focus,
     &:hover {
-      background-color: $color-failure !important;
       color: $color-white !important;
+      background-color: $color-failure !important;
       outline-color: $color-failure !important;
     }
   }
 
   &__version {
-    text-align: center;
     display: flex;
+    gap: $space-2;
     align-items: center;
     justify-content: center;
-    gap: $space-2;
+
+    text-align: center;
   }
 
   &__corrected-ncn-notification {
     display: flex;
     flex-direction: column;
     gap: $space-2;
+
     h3 {
       display: flex;
-      align-items: center;
       gap: $space-2;
+      align-items: center;
     }
+
     p,
     h3 {
       margin: 0;
@@ -64,24 +69,24 @@
 
   &__container {
     display: flex;
+    gap: $space-4;
     align-items: center;
     justify-content: space-between;
-    gap: $space-4;
   }
 
   &__info,
   &__actions {
     display: flex;
+    gap: $space-4;
     align-items: center;
     justify-content: center;
-    gap: $space-4;
   }
 
   &__submitter,
   &__status {
     display: flex;
-    align-items: center;
     gap: $space-2;
+    align-items: center;
     padding-right: $space-4;
 
     h4 {
@@ -92,11 +97,14 @@
   &__more {
     &__menu {
       display: flex;
+
       &__group {
+        flex-grow: 1;
+
         h4 {
+          margin: 0;
           font-size: $typography-sm-text-size;
           line-height: $typography-lg-line-height;
-          margin: 0;
         }
 
         p {
@@ -116,11 +124,10 @@
 
         li {
           margin-top: 0;
-          list-style: none;
           font-size: $typography-sm-text-size;
           line-height: $typography-2xl-line-height;
+          list-style: none;
         }
-        flex-grow: 1;
       }
     }
   }

--- a/ds_caselaw_editor_ui/sass/includes/_judgments_list.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgments_list.scss
@@ -4,73 +4,82 @@
 
     @media (min-width: $grid-breakpoint-large) {
       display: flex;
+      gap: $space-4;
       align-items: flex-end;
       justify-content: space-between;
-      gap: $space-4;
     }
   }
 
   &__container {
     @include container;
+
     padding: $space-4 0;
   }
 
   &__header {
-    font-family: $font-roboto;
-    font-weight: $typography-normal-font-weight;
-    font-size: $typography-xl-text-size;
     margin: 0 0 $space-4;
-    margin-left: $space-2;
     margin-bottom: $space-4;
+    margin-left: $space-2;
+
+    font-family: $font-roboto;
+    font-size: $typography-xl-text-size;
+    font-weight: $typography-normal-font-weight;
   }
 
   &__more-info {
     display: inline-block;
-    margin-bottom: $space-5;
     flex: 1;
+    margin-bottom: $space-5;
   }
 
   &__table-header {
-    box-sizing: border-box;
     display: flex;
     flex-direction: row;
-    padding: $space-4 $space-2;
     flex-grow: 0;
+
+    box-sizing: border-box;
     width: 100%;
+    padding: $space-4 $space-2;
+
     border-bottom: 1px solid black;
   }
 
   &__table-header-details {
     flex-basis: 100%;
     font-weight: $typography-bold-font-weight;
+
     @media (min-width: $grid-breakpoint-medium) {
       flex-basis: 85%;
     }
   }
 
   &__table-header-submitted {
+    display: none;
     flex-basis: 15%;
     font-weight: $typography-bold-font-weight;
-    display: none;
+
     @media (min-width: $grid-breakpoint-medium) {
       display: block;
     }
   }
 
   &__list {
+    margin-top: 0;
     padding: 0;
     list-style-type: none;
-    margin-top: 0;
   }
 
   &__judgment {
     display: flex;
     flex-direction: row;
     flex-grow: 0;
-    width: 100%;
+
     box-sizing: border-box;
+    width: 100%;
     padding: $space-4 $space-2;
+
     border-bottom: 1px solid $color-dark-grey;
+
     &:last-child {
       border-bottom: none;
     }
@@ -78,14 +87,16 @@
 
   &__judgment-details {
     flex-basis: 100%;
+
     @media (min-width: $grid-breakpoint-medium) {
       flex-basis: 85%;
     }
   }
 
   &__judgment-submitted {
-    flex-basis: 15%;
     display: none;
+    flex-basis: 15%;
+
     @media (min-width: $grid-breakpoint-medium) {
       display: block;
     }
@@ -98,21 +109,20 @@
   }
 
   &__judgment-details-meta {
-    list-style-type: none;
-    padding: 0;
     float: left;
+
     width: 100%;
-    line-height: $typography-lg-line-height;
     margin-top: $space-4;
+    padding: 0;
+
     font-size: $typography-sm-text-size;
+    line-height: $typography-lg-line-height;
+    list-style-type: none;
 
     li {
       float: left;
-      width: 100%;
-      @media (min-width: $grid-breakpoint-medium) {
-        width: 50%;
-      }
       box-sizing: border-box;
+      width: 100%;
 
       &:nth-child(odd) {
         width: 40%;
@@ -126,9 +136,14 @@
         float: left;
         width: 22%;
       }
+
       span:nth-child(even) {
         float: left;
         width: 72%;
+      }
+
+      @media (min-width: $grid-breakpoint-medium) {
+        width: 50%;
       }
     }
   }
@@ -139,14 +154,18 @@
 
   &__action-button {
     @include call-to-action-button;
-    outline-color: $color-dark-blue;
-    font-weight: $typography-normal-font-weight;
+
     margin-top: 0;
     padding: $space-2;
+
     font-size: $typography-sm-text-size;
+    font-weight: $typography-normal-font-weight;
+
+    outline-color: $color-dark-blue;
+
     &:hover {
-      background-color: $color-link-blue-hover;
       cursor: grab;
+      background-color: $color-link-blue-hover;
     }
   }
 

--- a/ds_caselaw_editor_ui/sass/includes/_layout.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_layout.scss
@@ -1,9 +1,11 @@
 body {
-  margin: 0;
-  font-family: $font-open-sans;
   display: flex;
   flex-direction: column;
+
   min-height: 100vh;
+  margin: 0;
+
+  font-family: $font-open-sans;
 }
 
 main {

--- a/ds_caselaw_editor_ui/sass/includes/_links.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_links.scss
@@ -25,13 +25,16 @@ a {
   top: -3rem;
 
   &:focus {
-    background-color: $color-white;
-    padding: $space-2;
-    color: $color-black;
+    z-index: 999;
     top: 0.313rem;
     left: 0.313rem;
-    outline: 0.313rem solid $color-white;
+
+    padding: $space-2;
+
+    color: $color-black;
+
+    background-color: $color-white;
     border: 0.19rem solid $color-black;
-    z-index: 999;
+    outline: 0.313rem solid $color-white;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_loading_indicator.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_loading_indicator.scss
@@ -1,21 +1,25 @@
 .loading-indicator {
   content: "";
-  border: 6px solid $color-light-grey;
-  border-radius: 50%;
-  border-top-color: $color-almost-black;
+
+  display: inline-block;
+
   width: 6px !important;
   height: 6px !important;
-  display: inline-block;
-  -webkit-animation: spin 2s linear infinite;
+
+  border: 6px solid $color-light-grey;
+  border-top-color: $color-almost-black;
+  border-radius: 50%;
+
   animation: spin 2s linear infinite;
 }
 
-@-webkit-keyframes spin {
+@keyframes spin {
   0% {
-    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
   }
+
   100% {
-    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
   }
 }
 
@@ -23,6 +27,7 @@
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
   }

--- a/ds_caselaw_editor_ui/sass/includes/_login.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_login.scss
@@ -1,7 +1,7 @@
 .login-background {
-  background-color: $color-light-grey;
   padding-top: $space-8;
   padding-bottom: $space-8;
+  background-color: $color-light-grey;
 
   @media (min-width: $grid-breakpoint-small) {
     padding-top: $space-20;
@@ -15,15 +15,14 @@
 }
 
 .login-container {
+  width: 80%;
+  max-width: 20rem;
+  margin: auto;
+  padding: $space-8;
+
   background-color: #fff;
   border: 5px solid $color-yellow;
   border-radius: 8px;
-
-  margin: auto;
-
-  max-width: 20rem;
-  width: 80%;
-  padding: $space-8;
 
   h1 {
     margin: 0;
@@ -42,8 +41,8 @@
   &__text-field {
     box-sizing: border-box;
     width: 100%;
-    font-size: $typography-lg-text-size;
     margin-top: $space-2;
+    font-size: $typography-lg-text-size;
   }
 
   .button-cta {

--- a/ds_caselaw_editor_ui/sass/includes/_metadata.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_metadata.scss
@@ -1,10 +1,11 @@
 .metadata-header__block {
-  background-color: $color-light-grey;
   padding: $space-8 0;
+  background-color: $color-light-grey;
 }
 
 .metadata-component {
   @include container;
+
   background-color: $color-light-grey;
 
   form {
@@ -13,16 +14,16 @@
   }
 
   &__left-column {
-    flex: 1;
     display: flex;
+    flex: 1;
     flex-direction: column;
     gap: $space-2;
   }
 
   &__right-column {
-    min-width: 20%;
     display: flex;
     flex-direction: column;
+    min-width: 20%;
 
     > div {
       @media (min-width: $grid-breakpoint-large) {
@@ -33,8 +34,8 @@
     .metadata-component__main-labels {
       @media (min-width: $grid-breakpoint-large) {
         display: inline-block;
-        margin: 0;
         width: 4rem;
+        margin: 0;
       }
     }
 
@@ -63,30 +64,32 @@
 
   &__court {
     width: 33%;
-    @media (min-width: $grid-breakpoint-large) {
-      width: 50%;
-    }
 
     input {
       width: 100% !important;
+    }
+
+    @media (min-width: $grid-breakpoint-large) {
+      width: 50%;
     }
   }
 
   &__date {
     width: 33%;
-    @media (min-width: $grid-breakpoint-large) {
-      width: 16.67%;
-    }
 
     input {
       width: 100% !important;
     }
+
+    @media (min-width: $grid-breakpoint-large) {
+      width: 16.67%;
+    }
   }
 
   &__actions {
-    margin-top: auto;
     width: 100%;
     height: auto !important;
+    margin-top: auto;
 
     input {
       margin: 0;
@@ -94,17 +97,19 @@
   }
 
   &__status {
+    margin-bottom: $space-2;
+    white-space: nowrap;
+
     p {
       border: 3px solid white;
     }
-
-    margin-bottom: $space-2;
-    white-space: nowrap;
   }
 
   &__main-labels {
     display: block;
+
     margin-bottom: $space-1;
+
     font-size: $typography-sm-text-size;
     line-height: $typography-lg-line-height;
     color: $color-dark-grey;
@@ -113,47 +118,58 @@
   &__more-options {
     margin-top: $space-8;
   }
+
   &__success {
+    width: fit-content;
+    padding: $space-2;
     background-color: $color-green;
-    width: fit-content;
-    padding: $space-2;
   }
+
   &__error {
-    background-color: $color-red;
     width: fit-content;
     padding: $space-2;
+    background-color: $color-red;
   }
 
   input[type="submit"] {
     @include call-to-action-button;
+
     width: 100%;
-    margin: 0;
     min-height: 0.5rem;
+    margin: 0;
   }
 
   &__court-input {
-    @include text_field;
+    $font-open-sans: "Open Sans", sans-serif;
+
+    left: 2rem;
+
     box-sizing: border-box;
     width: 50%;
-    left: 2rem;
     min-height: 2rem;
-    font-size: $typography-md-text-size;
-    $font-open-sans: "Open Sans", sans-serif;
-    padding: $space-2;
-    border: 2px solid $color-dark-grey;
     margin: 0;
+    padding: $space-2;
+
+    font-size: $typography-md-text-size;
+
+    border: 2px solid $color-dark-grey;
+
+    @include text_field;
   }
 
   &__judgment_date-input {
     width: 80%;
     min-height: 2rem;
     font-size: $typography-md-text-size;
+
     @media (min-width: $grid-breakpoint-small) {
       width: 4rem;
     }
+
     @media (min-width: $grid-breakpoint-medium) {
       width: 2rem;
     }
+
     @media (min-width: $grid-breakpoint-extra-large) {
       width: 2rem;
     }
@@ -161,23 +177,30 @@
 
   &__metadata_name-input {
     @include text_field;
-    width: 100%;
-    margin-top: 0;
-    box-sizing: border-box;
-    height: calc(100% - $space-4 - 8px);
-    font-size: $typography-md-text-size;
+
     resize: none;
+
+    box-sizing: border-box;
+    width: 100%;
+    height: calc(100% - $space-4 - 8px);
+    margin-top: 0;
+
+    font-size: $typography-md-text-size;
   }
 
   input[type="text"] {
-    @include text_field;
+    $font-open-sans: "Open Sans", sans-serif;
+
     box-sizing: border-box;
     width: 95%;
     min-height: 2rem;
-    font-size: $typography-md-text-size;
-    $font-open-sans: "Open Sans", sans-serif;
-    padding: $space-2;
-    border: 2px solid $color-dark-grey;
     margin: 0;
+    padding: $space-2;
+
+    font-size: $typography-md-text-size;
+
+    border: 2px solid $color-dark-grey;
+
+    @include text_field;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_mixins.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_mixins.scss
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-columns: 1fr 5fr 1fr;
   grid-template-rows: 1fr;
-  gap: 6px 6px;
+  gap: 6px;
 
   div {
     padding: calc($unit / 4);
@@ -20,26 +20,27 @@
   }
 
   h3 {
-    font-size: $typography-md-text-size;
     margin: 0;
+    font-size: $typography-md-text-size;
     text-decoration: underline;
   }
 }
 
 @mixin sr-only {
   position: absolute;
-  left: -10000px;
   top: auto;
+  left: -10000px;
+
+  overflow: hidden;
+
   width: 0.125rem;
   height: 0.125rem;
-  overflow: hidden;
 }
 
 @mixin container {
-  padding: 0 $gutter_unit;
-  margin: auto;
-
   max-width: $grid-breakpoint-small - ($gutter_unit * 1);
+  margin: auto;
+  padding: 0 $gutter_unit;
 
   @media (min-width: $grid-breakpoint-medium) {
     max-width: $grid-breakpoint-medium - ($gutter_unit * 1.5);
@@ -56,15 +57,20 @@
 
 @mixin call-to-action-button {
   all: unset;
-  background-color: $color-cta-background;
-  text-decoration: none;
-  font-weight: $typography-bold-font-weight;
-  border: 0;
-  color: $color-white;
-  padding: $space-4 $space-6;
-  display: inline-block;
-  font-size: $typography-md-text-size;
+
   cursor: pointer;
+
+  display: inline-block;
+
+  padding: $space-4 $space-6;
+
+  font-size: $typography-md-text-size;
+  font-weight: $typography-bold-font-weight;
+  color: $color-white;
+  text-decoration: none;
+
+  background-color: $color-cta-background;
+  border: 0;
 
   &:visited {
     color: $color-white;
@@ -73,26 +79,27 @@
   &:focus,
   &:hover {
     @include focus-default;
+
     color: $color-white;
-    background-color: $color-cta-background-hover;
-    outline-color: $color-cta-background-hover;
-    border-color: $color-cta-background-hover;
     text-decoration: underline;
+
+    background-color: $color-cta-background-hover;
+    border-color: $color-cta-background-hover;
+    outline-color: $color-cta-background-hover;
     outline-offset: 0.2rem;
   }
 }
 
 @mixin emphasised-block {
   padding: $space-4;
-
   background-color: $color-light-grey;
   border-left: 0.5rem solid $color-highlight-blue;
 }
 
 @mixin focus-default {
+  z-index: 999;
   outline: 5px solid $color-focus-blue-outline;
   outline-offset: 0;
-  z-index: 999;
 }
 
 @mixin link-on-dark-bg {
@@ -104,8 +111,8 @@
   }
 
   &:hover {
-    text-decoration: none;
     color: $color-white;
+    text-decoration: none;
   }
 
   &:active {
@@ -114,18 +121,21 @@
 
   &:focus {
     @include focus-default;
+
     outline-color: $color-white;
   }
 }
 
 @mixin text_field {
-  border: 2px solid $color-dark-grey;
-  padding: $space-2;
-  margin-top: $space-2;
-  background-color: $color-white;
   width: 80%;
+  margin-top: $space-2;
+  padding: $space-2;
+
   font-family: $font-open-sans;
   font-size: $typography-md-text-size;
+
+  background-color: $color-white;
+  border: 2px solid $color-dark-grey;
 
   &:focus {
     @include focus-default;
@@ -133,18 +143,16 @@
 }
 
 @mixin select {
-  font-size: $typography-md-text-size;
-  color: #444;
-  line-height: $typography-md-line-height;
-  padding: $space-2;
+  box-sizing: border-box;
+  width: 80%;
   margin-top: $space-2;
   margin-bottom: $space-4;
-  width: 80%;
-  box-sizing: border-box;
-  border: 2px solid $color-dark-grey;
-  border-radius: 0;
-  -moz-appearance: none;
-  -webkit-appearance: none;
+  padding: $space-2;
+
+  font-size: $typography-md-text-size;
+  line-height: $typography-md-line-height;
+  color: #444;
+
   appearance: none;
   background-color: $color-white;
   background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E");
@@ -155,16 +163,21 @@
   background-size:
     0.65rem auto,
     100%;
+  border: 2px solid $color-dark-grey;
+  border-radius: 0;
 
   &::-ms-expand {
     display: none;
   }
+
   &:hover {
     border-color: #888;
   }
+
   &:focus {
     @include focus-default;
   }
+
   option {
     font-weight: $typography-normal-font-weight;
   }

--- a/ds_caselaw_editor_ui/sass/includes/_note.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_note.scss
@@ -1,7 +1,9 @@
 .note-form {
   &__label {
     display: block;
+
     margin-bottom: $space-1;
+
     font-size: $typography-sm-text-size;
     line-height: $typography-lg-line-height;
     color: $color-dark-grey;
@@ -9,12 +11,16 @@
 
   &__text-area {
     @include text_field;
-    margin-top: 0;
+
     display: block;
+
+    box-sizing: border-box;
     width: calc(100% - $space-4);
+    margin-top: 0;
+
     font-size: $typography-md-text-size;
     line-height: $typography-md-line-height;
+
     border: 2px solid $color-almost-black;
-    box-sizing: border-box;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_notification_message.scss
@@ -1,29 +1,33 @@
 @mixin notification {
-  color: $color-white;
   padding: $space-3 $space-5;
+  color: $color-white;
 }
 
 .page-notification {
   &--success {
     @include notification;
+
     background-color: $color-success;
 
     .container {
       display: flex;
-      align-items: center;
       gap: $space-2;
+      align-items: center;
     }
   }
 
   &--failure {
     @include notification;
+
     background-color: $color-failure;
   }
 
   &--info {
     @include notification;
-    background-color: $color-information;
+
     color: $color-almost-black;
+    background-color: $color-information;
+
     a {
       color: $color-dark-blue;
     }
@@ -31,8 +35,10 @@
 
   &--warning {
     @include notification;
-    background-color: $color-yellow;
+
     color: $color-almost-black;
+    background-color: $color-yellow;
+
     a {
       color: $color-dark-blue;
     }
@@ -42,23 +48,27 @@
 .inline-notification {
   &--success {
     @include notification;
+
     background-color: $color-success;
   }
 
   &--info {
     @include notification;
+
     color: $color-almost-black;
     background-color: $color-information;
   }
 
   &--failure {
     @include notification;
+
     background-color: $color-failure;
   }
 }
 
 @mixin context-notification {
   @include notification;
+
   display: inline-block;
   animation: context-notification 0.5s 1;
   animation-fill-mode: forwards;
@@ -69,6 +79,7 @@
   from {
     opacity: 1;
   }
+
   to {
     opacity: 0;
   }
@@ -77,11 +88,13 @@
 .context-notification {
   &--success {
     @include context-notification;
+
     background-color: $color-success;
   }
 
   &--failure {
     @include context-notification;
+
     background-color: $color-failure;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_pagination.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_pagination.scss
@@ -1,20 +1,21 @@
 .pagination {
-  background-color: $color-almost-black;
   margin-bottom: $space-8;
+  background-color: $color-almost-black;
 
   h3 {
     @include sr-only;
   }
 
   &__list {
-    text-align: center;
-    list-style-type: none;
-    padding-left: 0;
-    min-height: 3.125rem;
-
     display: flex;
     justify-content: start;
+
+    min-height: 3.125rem;
     margin-bottom: 0;
+    padding-left: 0;
+
+    text-align: center;
+    list-style-type: none;
 
     &-pages {
       padding: 0;
@@ -27,8 +28,8 @@
 
     &-divider {
       display: inline-block;
-      color: $color-white;
       width: 2rem;
+      color: $color-white;
     }
 
     &-item {
@@ -36,13 +37,13 @@
       min-height: 3.125rem;
 
       &:first-child {
-        margin-left: 0;
         margin-right: auto;
+        margin-left: 0;
       }
 
       &:last-child {
-        margin-left: auto;
         margin-right: 0;
+        margin-left: auto;
       }
     }
   }
@@ -53,11 +54,13 @@
     &-link,
     &-link-current {
       display: flex;
-      justify-content: center;
       align-items: center;
-      text-decoration: none;
+      justify-content: center;
+
       width: 3.125rem;
       height: 3.125rem;
+
+      text-decoration: none;
 
       > span {
         @include sr-only;
@@ -72,16 +75,16 @@
     &-chevron-next,
     &-chevron-previous {
       background-color: $color-grey;
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: 40%;
 
       &:hover,
       &:focus {
         @include focus-default;
+
         background-color: $color-dark-grey;
       }
-
-      background-repeat: no-repeat;
-      background-position: center;
-      background-size: 40%;
     }
 
     &-chevron-next {
@@ -99,15 +102,17 @@
       }
 
       &--disabled {
+        display: flex;
+        justify-content: center;
+
+        width: 3.125rem;
+        height: 100%;
+
         background-color: $color-grey;
         background-image: url($fa_chevron_right_disabled);
         background-repeat: no-repeat;
         background-position: center;
         background-size: 40%;
-        width: 3.125rem;
-        height: 100%;
-        display: flex;
-        justify-content: center;
 
         &:hover,
         &:focus {
@@ -137,15 +142,17 @@
       }
 
       &--disabled {
+        display: flex;
+        justify-content: center;
+
+        width: 3.125rem;
+        height: 100%;
+
         background-color: $color-grey;
         background-image: url($fa_chevron_left_disabled);
         background-repeat: no-repeat;
         background-position: center;
         background-size: 40%;
-        width: 3.125rem;
-        height: 100%;
-        display: flex;
-        justify-content: center;
 
         &:hover,
         &:focus {
@@ -185,9 +192,9 @@
     &-link-current:visited,
     &-link:hover,
     &-link:focus {
-      background-color: $color-white;
-      color: $color-black;
       font-weight: $typography-bold-font-weight;
+      color: $color-black;
+      background-color: $color-white;
       outline-color: $color-highlight-blue;
     }
   }

--- a/ds_caselaw_editor_ui/sass/includes/_result_controls.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_result_controls.scss
@@ -1,13 +1,14 @@
 .result-controls {
   &__order-by-label {
-    font-family: $font-roboto;
-    font-size: $typography-lg-text-size;
     display: block;
     margin-bottom: $space-4;
+    font-family: $font-roboto;
+    font-size: $typography-lg-text-size;
   }
 
   &__order-by {
     @include select;
+
     min-width: auto;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_results.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_results.scss
@@ -26,8 +26,8 @@
   }
 
   &__result-list-container {
-    grid-row: 1 / 2;
     grid-column: 1 / 2;
+    grid-row: 1 / 2;
     background-color: #fff;
 
     h2 {
@@ -36,9 +36,9 @@
   }
 
   &__results-intro {
+    margin: 0 0 $space-5;
     font-family: $font-roboto;
     font-size: $typography-xl-text-size;
-    margin: 0 0 $space-5;
   }
 
   &__filter-heading {
@@ -56,8 +56,8 @@
   }
 
   &__result-title {
-    font-size: $typography-lg-text-size;
     font-family: $font-roboto;
+    font-size: $typography-lg-text-size;
   }
 
   &__result-term-sr {
@@ -82,24 +82,24 @@
 
   &__result-term-matching {
     margin: $space-4 0 $space-2 0;
-    color: $color-dark-grey;
     font-size: $typography-sm-text-size;
+    color: $color-dark-grey;
   }
 
   fieldset {
-    border: none;
     padding: 0;
+    border: none;
   }
 
   legend {
-    font-weight: $typography-bold-font-weight;
     font-size: $typography-lg-text-size;
+    font-weight: $typography-bold-font-weight;
   }
 
   &__container-extend-search-option {
-    background-color: $color-light-grey;
-    padding: $space-4 $space-8;
     margin: $space-4 0;
+    padding: $space-4 $space-8;
+    background-color: $color-light-grey;
   }
 
   &__result-failed {

--- a/ds_caselaw_editor_ui/sass/includes/_results_search_component.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_results_search_component.scss
@@ -1,31 +1,36 @@
 .results-search-component {
-  background-color: $color-light-grey;
-  padding: $space-6 0 $space-8;
   margin: 0 0 $space-12;
+  padding: $space-6 0 $space-8;
+  background-color: $color-light-grey;
 
   &__container {
     @include container;
+
     text-align: center;
   }
 
   &__header {
-    font-size: $typography-xl-text-size;
-    line-height: $typography-xl-line-height;
     display: inline-block;
-    font-family: $font-roboto;
-    font-weight: $typography-normal-font-weight;
-    color: $color-almost-black;
+
     margin: 0;
+
+    font-family: $font-roboto;
+    font-size: $typography-xl-text-size;
+    font-weight: $typography-normal-font-weight;
+    line-height: $typography-xl-line-height;
+    color: $color-almost-black;
   }
 
   &__sub-header {
-    font-size: $typography-md-text-size;
-    line-height: $typography-3xl-line-height;
     display: inline-block;
-    font-family: $font-roboto;
-    font-weight: $typography-normal-font-weight;
-    color: $color-almost-black;
+
     margin: 0 $space-6;
+
+    font-family: $font-roboto;
+    font-size: $typography-md-text-size;
+    font-weight: $typography-normal-font-weight;
+    line-height: $typography-3xl-line-height;
+    color: $color-almost-black;
 
     &--sr-only {
       @include sr-only;
@@ -34,6 +39,7 @@
 
   &__full-text-panel {
     margin: $space-2 0 0;
+
     @media (min-width: $grid-breakpoint-medium) {
       padding: $space-1 $space-4;
     }
@@ -45,6 +51,7 @@
 
   &__full-text-input {
     @include text_field;
+
     width: 90%;
     min-height: $space-12;
 
@@ -59,8 +66,9 @@
 
   &__search-submit-button {
     @include call-to-action-button;
-    padding-left: $space-12;
+
     padding-right: $space-12;
+    padding-left: $space-12;
   }
 
   &__facet-outer-container {
@@ -86,21 +94,25 @@
   }
 
   &__fieldset {
-    border: 0;
-    padding: $space-8;
     margin: $space-1;
-    background: $color-yellow;
+    padding: $space-8;
+
     color: $color-black;
+
+    background: $color-yellow;
+    border: 0;
   }
 
   &__legend {
-    font-size: $typography-lg-text-size;
-    padding: $space-4;
-    text-align: center;
-    font-family: $font-roboto;
     float: left;
-    margin: 0 0 $space-2;
+
     width: 100%;
+    margin: 0 0 $space-2;
+    padding: $space-4;
+
+    font-family: $font-roboto;
+    font-size: $typography-lg-text-size;
+    text-align: center;
   }
 
   &__multi-fields-panel {
@@ -114,6 +126,7 @@
 
   &__name-input {
     @include text_field;
+
     width: 18rem;
   }
 
@@ -131,45 +144,50 @@
 
   &__date-input {
     @include text_field;
+
     margin-top: 0;
     padding: $space-2;
   }
 
   &__filter-submit-button {
     @include call-to-action-button;
+
     margin: 0 auto;
   }
 
   &__name-container {
-    border-left-width: 0.375rem;
-    padding: 0 $space-4;
     margin-bottom: $space-4;
+    padding: 0 $space-4;
+    border-left-width: 0.375rem;
   }
 
   &__limit-to-container {
-    border-left-width: 0.375rem;
-    padding: 0 $space-4;
     margin-bottom: $space-4;
+    padding: 0 $space-4;
+    border-left-width: 0.375rem;
   }
 
   &__removable-options {
-    font-size: $typography-sm-text-size;
-    padding: 0;
-    list-style-type: none;
     display: inline-block;
+    padding: 0;
+    font-size: $typography-sm-text-size;
+    list-style-type: none;
 
     li {
+      display: inline-block;
+
       margin: $space-1 $space-2;
       padding: 0 $space-3 0 $space-4;
-      display: inline-block;
-      background: $color-yellow;
+
       font-size: $typography-sm-text-size;
+
+      background: $color-yellow;
     }
   }
 
   &__removable-options-key {
-    font-weight: $typography-bold-font-weight;
     display: inline-block;
+    font-weight: $typography-bold-font-weight;
   }
 
   &__removable-options-value {
@@ -182,10 +200,12 @@
 
   &__removable-options-link {
     display: inline-block;
+
+    padding: $space-2;
+
+    font-size: $typography-sm-text-size;
     color: $color-black;
     text-decoration: none;
-    padding: $space-2;
-    font-size: $typography-sm-text-size;
 
     &::after {
       content: "x";
@@ -206,58 +226,63 @@
 .results {
   &-search-component {
     &__toggle-control {
-      border: none;
-      background-color: transparent;
-      font-size: $typography-md-text-size;
       position: relative;
-      padding: $space-2 0;
-      border-bottom: 0.125rem solid $color-yellow;
+
       display: block;
+
       margin: $space-6 auto 0;
+      padding: $space-2 0;
+
+      font-size: $typography-md-text-size;
       font-weight: $typography-bold-font-weight;
 
-      @media (min-width: $grid-breakpoint-medium) {
-        padding-right: $space-4;
-        padding-left: $space-8;
-      }
-
-      &:focus {
-        @include focus-default;
-        text-decoration: underline;
-      }
-
-      &:hover {
-        text-decoration: underline;
-        cursor: pointer;
-      }
+      background-color: transparent;
+      border: none;
+      border-bottom: 0.125rem solid $color-yellow;
 
       &::after {
         @media (min-width: $grid-breakpoint-medium) {
           content: "";
-          display: block;
+
           position: absolute;
           top: 0;
           bottom: 0;
+          left: 0.5rem;
+          transform: rotate(313deg);
+
+          display: block;
+
           width: 0.438rem;
           height: 0.438rem;
-          left: 0.5rem;
           margin: auto 0;
-          -webkit-transform: rotate(313deg);
-          -ms-transform: rotate(313deg);
-          transform: rotate(313deg);
+
           border: solid;
-          border-width: 0.125rem 0.125rem 0 0;
           border-color: $color-dark-grey;
+          border-width: 0.125rem 0.125rem 0 0;
         }
+      }
+
+      &:focus {
+        @include focus-default;
+
+        text-decoration: underline;
+      }
+
+      &:hover {
+        cursor: pointer;
+        text-decoration: underline;
       }
 
       &.collapsed {
         &::after {
-          -webkit-transform: rotate(135deg);
-          -ms-transform: rotate(135deg);
-          transform: rotate(135deg);
           top: 0;
+          transform: rotate(135deg);
         }
+      }
+
+      @media (min-width: $grid-breakpoint-medium) {
+        padding-right: $space-4;
+        padding-left: $space-8;
       }
     }
   }

--- a/ds_caselaw_editor_ui/sass/includes/_spacing.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_spacing.scss
@@ -20,6 +20,7 @@
     padding-bottom: $space-4 * $i;
   }
 }
+
 .p-1 {
   padding: $space-1;
 }

--- a/ds_caselaw_editor_ui/sass/includes/_standard-text-template.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_standard-text-template.scss
@@ -1,8 +1,9 @@
 .standard-text-template {
   @include container;
+
+  min-height: 40rem;
   margin-top: $space-20;
   margin-bottom: $space-32;
-  min-height: 40rem;
 
   h1,
   h2,
@@ -12,20 +13,20 @@
   }
 
   h1 {
-    font-size: $typography-2xl-text-size;
     margin: 0 0 $space-8;
+    font-size: $typography-2xl-text-size;
   }
 
   h2 {
-    font-size: $typography-xl-text-size;
     margin: 0 0 $space-5;
     padding: $space-8 0 0;
+    font-size: $typography-xl-text-size;
   }
 
   h3 {
-    font-size: $typography-lg-text-size;
     margin: 0 0 $space-5;
     padding: $space-5 0 0;
+    font-size: $typography-lg-text-size;
   }
 
   p {

--- a/ds_caselaw_editor_ui/sass/includes/_sticky_menu.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_sticky_menu.scss
@@ -1,6 +1,6 @@
 .sticky-menu {
   position: sticky;
   top: 0;
-  max-height: 100vh;
   overflow-y: scroll;
+  max-height: 100vh;
 }

--- a/ds_caselaw_editor_ui/sass/includes/_structured_search.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_structured_search.scss
@@ -1,19 +1,21 @@
 .structured-search {
   &__main-search {
-    background-color: $color-light-grey;
-    padding: $space-6 0 $space-8;
     margin: 0 0 $space-12;
+    padding: $space-6 0 $space-8;
     text-align: center;
+    background-color: $color-light-grey;
   }
 
   &__main-search-header {
-    font-size: $typography-2xl-text-size;
-    line-height: $typography-xs-line-height;
     display: inline-block;
-    font-family: $font-roboto;
-    font-weight: $typography-normal-font-weight;
-    color: $color-almost-black;
+
     margin: $space-12 0 0 0;
+
+    font-family: $font-roboto;
+    font-size: $typography-2xl-text-size;
+    font-weight: $typography-normal-font-weight;
+    line-height: $typography-xs-line-height;
+    color: $color-almost-black;
   }
 
   &__container {
@@ -23,6 +25,7 @@
   &__full-text-panel {
     margin-top: $space-4;
     margin-bottom: $space-4;
+
     @media (min-width: $grid-breakpoint-medium) {
       padding: $space-6 $space-8;
     }
@@ -34,6 +37,7 @@
 
   &__full-text-input {
     @include text_field;
+
     width: 70%;
 
     @media (min-width: $grid-breakpoint-medium) {
@@ -59,6 +63,7 @@
 
   &__name-input {
     @include text_field;
+
     width: 70%;
   }
 
@@ -73,9 +78,9 @@
   }
 
   &__multi-fields-panel {
-    padding-top: $space-4;
     margin-top: $space-4;
     margin-bottom: $space-4;
+    padding-top: $space-4;
 
     @media (min-width: $grid-breakpoint-medium) {
       display: grid;
@@ -86,23 +91,27 @@
   }
 
   &__name-container {
-    background-color: $color-yellow;
-    padding: $space-8 $space-12;
-    margin-bottom: $space-4;
-    min-height: 10rem;
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;
+
+    min-height: 10rem;
+    margin-bottom: $space-4;
+    padding: $space-8 $space-12;
+
+    background-color: $color-yellow;
   }
 
   &__limit-to-container {
-    background-color: $color-yellow;
-    padding: $space-8 $space-12;
-    margin-bottom: $space-4;
-    min-height: 10rem;
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;
+
+    min-height: 10rem;
+    margin-bottom: $space-4;
+    padding: $space-8 $space-12;
+
+    background-color: $color-yellow;
   }
 
   &__submit-container {
@@ -122,13 +131,14 @@
   }
 
   fieldset {
-    border: none;
-    padding: 0;
     margin-top: $space-4;
+    padding: 0;
+    border: none;
   }
 
   input[type="submit"] {
     @include call-to-action-button;
+
     padding-right: $space-12;
     padding-left: $space-12;
   }

--- a/ds_caselaw_editor_ui/sass/includes/_style_guide.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_style_guide.scss
@@ -33,20 +33,20 @@
   }
 
   hr {
-    margin: $space-12 0;
     height: 1rem;
+    margin: $space-12 0;
     background-color: $color-light-grey;
     border: none;
   }
 
   &__spacing-container {
-    background: $color-light-pink;
     margin-bottom: $space-4;
+    background: $color-light-pink;
   }
 
   &__spacing-item {
-    background: $color-white;
     text-align: center;
+    background: $color-white;
   }
 
   &__line-heights {

--- a/ds_caselaw_editor_ui/sass/includes/_summary-panels.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_summary-panels.scss
@@ -1,16 +1,20 @@
 .summary-panel {
-  border-width: 0px;
   position: relative;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   width: 391px;
   height: 139px;
-  background-color: #f2f2f2;
-  border: none;
-  border-radius: 10px;
+
   font-size: $typography-lg-text-size;
   text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+
+  background-color: #f2f2f2;
+  border: none;
+  border-width: 0;
+  border-radius: 10px;
 
   &:hover {
     background-color: #d7d7d7;
@@ -21,21 +25,22 @@
     background-color: #ffb952;
   }
 
-  @media screen and (max-device-width: 480px) {
-    width: 266px;
-    height: 95px;
-  }
-
   &__number {
     font-size: $typography-2xl-text-size;
     text-align: left;
   }
 
   &__text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
     font-size: $typography-lg-text-size;
     text-align: center;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  }
+
+  @media screen and (device-width <= 480px) {
+    width: 266px;
+    height: 95px;
   }
 }

--- a/ds_caselaw_editor_ui/sass/includes/_tabs.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_tabs.scss
@@ -1,7 +1,7 @@
 .tabs-set {
   width: 100%;
-  padding: $space-6 0 0;
   margin: auto;
+  padding: $space-6 0 0;
   text-align: center;
 
   &.tabs-set--primary {
@@ -16,23 +16,30 @@
     margin: 0 $space-1;
 
     label {
-      background: $color-aqua-blue;
       padding-top: $space-3;
+
+      font-family: "Open Sans", sans-serif;
+      font-size: $typography-md-text-size;
+      font-weight: $typography-bold-font-weight;
+      color: $color-white;
+
+      background: $color-aqua-blue;
       border: 2px solid $color-aqua-blue;
       border-bottom: none;
       border-top-left-radius: 10px;
       border-top-right-radius: 10px;
-      color: $color-white;
-      font-family: "Open Sans", sans-serif;
-      font-weight: $typography-bold-font-weight;
-      font-size: $typography-md-text-size;
+
       a {
-        padding: $space-3 $space-8 0 $space-8;
         position: relative;
         top: -0.33rem;
+
         display: inline-block;
-        text-decoration: none;
+
+        padding: $space-3 $space-8 0 $space-8;
+
         color: $color-white;
+        text-decoration: none;
+
         &:focus {
           outline-offset: 5px;
         }
@@ -54,11 +61,12 @@
     }
 
     input[type="radio"]:checked ~ label {
-      border-bottom: 2px solid $color-white;
       background: $color-white;
+      border-bottom: 2px solid $color-white;
+
       a {
-        color: $color-aqua-blue;
         cursor: default;
+        color: $color-aqua-blue;
       }
     }
   }

--- a/ds_caselaw_editor_ui/sass/includes/_variables.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_variables.scss
@@ -7,7 +7,6 @@ $colour-published: #bfe3e0;
 $colour-in-progress-text: #3d2375;
 $colour-on-hold-text: #942514;
 $colour-published-text: #10403c;
-
 $space-1: 0.25rem;
 $space-2: 0.5rem;
 $space-3: 0.75rem;
@@ -24,27 +23,22 @@ $space-20: 5rem;
 $space-24: 6rem;
 $space-28: 7rem;
 $space-32: 8rem;
-
 $gutter_unit: 25px;
-
 $grid-breakpoint-small: 576px;
 $grid-breakpoint-medium: 768px;
 $grid-breakpoint-large: 992px;
 $grid-breakpoint-extra-large: 1200px;
-
 $font-roboto: "Roboto", sans-serif;
 $font-open-sans: "Open Sans", sans-serif;
 $font-serif: serif;
 $typography-display-font-family: $font-roboto;
 $typography-body-font-family: $font-open-sans;
-
 $typography-xs-text-size: 0.7rem;
 $typography-sm-text-size: 0.9rem;
 $typography-md-text-size: 1.1rem;
 $typography-lg-text-size: 1.3rem;
 $typography-xl-text-size: 2rem;
 $typography-2xl-text-size: 2.4rem;
-
 $typography-xs-line-height: 0.8;
 $typography-sm-line-height: 1;
 $typography-md-line-height: 1.2;
@@ -52,7 +46,6 @@ $typography-lg-line-height: 1.5;
 $typography-xl-line-height: 1.8;
 $typography-2xl-line-height: 2;
 $typography-3xl-line-height: 2.6;
-
 $typography-normal-font-weight: 400;
 $typography-bold-font-weight: 700;
 

--- a/ds_caselaw_editor_ui/sass/includes/components/_judgment_status_indicator.scss
+++ b/ds_caselaw_editor_ui/sass/includes/components/_judgment_status_indicator.scss
@@ -1,21 +1,20 @@
 .judgment-status-indicator {
-  border: 3px solid $color-white;
   display: inline-block;
 
   padding: $space-1 $space-2;
 
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-
   color: $color-white;
-  background-color: $color-dark-blue;
-
   text-decoration: none;
   text-transform: capitalize;
 
+  background-color: $color-dark-blue;
+  border: 3px solid $color-white;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+
   &--compact {
-    border: 0;
     padding: 0 $space-1;
+    border: 0;
   }
 
   &--new,

--- a/ds_caselaw_editor_ui/sass/includes/cookie_consent/ds-cookie-consent.scss
+++ b/ds_caselaw_editor_ui/sass/includes/cookie_consent/ds-cookie-consent.scss
@@ -1,17 +1,19 @@
 #ds-cookie-consent-form {
   input[type="radio"] {
     margin-right: $space-2;
+
     + label {
       cursor: pointer;
-      @media only screen and (max-width: 818px) {
+
+      @media only screen and (width <= 818px) {
         display: inline;
       }
     }
   }
 
   #form_submit:focus {
-    background-color: #fff;
     color: #26262a;
+    background-color: #fff;
   }
 
   .form-group {
@@ -24,46 +26,50 @@
 }
 
 #ds-cookie-consent-banner {
-  z-index: 999;
-  padding: $space-2 $space-2 $space-4 $space-2;
   position: fixed;
+  z-index: 999;
+  bottom: 0;
+
   display: block;
-  bottom: 0px;
-  font-size: $typography-sm-text-size;
+
   width: 100%;
+  padding: $space-2 $space-2 $space-4 $space-2;
+
+  font-size: $typography-sm-text-size;
   color: #fff;
 
   .container {
-    background: #134571;
-    padding: $space-2 $space-5 $space-5 $space-8;
     box-sizing: border-box;
+    padding: $space-2 $space-5 $space-5 $space-8;
+    background: #134571;
     border-radius: 5px;
 
     .cookie_head {
-      font-family: "Roboto Mono";
-      font-style: normal;
-      font-weight: $typography-normal-font-weight;
-      font-size: $typography-lg-text-size;
-      line-height: inherit;
-      color: #ffffff;
       margin-top: $space-2;
       margin-bottom: 0;
+
+      font-family: "Roboto Mono";
+      font-size: $typography-lg-text-size;
+      font-weight: $typography-normal-font-weight;
+      font-style: normal;
+      line-height: inherit;
+      color: #fff;
     }
 
     .cookie-p {
+      margin-top: $space-2;
+      margin-bottom: $space-3;
+
       font-family: "Open Sans";
       font-size: $typography-md-text-size;
       line-height: inherit;
-      color: #ffffff;
-      margin-bottom: $space-3;
-      margin-top: $space-2;
+      color: #fff;
 
       br {
         content: "";
         display: block;
-        font-size: 100%;
         height: 0.25em;
-        display: block;
+        font-size: 100%;
       }
 
       a {
@@ -71,11 +77,13 @@
         text-decoration: underline;
 
         &:hover {
-          color: #000;
-          outline-offset: 0;
           z-index: 999;
+
+          color: #000;
+
           background-color: #fff;
           outline: 5px solid #1d70b8;
+          outline-offset: 0;
         }
 
         &:focus {
@@ -87,22 +95,25 @@
     #hide_this_message,
     #reject_optional_cookies,
     #accept_optional_cookies {
-      background: #eee;
-      color: #000;
-      border: #eee;
-      text-decoration: none;
-      margin-right: $space-4;
-      border: 2px solid #fff;
-      font-family: "Roboto Mono", monospace;
-      padding: $space-2 $space-4;
       display: inline-block;
+
       min-width: 24px;
+      margin-right: $space-4;
+      padding: $space-2 $space-4;
+
+      font-family: "Roboto Mono", monospace;
+      color: #000;
       text-align: center;
+      text-decoration: none;
+
+      background: #eee;
+      border: #eee;
+      border: 2px solid #fff;
 
       &:hover,
       &:focus {
-        background: #000;
         color: #fff;
+        background: #000;
         border: 2px solid #fff;
       }
 
@@ -110,24 +121,24 @@
         outline: 5px solid #fff;
       }
 
-      @media (max-width: 560px) {
+      @media (width <= 560px) {
         display: block;
-        margin-bottom: $space-3;
         width: 100%;
+        margin-bottom: $space-3;
       }
     }
 
     #btn_preferences {
+      text-decoration: underline;
       background: none;
       border: none;
       border: 2px solid transparent;
-      text-decoration: underline;
 
       &:hover,
       &:focus {
-        background: #000;
         color: #fff;
         text-decoration: none;
+        background: #000;
         border: 2px solid #fff;
       }
 
@@ -135,23 +146,23 @@
         outline: 5px solid #fff;
       }
 
-      @media (max-width: 675px) {
+      @media (width <= 675px) {
         margin-top: $space-1;
       }
 
-      @media (max-width: 560px) {
+      @media (width <= 560px) {
         display: block;
       }
     }
 
-    @media (max-width: 560px) {
+    @media (width <= 560px) {
       padding: $space-2 $space-6 $space-5 $space-6;
     }
   }
 }
 
 .cookie-consent-table {
-  @media only screen and (max-width: 768px) {
+  @media only screen and (width <= 768px) {
     tr {
       td:first-of-type {
         word-break: break-all;
@@ -164,6 +175,7 @@
   .jsON {
     display: none;
   }
+
   .jsOFF {
     display: block;
   }

--- a/ds_caselaw_editor_ui/static/sass/project.scss
+++ b/ds_caselaw_editor_ui/static/sass/project.scss
@@ -21,13 +21,13 @@ $red: #b94a48;
 // debug, info, success, warning, error
 
 .alert-debug {
+  color: $black;
   background-color: $white;
   border-color: $mint-green;
-  color: $black;
 }
 
 .alert-error {
+  color: $red;
   background-color: $pink;
   border-color: $dark-pink;
-  color: $red;
 }


### PR DESCRIPTION
Run most automated style fixes on our SCSS via stylelint, so that we can move closer to running a full test on every PR instead of just against changed files.