### PR TITLE
Explicit 404 for favicon.ico rather than 500ing due to invalid NCN URL

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
         "robots.txt",
         TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
     ),
+    path("favicon.ico", default_views.page_not_found, kwargs={"exception": Exception("Page not Found")}),
     path("", include("judgments.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 


### PR DESCRIPTION
A large number of InvalidDocumentURIExceptions are browsers requesting favicon.ico. Explicitly return a 404 rather than generating an exception.

https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-editor-ui/195/occurrence/425839049443#occurrences