### PR TITLE
[FCL-625] Update Jira link generator with better identifier handling

### DIFF
--- a/ds_caselaw_editor_ui/templates/emails/jira_ticket_body.txt
+++ b/ds_caselaw_editor_ui/templates/emails/jira_ticket_body.txt
@@ -1,0 +1,9 @@
+EUI link: {{editor_link}}
+
+Identifiers:{% for identifier in identifiers %}
+    {{identifier.schema.name}}: {{identifier.value}}{% empty %}
+    None{% endfor %}
+
+{{source_name_label}}: {{source_name}}
+{{source_email_label}}: {{source_email}}
+{{consignment_ref_label}}: {{consignment_ref}}


### PR DESCRIPTION
This puts the best human identifier (where present) in the Jira summary field, and expands the description to include all identifiers which are known.