### PR TITLE
Add Zizmor to pre-commit to provide static analysis of GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-
+permissions: {}
 # Enable Buildkit and let compose use it to speed up image building
 env:
   DOCKER_BUILDKIT: 1
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up node
         uses: actions/setup-node@v4.3.0
@@ -36,6 +38,8 @@ jobs:
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5.4.0
@@ -57,6 +61,8 @@ jobs:
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Copy .env.example file
         uses: canastro/copy-file-action@master
@@ -77,6 +83,8 @@ jobs:
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Copy .env.example file
         uses: canastro/copy-file-action@master

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/e2e_cypress_tests.yml
+++ b/.github/workflows/e2e_cypress_tests.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v4
@@ -29,4 +31,7 @@ jobs:
         run: npm install cypress
 
       - name: Run Cypress Tests
-        run: CYPRESS_BASE_URL=${{inputs.CYPRESS_BASE_URL}} CYPRESS_USERNAME=${{secrets.CYPRESS_USERNAME}} CYPRESS_PASSWORD=${{secrets.CYPRESS_PASSWORD}} npx cypress run --headless
+        run: CYPRESS_BASE_URL=${CYPRESS_BASE_URL} CYPRESS_USERNAME=${{secrets.CYPRESS_USERNAME}} CYPRESS_PASSWORD=${{secrets.CYPRESS_PASSWORD}} npx cypress run --headless
+
+env:
+  CYPRESS_BASE_URL: ${{inputs.CYPRESS_BASE_URL}}

--- a/.github/workflows/e2e_staging_tests.yml
+++ b/.github/workflows/e2e_staging_tests.yml
@@ -1,5 +1,5 @@
 name: E2E Staging Tests
-
+permissions: {}
 on:
   schedule:
     - cron: "0 8 * * *"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release latest code for production deploy
+permissions: {}
 on:
   release:
     types: [published]
@@ -17,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run latest-tag
         uses: EndBug/latest-tag@latest
         with:

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -1,4 +1,5 @@
 name: Source safety
+permissions: {}
 on:
   pull_request:
   push:
@@ -8,4 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,8 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, json, xml, markdown, scss, javascript]
+
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.5.1
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
<!-- Amend as appropriate -->

> [`zizmor`](https://github.com/woodruffw/zizmor) is a static analysis tool for GitHub Actions.
> It can find many common security issues in typical GitHub Actions CI/CD setups, including:
> * Template injection vulnerabilities, leading to attacker-controlled code execution
> * Accidental credential persistence and leakage
> * Excessive permission scopes and credential grants to runners
> * Impostor commits and confusable git references
> * ...[and much more](https://woodruffw.github.io/zizmor/audits/)!


## Changes in this PR:
* Add zizmor to precommit
* Change CI config to resolve errors

## Jira card / Rollbar error (etc)
https://dxw.slack.com/archives/CD8TQ9NP9/p1742225253315449 [general advert from @rjw1]

## Screenshots of UI changes:

### Before
No checks
### During
https://woodruffw.github.io/zizmor/audits/#excessive-permissions
https://woodruffw.github.io/zizmor/audits/#template-injection
https://woodruffw.github.io/zizmor/audits/#artipacked

It's possible things will fail in CI because of the lack of credentials from the last one; it's OK to set to "true" if needed for git stuff.
### After
0 errors (on default settings)

