### PR TITLE
Bump API to 28.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ xmltodict~=0.14.1
 requests-toolbelt~=1.0.0
 lxml~=5.3.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=28.1.0
+ds-caselaw-marklogic-api-client~=28.2.0
 ds-caselaw-utils~=2.0.1
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
Upgrade [API client to 28.2](https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases/tag/v28.2.0) to get the IdentifierSchema for creating SQID-based Find Case Law Identifiers 