### PR TITLE
[FCL-626] Reinstate updating a document URI on NCN update

### DIFF
--- a/judgments/tests/test_document_edit.py
+++ b/judgments/tests/test_document_edit.py
@@ -1,16 +1,23 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from caselawclient.factories import JudgmentFactory
+from caselawclient.factories import JudgmentFactory, PressSummaryFactory
 from caselawclient.identifier_resolution import IdentifierResolution, IdentifierResolutions
 from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
 from caselawclient.xquery_type_dicts import MarkLogicDocumentURIString
 from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
 from django.test import TestCase
 from django.urls import reverse
 
-from judgments.views.judgment_edit import StubAlreadyUsedError, verify_stub_not_used
+from judgments.views.judgment_edit import (
+    CannotUpdateNCNOfNonJudgment,
+    NeutralCitationToUriError,
+    StubAlreadyUsedError,
+    update_ncn_of_document,
+    verify_stub_not_used,
+)
 
 
 class TestDocumentEdit(TestCase):
@@ -26,13 +33,13 @@ class TestDocumentEdit(TestCase):
     @patch("judgments.views.judgment_edit.api_client")
     @patch("judgments.views.judgment_edit.get_document_by_uri_or_404")
     @patch("judgments.utils.aws.boto3")
-    def test_edit_judgment(self, mock_boto, mock_judgment, api_client):
+    def test_edit_judgment_no_ncn_change(self, mock_boto, mock_judgment, api_client):
         judgment = JudgmentFactory.build(
             uri=DocumentURIString("edittest/4321/123"),
             name="Test v Tested",
         )
-        judgment.save_identifiers = Mock()  # type:ignore[method-assign]
-        judgment.identifiers = Mock()
+
+        judgment.identifiers.add(NeutralCitationNumber("[4321] UKSC 123"))
         mock_judgment.return_value = judgment
 
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])
@@ -53,10 +60,6 @@ class TestDocumentEdit(TestCase):
             "/edittest/4321/123",
             "New Name",
         )
-        api_client.set_judgment_citation.assert_called_with(
-            "/edittest/4321/123",
-            "[4321] UKSC 123",
-        )
         api_client.set_document_court_and_jurisdiction.assert_called_with(
             "/edittest/4321/123",
             "Court of Testing",
@@ -65,9 +68,33 @@ class TestDocumentEdit(TestCase):
             "/edittest/4321/123",
             "2023-01-02",
         )
-        assert "NeutralCitationNumber" in str(judgment.identifiers.delete_type.call_args_list[0][0])
-        assert "<Neutral Citation Number [4321] UKSC 123:" in str(judgment.identifiers.add.call_args_list[0][0])
-        judgment.save_identifiers.assert_called_once_with()
+
+    @patch("judgments.views.judgment_edit.update_ncn_of_document")
+    @patch("judgments.views.judgment_edit.api_client")
+    @patch("judgments.views.judgment_edit.get_document_by_uri_or_404")
+    @patch("judgments.utils.aws.boto3")
+    def test_edit_judgment_ncn_change(self, mock_boto, mock_judgment, api_client, mock_update_ncn_of_document):
+        judgment = JudgmentFactory.build(
+            uri=DocumentURIString("uksc/4321/123"),
+            name="Test v Tested",
+        )
+        judgment.identifiers.add(NeutralCitationNumber("[4321] UKSC 123"))
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+        User.objects.get_or_create(username="testuser2")
+
+        self.client.post(
+            "/uksc/4321/123/edit",
+            {
+                "judgment_uri": "/uksc/4321/123",
+                "metadata_name": "New Name",
+                "neutral_citation": "[2023] EWCC 456",
+                "court": "Court of Testing",
+                "judgment_date": "2 Jan 2023",
+            },
+        )
+        mock_update_ncn_of_document.assert_called_once_with(judgment, "[2023] EWCC 456")
 
     @patch("judgments.views.judgment_edit.api_client")
     @patch("judgments.views.judgment_edit.get_document_by_uri_or_404")
