### PR TITLE
Remove AWS IAM user credentials for cache invalidation, rely on container's role

### DIFF
--- a/judgments/tests/test_document_edit.py
+++ b/judgments/tests/test_document_edit.py
@@ -25,7 +25,8 @@ class TestDocumentEdit(TestCase):
 
     @patch("judgments.views.judgment_edit.api_client")
     @patch("judgments.views.judgment_edit.get_document_by_uri_or_404")
-    def test_edit_judgment(self, mock_judgment, api_client):
+    @patch("judgments.utils.aws.boto3")
+    def test_edit_judgment(self, mock_boto, mock_judgment, api_client):
         judgment = JudgmentFactory.build(
             uri=DocumentURIString("edittest/4321/123"),
             name="Test v Tested",

--- a/judgments/utils/aws.py
+++ b/judgments/utils/aws.py
@@ -1,4 +1,3 @@
-import logging
 import time
 
 import boto3
@@ -46,22 +45,7 @@ def generate_signed_asset_url(key: str):
 
 
 def invalidate_caches(uri: str) -> None:
-    if (
-        env("CLOUDFRONT_INVALIDATION_ACCESS_KEY_ID", default=None) is None
-        and env("CLOUDFRONT_INVALIDATION_ACCESS_SECRET", default=None) is None
-    ):
-        logging.warning(
-            "Cannot invalidate cache: no cloudfront environment variables set",
-        )
-        return
-
-    aws = boto3.session.Session(
-        aws_access_key_id=env("CLOUDFRONT_INVALIDATION_ACCESS_KEY_ID", default=None),
-        aws_secret_access_key=env(
-            "CLOUDFRONT_INVALIDATION_ACCESS_SECRET",
-            default=None,
-        ),
-    )
+    aws = boto3.session.Session()
     cloudfront = aws.client("cloudfront")
     cloudfront.create_invalidation(
         DistributionId=env("CLOUDFRONT_PUBLIC_DISTRIBUTION_ID", default=None),


### PR DESCRIPTION
https://national-archives.atlassian.net/issues/FCL-509