### PR TITLE
Add qrcode to requirements for mfa signup

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,6 +23,7 @@ rollbar
 django-stronghold==0.4.0
 boto3~=1.38.3
 fido2~=2.0.0
+qrcode~=8.2
 
 # Type stubs
 mypy-boto3-s3==1.38.26


### PR DESCRIPTION
<!-- Amend as appropriate -->

Displaying the QR code on /accounts/2fa/ requires the qrcode library, which wasn't imported because we're using requirements.txt not poetry or similar.

## Changes in this PR:
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/0cf2829b-cdb3-4103-b8ef-ea679fa5b0b8" />

## Jira card / Rollbar error (etc)
https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-editor-ui/252
