### PR TITLE
[FCL-881] editors are not able to view document history pages

### DIFF
--- a/ds_caselaw_editor_ui/templates/judgment/history.html
+++ b/ds_caselaw_editor_ui/templates/judgment/history.html
@@ -3,67 +3,27 @@
 {% block content %}
   {% include "includes/judgment/metadata_panel_static.html" with judgment=document %}
   <div class="container">
-    {% flag history_timeline %}
-      <div class="document-history">
-        {% for submission in structured_history reversed %}
-          <div class="document-history__submission my-3">
-            {% if submission.submission_type == 'structured' %}
-              {% include "includes/judgment/history/structured_submission.html" with expand=forloop.first %}
-            {% elif submission.submission_type == 'orphan' %}
-              {% include "includes/judgment/history/orphaned_events.html" with expand=forloop.first %}
-            {% else %}
-              <h2>Legacy version {{ submission.marklogic_version }}</h2>
+    <div class="document-history">
+      {% for submission in structured_history reversed %}
+        <div class="document-history__submission my-3">
+          {% if submission.submission_type == 'structured' %}
+            {% include "includes/judgment/history/structured_submission.html" with expand=forloop.first %}
+          {% elif submission.submission_type == 'orphan' %}
+            {% include "includes/judgment/history/orphaned_events.html" with expand=forloop.first %}
+          {% else %}
+            <h2>Legacy version {{ submission.marklogic_version }}</h2>
+            <p>
+              <time datetime="{{ submission.datetime|date:"c" }}">{{ submission.datetime|display_datetime }}</time>
+            </p>
+            {% if submission.annotation %}<p>{{ submission.annotation }}</p>{% endif %}
+            {% if user|is_developer %}
               <p>
-                <time datetime="{{ submission.datetime|date:"c" }}">{{ submission.datetime|display_datetime }}</time>
+                <small class="muted">Event #{{ submission.event_sequence_number }} • Submission #{{ submission.submission_sequence_number }} • MarkLogic version #{{ submission.marklogic_version }}</small>
               </p>
-              {% if submission.annotation %}<p>{{ submission.annotation }}</p>{% endif %}
-              {% if user|is_developer %}
-                <p>
-                  <small class="muted">Event #{{ submission.event_sequence_number }} • Submission #{{ submission.submission_sequence_number }} • MarkLogic version #{{ submission.marklogic_version }}</small>
-                </p>
-              {% endif %}
             {% endif %}
-          </div>
-        {% endfor %}
-      </div>
-    {% else %}
-      <div class="document-version-history">
-        <h2>Document version history</h2>
-        <table class="document-version-history__table table">
-          <thead>
-            <tr>
-              <th scope="col">Version</th>
-              <th scope="col">Date created</th>
-              <th scope="col">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for version in document.versions_as_documents %}
-              <tr>
-                <td>
-                  <a href="{% url 'full-text-html' document_uri %}?version_uri={{ version.uri }}">
-                    {% if forloop.first %}
-                      <strong>Current (version {{ version.version_number }})</strong>
-                    {% else %}
-                      Version {{ version.version_number }}
-                    {% endif %}
-                  </a>
-                </td>
-                <td>{{ version.version_created_datetime|display_datetime }}</td>
-                <td>
-                  {% with annotation=version.annotation %}
-                    {% if annotation %}
-                      {{ annotation|display_annotation_type }}
-                    {% else %}
-                      <span class="muted">Unknown</span>
-                    {% endif %}
-                  {% endwith %}
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    {% endflag %}
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
   </div>
 {% endblock content %}

--- a/judgments/tests/test_document_history.py
+++ b/judgments/tests/test_document_history.py
@@ -4,57 +4,17 @@ from unittest.mock import patch
 
 from caselawclient.client_helpers import VersionAnnotation, VersionType
 from caselawclient.factories import DocumentBodyFactory, JudgmentFactory
-from caselawclient.models.documents import DocumentURIString, VersionsDict
+from caselawclient.models.documents import DocumentURIString
 from caselawclient.models.judgments import Judgment
 from django.contrib.auth.models import Group, User
 from django.test import TestCase
 from django.urls import reverse
 from factories import DocumentVersionFactory
-from waffle.testutils import override_flag
 
 from judgments.views import document_history
 from judgments.views.document_history import DocumentHistorySequencer
 
 
-class TestDocumentHistory(TestCase):
-    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
-    @patch("judgments.utils.api_client.document_exists")
-    @patch("judgments.utils.api_client.get_document_type_from_uri")
-    def test_document_history_view(self, document_type, document_exists, mock_get_document):
-        document_type.return_value = Judgment
-        document_exists.return_value = None
-
-        document = JudgmentFactory.build(
-            uri=DocumentURIString("ewca/civ/2005/1444"),
-            versions=[
-                VersionsDict({"uri": DocumentURIString("ewca/civ/2005/1444_xml_versions/1-1444"), "version": 1}),
-            ],
-            body=DocumentBodyFactory.build(name="Test v Tested"),
-        )
-
-        version_document = DocumentVersionFactory.build()
-        document.versions_as_documents = [version_document]
-        mock_get_document.return_value = document
-
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-
-        assert reverse("document-history", kwargs={"document_uri": document.uri}) == "/ewca/civ/2005/1444/history"
-
-        response = self.client.get(
-            reverse("document-history", kwargs={"document_uri": document.uri}),
-        )
-
-        assert response.status_code == 200
-
-        decoded_response = response.content.decode("utf-8")
-        dt = document.versions_as_documents[0].version_created_datetime
-        assert "Current (version 1)" in decoded_response
-        assert dt.strftime("%d %b %Y") in decoded_response
-        assert dt.strftime("%H:%M") in decoded_response
-        assert "Submitted" in decoded_response
-
-
-@override_flag("history_timeline", active=True)
 class TestStructuredDocumentHistoryLogic(TestCase):
     def test_build_event_object_without_submitter(self):
         version_document = DocumentVersionFactory.build(
@@ -372,7 +332,6 @@ class TestStructuredDocumentHistoryLogic(TestCase):
         ]
 
 
-@override_flag("history_timeline", active=True)
 class TestStructuredDocumentHistoryView(TestCase):
     def sign_in_developer_user(self):
         developer_user = User.objects.get_or_create(username="testuser")[0]

--- a/judgments/views/labs.py
+++ b/judgments/views/labs.py
@@ -9,12 +9,7 @@ class Labs(TemplateView):
     #     "title": "Embedded PDF",
     #     "description": "View PDFs directly in the browser without needing to download them.",
     # },
-    EXPERIMENTS: dict[str, dict] = {
-        "history_timeline": {
-            "title": "Improved document history",
-            "description": "Display structured information about the history of a document, instead of just versions in the database.",
-        },
-    }
+    EXPERIMENTS: dict[str, dict] = {}
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ xmltodict~=0.14.1
 requests-toolbelt~=1.0.0
 lxml~=5.4.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=37.3.0
+ds-caselaw-marklogic-api-client~=37.3.1
 ds-caselaw-utils~=2.4.0
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
Bump to fixed version of API Client to allow history to be loaded for pages with UUID-based URIs. As a bonus action, promote structured history view out of labs.