@@ -76,6 +103,7 @@ class TestDocumentEdit(TestCase):
             uri=DocumentURIString("edittest/4321/123"),
             name="Test v Tested",
         )
+        judgment.identifiers.add(NeutralCitationNumber("[4321] UKSC 123"))
         mock_judgment.return_value = judgment
 
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])
@@ -99,7 +127,107 @@ class TestDocumentEdit(TestCase):
 @patch("judgments.views.judgment_edit.api_client")
 def test_verify_stub_not_used_no_values(api_client):
     api_client.resolve_from_identifer.return_value = []
-    verify_stub_not_used("/uksc/2024/999", "[1701] UKSC 999")
+    verify_stub_not_used(DocumentURIString("uksc/2024/999"), "[1701] UKSC 999")
+
+
+class TestUpdateNCNOfDocument(TestCase):
+    @patch("judgments.views.judgment_edit.api_client")
+    @patch("judgments.views.judgment_edit.verify_stub_not_used")
+    @patch("judgments.views.judgment_edit.update_document_uri")
+    def test_update_ncn_of_document_where_change_is_valid(
+        self,
+        mock_update_document_uri,
+        mock_verify_stub_not_used,
+        api_client,
+    ):
+        document = JudgmentFactory.build(
+            uri=DocumentURIString("uksc/4321/123"),
+            name="Test v Tested",
+        )
+        document.save_identifiers = Mock()  # type:ignore[method-assign]
+        document.identifiers = Mock()
+
+        update_ncn_of_document(document, "[2025] EWCC 456")
+
+        mock_verify_stub_not_used.assert_called_once_with("uksc/4321/123", "[2025] EWCC 456")
+
+        document.identifiers.delete_type.assert_called_once_with(NeutralCitationNumber)
+        document.identifiers.add.assert_called_once()
+        document.save_identifiers.assert_called_once()
+        api_client.set_judgment_citation.assert_called_once_with("uksc/4321/123", "[2025] EWCC 456")
+        mock_update_document_uri.assert_called_once_with("uksc/4321/123", "ewcc/2025/456")
+
+    @patch("judgments.views.judgment_edit.api_client")
+    @patch("judgments.views.judgment_edit.verify_stub_not_used")
+    @patch("judgments.views.judgment_edit.update_document_uri")
+    def test_update_ncn_of_document_rejects_non_judgment(
+        self,
+        mock_update_document_uri,
+        mock_verify_stub_not_used,
+        api_client,
+    ):
+        document = PressSummaryFactory.build(
+            uri=DocumentURIString("uksc/4321/123"),
+            name="Test v Tested",
+        )
+        document.save_identifiers = Mock()  # type:ignore[method-assign]
+        document.identifiers.add(NeutralCitationNumber("[2023] UKSC 123"))
+
+        with pytest.raises(CannotUpdateNCNOfNonJudgment):
+            update_ncn_of_document(document, "[2025] EWCC 456")
+
+        mock_verify_stub_not_used.assert_not_called()
+        document.save_identifiers.assert_not_called()
+        api_client.set_judgment_citation.assert_not_called()
+        mock_update_document_uri.assert_not_called()
+
+    @patch("judgments.views.judgment_edit.api_client")
+    @patch("judgments.views.judgment_edit.verify_stub_not_used")
+    @patch("judgments.views.judgment_edit.update_document_uri")
+    def test_update_ncn_of_document_rejects_malformed_ncn(
+        self,
+        mock_update_document_uri,
+        mock_verify_stub_not_used,
+        api_client,
+    ):
+        document = JudgmentFactory.build(
+            uri=DocumentURIString("uksc/4321/123"),
+            name="Test v Tested",
+        )
+        document.save_identifiers = Mock()  # type:ignore[method-assign]
+        document.identifiers.add(NeutralCitationNumber("[2023] UKSC 123"))
+
+        with pytest.raises(NeutralCitationToUriError):
+            update_ncn_of_document(document, "TEST-123")
+
+        mock_verify_stub_not_used.assert_not_called()
+        document.save_identifiers.assert_not_called()
+        api_client.set_judgment_citation.assert_not_called()
+        mock_update_document_uri.assert_not_called()
+
+    @patch("judgments.views.judgment_edit.api_client")
+    @patch("judgments.views.judgment_edit.verify_stub_not_used")
+    @patch("judgments.views.judgment_edit.update_document_uri")
+    def test_update_ncn_of_document_rejects_plausible_but_invalid_ncn(
+        self,
+        mock_update_document_uri,
+        mock_verify_stub_not_used,
+        api_client,
+    ):
+        document = JudgmentFactory.build(
+            uri=DocumentURIString("uksc/4321/123"),
+            name="Test v Tested",
+        )
+        document.save_identifiers = Mock()  # type:ignore[method-assign]
+        document.identifiers.add(NeutralCitationNumber("[2023] UKSC 123"))
+
+        with pytest.raises(NeutralCitationToUriError):
+            update_ncn_of_document(document, "[2023] UKSC 123 (Fam)")
+
+        mock_verify_stub_not_used.assert_not_called()
+        document.save_identifiers.assert_not_called()
+        api_client.set_judgment_citation.assert_not_called()
+        mock_update_document_uri.assert_not_called()
 
 
 @patch("judgments.views.judgment_edit.api_client")
