### PR TITLE
Use upstream latest-tag because dxw fork is outdated and archived.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run latest-tag
-        uses: dxw/latest-tag@force-branch
+        uses: EndBug/latest-tag@latest
         with:
           tag-name: production
           force-branch: true


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
