### PR TITLE
Bump APIC to v36.0.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ xmltodict~=0.14.1
 requests-toolbelt~=1.0.0
 lxml~=5.4.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=36.0.0
+ds-caselaw-marklogic-api-client~=36.0.2
 ds-caselaw-utils~=2.4.0
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
This allows the EUI to handle EWCOP T* URIs.