### PR TITLE
Bump API to v35

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ xmltodict~=0.14.1
 requests-toolbelt~=1.0.0
 lxml~=5.3.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=34.1.1
+ds-caselaw-marklogic-api-client~=35.0.0
 ds-caselaw-utils~=2.4.0
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
Encountered https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-editor-ui/237 which is an error due to the environment variable confusion when attempting to delete a document -- updating the API client should fix it. 