### PR TITLE
Explicitly persist credentials between checkout and latest-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          persist-credentials: true
       - name: Run latest-tag
         uses: EndBug/latest-tag@latest
         with:


### PR DESCRIPTION
Attempting to fix error caused by zizmor overzealousness:
```
Error: Command failed: git -C /home/runner/work/ds-caselaw-editor-ui/ds-caselaw-editor-ui push --force origin production
fatal: could not read Username for 'https://github.com/': No such device or address```