@@ -122,10 +250,10 @@ def test_verify_stub_not_used_with_values(api_client):
     )
 
     # If all Resolutions match either the old or new URI, that's fine
-    verify_stub_not_used("uksc/2024/999", "[1701] UKSC 999")
+    verify_stub_not_used(DocumentURIString("uksc/2024/999"), "[1701] UKSC 999")
 
     # but it's not OK if there's one left over which doesn't match
     with pytest.raises(StubAlreadyUsedError):
-        verify_stub_not_used("uksc/2024/999", "[2024] UKSC 999")
+        verify_stub_not_used(DocumentURIString("uksc/2024/999"), "[2024] UKSC 999")
     with pytest.raises(StubAlreadyUsedError):
-        verify_stub_not_used("uksc/1701/999", "[1701] UKSC 999")
+        verify_stub_not_used(DocumentURIString("uksc/1701/999"), "[1701] UKSC 999")

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -9,10 +9,9 @@ from urllib.parse import urlparse
 from caselawclient.Client import DEFAULT_USER_AGENT, MarklogicApiClient, MarklogicAPIError
 from caselawclient.models.documents import DocumentURIString
 from caselawclient.models.press_summaries import PressSummary
+from caselawclient.models.utilities.aws import copy_assets
 from django.conf import settings
 from django.contrib.auth.models import Group, User
