### PR TITLE
FCL-822 Use doc.content_as_html not doc.body's

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - postgres
     volumes:
       - .:/app:z
+      - ../ds-caselaw-custom-api-client:/apiclient
     init: true
     environment:
       DATABASE_URL: "postgres://postgres:admin@postgres:5432/ds_judgments_editor_ui"

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -91,15 +91,11 @@ class DocumentView(TemplateView):
 
         version_uri = self.request.GET.get("version_uri", None)
 
-        xslt_image_location = env("XSLT_IMAGE_LOCATION", default=None)
-
         if version_uri:
             context["current_version_number"] = extract_version_number_from_filename(version_uri)
-            context["document_html"] = get_document_by_uri_or_404(version_uri).body.content_as_html(
-                image_base_url=xslt_image_location,
-            )
+            context["document_html"] = get_document_by_uri_or_404(version_uri).content_as_html()
         else:
-            context["document_html"] = document.body.content_as_html(image_base_url=xslt_image_location)
+            context["document_html"] = document.content_as_html()
 
         # TODO: Remove this once we fully deprecate 'judgment' contexts
         context["judgment"] = document

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ xmltodict~=0.14.1
 requests-toolbelt~=1.0.0
 lxml~=5.4.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=36.0.2
+ds-caselaw-marklogic-api-client~=37.0.0
 ds-caselaw-utils~=2.4.0
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
Uses API Client 37 to correctly write the image names.
https://national-archives.atlassian.net/browse/FCL-822

Note that this also changes prefixes to not include the trailing slash: `/signed-assets` is now correct, whereas it was `/signed-assets/`; the enviroment variable will need changing.
