### PR TITLE
Remove extra dash from max-requests option

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -7,4 +7,4 @@ set -o nounset
 npm run build
 python /app/manage.py collectstatic --noinput
 cd /app
-/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s" "%({cloudfront-viewer-address}i)s" "%({x-amz-cf-id}i)s" "%({x-amzn-trace-id}i)s"' ---max-requests 500 --max-requests-jitter 50
+/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s" "%({cloudfront-viewer-address}i)s" "%({x-amz-cf-id}i)s" "%({x-amzn-trace-id}i)s"' --max-requests 500 --max-requests-jitter 50


### PR DESCRIPTION
The extra dash in the max-requests option was causing the gunicorn to die on
startup