-
-from .aws import copy_assets
 
 api_client = MarklogicApiClient(
     host=settings.MARKLOGIC_HOST,

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -6,14 +6,13 @@ from operator import itemgetter
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from caselawclient.Client import (
-    DEFAULT_USER_AGENT,
-    MarklogicApiClient,
-)
+from caselawclient.Client import DEFAULT_USER_AGENT, MarklogicApiClient, MarklogicAPIError
 from caselawclient.models.documents import DocumentURIString
 from caselawclient.models.press_summaries import PressSummary
 from django.conf import settings
 from django.contrib.auth.models import Group, User
+
+from .aws import copy_assets
 
 api_client = MarklogicApiClient(
     host=settings.MARKLOGIC_HOST,
@@ -34,10 +33,6 @@ uk_namespace = {"uk": "https://caselaw.nationalarchives.gov.uk/akn"}
 
 
 class MoveJudgmentError(Exception):
-    pass
-
-
-class NeutralCitationToUriError(Exception):
     pass
 
 
@@ -66,6 +61,40 @@ def format_date(date):
 
     time = datetime.strptime(date, "%Y-%m-%d")
     return time.strftime("%d-%m-%Y")
+
+
+def update_document_uri(old_uri: DocumentURIString, new_uri: DocumentURIString):
+    """
+    Move the document at old_uri to the correct location based on the neutral citation
+    The new neutral citation *must* not already exist (that is handled elsewhere)
+    """
+
+    if api_client.document_exists(new_uri):
+        msg = f"The URI {new_uri} already exists, you cannot move this document to a pre-existing Neutral Citation Number."
+        raise MoveJudgmentError(
+            msg,
+        )
+
+    try:
+        api_client.copy_document(old_uri, new_uri)
+        set_metadata(old_uri, new_uri)
+        copy_assets(old_uri, new_uri)
+        api_client.set_judgment_this_uri(new_uri)
+    except MarklogicAPIError as e:
+        msg = f"Failure when attempting to copy document from {old_uri} to {new_uri}: {e}"
+        raise MoveJudgmentError(
+            msg,
+        ) from e
+
+    try:
+        api_client.delete_judgment(old_uri)
+    except MarklogicAPIError as e:
+        msg = f"Failure when attempting to delete document from {old_uri}: {e}"
+        raise MoveJudgmentError(
+            msg,
+        ) from e
+
+    return new_uri
 
 
 def set_metadata(old_uri, new_uri):

--- a/judgments/utils/aws.py
+++ b/judgments/utils/aws.py
@@ -1,73 +1,9 @@
 import time
 
 import boto3
-import botocore.client
 import environ
 
 env = environ.Env()
-
-
-def copy_assets(old_uri, new_uri):
-    client = create_s3_client()
-    bucket = env("PRIVATE_ASSET_BUCKET")
-    old_uri = uri_for_s3(old_uri)
-    new_uri = uri_for_s3(new_uri)
-
-    response = client.list_objects(Bucket=bucket, Prefix=old_uri)
-
-    for result in response.get("Contents", []):
-        old_key = str(result["Key"])
-        new_key = build_new_key(old_key, new_uri)
-        if new_key is not None:
-            source = {"Bucket": bucket, "Key": old_key}
-            client.copy(source, bucket, new_key)
-
-
-def build_new_key(old_key, new_uri):
-    old_filename = old_key.rsplit("/", 1)[-1]
-
-    if old_filename.endswith((".docx", ".pdf")):
-        new_filename = new_uri.replace("/", "_")
-        return f"{new_uri}/{new_filename}.{old_filename.split('.')[-1]}"
-    else:
-        return f"{new_uri}/{old_filename}"
-
-
-def create_aws_client(service: str):  # service
-    """@param: service The AWS service, e.g. 's3'"""
-    aws = boto3.session.Session(
-        aws_access_key_id=env("AWS_ACCESS_KEY_ID", default=None),
-        aws_secret_access_key=env("AWS_SECRET_KEY", default=None),
-    )
-    return aws.client(
-        service,
-        endpoint_url=env("AWS_ENDPOINT_URL", default=None),
-        region_name=env("PRIVATE_ASSET_BUCKET_REGION", default=None),
-        config=botocore.client.Config(signature_version="s3v4"),
-    )
-
-
-def create_s3_client():
-    return create_aws_client("s3")
-
-
-def uri_for_s3(uri: str):
-    return uri.lstrip("/")
-
-
-def generate_signed_asset_url(key: str):
-    # If there isn't a PRIVATE_ASSET_BUCKET, don't try to get the bucket.
-    # This helps local environment setup where we don't use S3.
-    bucket = env("PRIVATE_ASSET_BUCKET", None)
-    if not bucket:
-        return ""
-
-    client = create_s3_client()
-
-    return client.generate_presigned_url(
-        "get_object",
-        Params={"Bucket": bucket, "Key": key},
-    )
 
 
 def invalidate_caches(uri: str) -> None:

--- a/judgments/views/signed_asset.py
+++ b/judgments/views/signed_asset.py
@@ -1,6 +1,5 @@
+from caselawclient.models.utilities.aws import generate_signed_asset_url
 from django.shortcuts import redirect
-
-from judgments.utils.aws import generate_signed_asset_url
 
 
 def redirect_to_signed_asset(request, key):


### PR DESCRIPTION
We haven't yet implemented the ingester change to provide UUID-based document URIs, but editors are still receiving documents at `/failure` URIs. Since the new code won't change these (by design), we need to temporarily reinstate the functions which update the URI when the NCN changes.

As part of this we refactor out the logic in `EditJudgmentView.post` which processes the actual change into a new `update_ncn_of_document` method.