### PR TITLE
[FCL-812] Public URL links in EUI should open the document in PUI

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_links.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_links.scss
@@ -18,6 +18,11 @@ a {
   &:focus {
     @include focus-default;
   }
+
+  &.link__new-window::after {
+    content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==");
+    margin: 0 3px 0 5px;
+  }
 }
 
 #skip-to-main-content {

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers.html
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers.html
@@ -37,7 +37,9 @@
             </td>
             <td>
               {% if document.is_published %}
-                <a href="https://caselaw.nationalarchives.gov.uk/{{ identifier.url_slug }}"><code>/{{ identifier.url_slug }}</code></a>
+                <a href="https://caselaw.nationalarchives.gov.uk/{{ identifier.url_slug }}"
+                   target="_blank"
+                   class="link__new-window"><code>/{{ identifier.url_slug }}</code></a>
               {% else %}
                 <code>/{{ identifier.url_slug }}</code>
               {% endif %}

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers.html
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers.html
@@ -36,7 +36,11 @@
               {% endif %}
             </td>
             <td>
-              <code>/{{ identifier.url_slug }}</code>
+              {% if document.is_published %}
+                <a href="https://caselaw.nationalarchives.gov.uk/{{ identifier.url_slug }}"><code>/{{ identifier.url_slug }}</code></a>
+              {% else %}
+                <code>/{{ identifier.url_slug }}</code>
+              {% endif %}
             </td>
             {% if user|is_developer %}
               <td>{{ identifier.schema.human_readable }}</td>

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers.html
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers.html
@@ -13,7 +13,7 @@
         <tr>
           <th>Type</th>
           <th>Value</th>
-          <th>URL</th>
+          <th>Public URL</th>
           {% if user|is_developer %}
             <th>Human readable</th>
             <th>Score</th>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

When a document has been published, the public links in the list of identifiers should open the PUI.

## Jira card / Rollbar error (etc)

FCL-812

## Screenshots of UI changes:

![Screenshot 2025-04-22 at 16 28 33](https://github.com/user-attachments/assets/c56a198a-506b-4414-a2c1-5469ebe69ab5)
