### PR TITLE
Check stylelint in CI once again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         env:
-          SKIP: no-commit-to-branch,stylelint
+          SKIP: no-commit-to-branch
 
   static-analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         run: npm run build
   linter:
     runs-on: ubuntu-latest
+    needs: build-scss
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
@@ -45,6 +46,8 @@ jobs:
           cache-dependency-path: |
             requirements/base.txt
             requirements/local.txt
+
+      - run: npm link
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Stylelint passes with --all, so we can add it to CI again.

---

This doesn't work in CI.

Think I've got a fix (import the frontend in precommit)
[that didn't work either]

I think the issue is that we're referring to an npm package that doesn't exist and then shoehorning the git repo into that namespace and we're not telling precommit:
```
package.json
40:    "@nationalarchives/ds-caselaw-frontend": "github:nationalarchives/ds-caselaw-frontend#v2.0.10",
```
maybe we should just be uploading it to npm?