### PR TITLE
Do not look for public uri if raising an issue to the submitter

### DIFF
--- a/judgments/utils/link_generators.py
+++ b/judgments/utils/link_generators.py
@@ -61,7 +61,6 @@ def build_raise_issue_email_link(
     email_context = {
         "judgment_name": document.body.name,
         "reference": document.consignment_reference,
-        "public_judgment_url": document.public_uri,
         "user_signature": signature,
         "submitter": document.source_name or "XXXXXX",
     }


### PR DESCRIPTION
1) it's not in [the email](https://github.com/nationalarchives/ds-caselaw-editor-ui/blob/main/ds_caselaw_editor_ui/templates/emails/raise_issue_with_submitter.txt) anyway
2) it [doesn't work if there was a failure to parse](https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-editor-ui/229), because there's no identifiers

## Jira card / Rollbar error (etc)
https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-editor-ui/229