### PR TITLE
[FCL-880] Allow editors to directly manipulate identifiers

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -78,6 +78,8 @@ THIRD_PARTY_APPS = [
     "stronghold",
     "waffle",
     "widget_tweaks",
+    "crispy_forms",
+    "crispy_forms_gds",
 ]
 
 LOCAL_APPS = [
@@ -158,7 +160,10 @@ STATIC_ROOT = str(ROOT_DIR / "staticfiles")
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
 STATIC_URL = "/static/"
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
-STATICFILES_DIRS = [str(APPS_DIR / "static")]
+STATICFILES_DIRS = [
+    str(APPS_DIR / "static"),
+    ("govuk-assets", str(ROOT_DIR / "node_modules" / "govuk-frontend" / "dist" / "govuk" / "assets")),
+]
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#staticfiles-finders
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",
@@ -296,6 +301,15 @@ STRONGHOLD_PUBLIC_URLS = (
     r"^/accounts/",
     r"^/check",
 )
+
+CRISPY_ALLOWED_TEMPLATE_PACKS = (
+    # "bootstrap",
+    # "bootstrap3",
+    # "bootstrap4",
+    # "uni_form",
+    "gds",
+)
+CRISPY_TEMPLATE_PACK = "gds"
 
 JIRA_INSTANCE = env("JIRA_INSTANCE")
 

--- a/ds_caselaw_editor_ui/sass/main.scss
+++ b/ds_caselaw_editor_ui/sass/main.scss
@@ -1,8 +1,11 @@
 @use "includes/tna_colour_overrides";
 @use "@nationalarchives/frontend/nationalarchives/tools/colour" as *;
 
+$govuk-assets-path: "/static/govuk-assets/";
+
 // Vendor imports
 @import "@nationalarchives/ds-caselaw-frontend/src/main";
+@import "govuk-frontend/dist/govuk/index";
 
 // Setup
 @import "includes/variables";

--- a/ds_caselaw_editor_ui/static/js/src/app.js
+++ b/ds_caselaw_editor_ui/static/js/src/app.js
@@ -1,5 +1,5 @@
 import $ from "jquery";
-
+import { initAll } from "govuk-frontend";
 import TabSet from "./components/tabSet";
 import "./components/document_navigation_links";
 
@@ -70,3 +70,5 @@ $(".document-history__submission-toggle").on("click", function () {
 });
 
 TabSet.init();
+
+initAll();

--- a/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
@@ -2,24 +2,28 @@
   <div class="metadata-component">
     <form aria-label="Edit judgment"
           method="post"
-          action="{% url 'edit-document' judgment.uri %}">
+          action="{% url 'edit-document' document.uri %}">
       {% csrf_token %}
       <input type="hidden" name="return_to" value="{{ return_to }}" />
       <div class="metadata-component__left-column">
         <div class="metadata-component__top-left-row">
           <div class="metadata-component__ncn">
-            <label for="neutral_citation" class="metadata-component__main-labels">NCN</label>
-            <input type="text"
-                   class="metadata-component__neutral_citation-input"
-                   value="{{ preferred_ncn.value }}"
-                   name="neutral_citation"
-                   id="neutral_citation" />
+            <label class="metadata-component__main-labels">Preferred Identifier</label>
+            <span class="judgment-metadata-panel__value">
+              {% if document.identifiers.preferred %}
+                <small>{{ document.identifiers.preferred.schema.name }}</small>
+                <br>
+                <b>{{ document.identifiers.preferred.value }}</b>
+              {% else %}
+                &mdash;
+              {% endif %}
+            </span>
           </div>
           <div class="metadata-component__court">
             <label for="court" class="metadata-component__main-labels">Court</label>
             <input type="text"
                    class="metadata-component__court-input"
-                   value="{{ judgment.body.court_and_jurisdiction_identifier_string }}"
+                   value="{{ document.body.court_and_jurisdiction_identifier_string }}"
                    name="court"
                    id="court"
                    list="court-ids" />
@@ -31,7 +35,7 @@
             <label for="judgment_date" class="metadata-component__main-labels">Judgment date</label>
             <input type="text"
                    class="metadata-component__judgment-date-input"
-                   value="{{ judgment.body.document_date_as_date | date:'j M Y' }}"
+                   value="{{ document.body.document_date_as_date | date:'j M Y' }}"
                    name="judgment_date"
                    id="judgment_date" />
           </div>
@@ -41,7 +45,7 @@
           <textarea class="metadata-component__metadata-name-input"
                     name="metadata_name"
                     id="metadata_name"
-                    rows="2">{{ judgment.body.name }}</textarea>
+                    rows="2">{{ document.body.name }}</textarea>
         </div>
       </div>
       <div class="metadata-component__right-column">
@@ -49,13 +53,13 @@
           <aside for="metadata_name" class="metadata-component__main-labels">
             TDR ref
           </aside>
-          <p>{{ judgment.consignment_reference }}</p>
+          <p>{{ document.consignment_reference }}</p>
         </div>
         <div class="metadata-component__type">
           <aside for="metadata_name" class="metadata-component__main-labels">
             Type
           </aside>
-          <p>{{ judgment.document_noun|title }}</p>
+          <p>{{ document.document_noun|title }}</p>
         </div>
         <div class="metadata-component__actions">
           <input type="hidden" name="judgment_uri" value="{{ document_uri }}" />

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -3,16 +3,24 @@
   <div class="judgment-metadata-panel">
     <ul class="judgment-metadata-panel__primary-details">
       <li>
-        <span class="judgment-metadata-panel__key">NCN</span>
-        <span class="judgment-metadata-panel__value">{{ preferred_ncn.value }}</span>
+        <span class="judgment-metadata-panel__key">Best ID</span>
+        <span class="judgment-metadata-panel__value">
+          {% if document.identifiers.preferred %}
+            <small>{{ document.identifiers.preferred.schema.name }}</small>
+            <br>
+            {{ document.identifiers.preferred.value }}
+          {% else %}
+            &mdash;
+          {% endif %}
+        </span>
       </li>
       <li>
         <span class="judgment-metadata-panel__key">Court</span>
-        <span class="judgment-metadata-panel__value">{{ judgment.body.court }}</span>
+        <span class="judgment-metadata-panel__value">{{ document.body.court }}</span>
       </li>
       <li>
         <span class="judgment-metadata-panel__key">Name</span>
-        <span class="judgment-metadata-panel__value">{{ judgment.body.name }}</span>
+        <span class="judgment-metadata-panel__value">{{ document.body.name }}</span>
       </li>
     </ul>
     <ul class="judgment-metadata-panel__secondary-details">
@@ -25,15 +33,15 @@
           {% endif %}
         </span>
         <time class="judgment-metadata-panel__value"
-              datetime="{{ judgment.body.document_date_as_string }}">{{ judgment.body.document_date_as_string }}</time>
+              datetime="{{ judgment.body.document_date_as_string }}">{{ document.body.document_date_as_string }}</time>
       </li>
       <li>
         <span class="judgment-metadata-panel__key">Type</span>
-        <span class="judgment-metadata-panel__value">{{ judgment.document_noun|title }}</span>
+        <span class="judgment-metadata-panel__value">{{ document.document_noun|title }}</span>
       </li>
       <li>
         <span class="judgment-metadata-panel__key">TDR ref</span>
-        <span class="judgment-metadata-panel__value">{{ judgment.consignment_reference }}</span>
+        <span class="judgment-metadata-panel__value">{{ document.consignment_reference }}</span>
       </li>
     </ul>
   </div>

--- a/ds_caselaw_editor_ui/templates/includes/style_guide/judgment_metadata_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/style_guide/judgment_metadata_form.html
@@ -3,4 +3,6 @@
 <p>
   Use with <code>include "includes/judgment/judgment_metadata_form.html"</code>
 </p>
-<div class="style-guide__component-wrapper--large">{% include "includes/judgment/judgment_metadata_form.html" %}</div>
+<div class="style-guide__component-wrapper--large">
+  {% include "includes/judgment/judgment_metadata_form.html" with document=mock_document %}
+</div>

--- a/ds_caselaw_editor_ui/templates/includes/style_guide/judgment_toolbar.html
+++ b/ds_caselaw_editor_ui/templates/includes/style_guide/judgment_toolbar.html
@@ -6,5 +6,5 @@
   Use with <code>include "includes/judgment/toolbar.html"</code>
 </p>
 <div class="style-guide__component-wrapper--large">
-  {% include "includes/judgment/toolbar.html" with document=judgment %}
+  {% include "includes/judgment/toolbar.html" with document=mock_document %}
 </div>

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers.html
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers.html
@@ -60,6 +60,10 @@
         </div>
       </div>
     {% endif %}
+    <div class="judgment-component__button-actions">
+      <a class="button-cta"
+         href="{% url 'document-identifiers-add' document.uri %}">Add new identifier</a>
+    </div>
     {% if user|is_developer %}
       <h3>System identifiers</h3>
       <table class="table">

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers_add.html
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers_add.html
@@ -1,0 +1,11 @@
+{% extends "layouts/judgment.html" %}
+{% load i18n document_utils user_permissions crispy_forms_tags crispy_forms_gds %}
+{% block content %}
+  {% include "includes/judgment/metadata_panel_static.html" with judgment=document %}
+  <div class="container">
+    <h1 class="judgment-component__confirmation-title">Add identifier for:</h1>
+    <h2 class="judgment-component__confirmation-subtitle">{{ document.body.name }}</h2>
+    {% error_summary form %}
+    {% crispy form %}
+  </div>
+{% endblock content %}

--- a/judgments/tests/test_add_identifier_form.py
+++ b/judgments/tests/test_add_identifier_form.py
@@ -1,0 +1,60 @@
+from django.test import TestCase
+
+from judgments.views.document_identifiers import AddIdentifierForm
+
+
+class TestAddIdentifierForm(TestCase):
+    def setUp(self):
+        self.type_choices = [
+            ("namespace1", "Type 1"),
+            ("namespace2", "Type 2"),
+        ]
+
+    def test_valid_data(self):
+        form = AddIdentifierForm(
+            data={
+                "type": "namespace1",
+                "value": "ID123",
+                "deprecated": False,
+            },
+            type_choices=self.type_choices,
+        )
+        assert form.is_valid() is True
+        assert form.cleaned_data["type"] == "namespace1"
+        assert form.cleaned_data["value"] == "ID123"
+        assert form.cleaned_data["deprecated"] is False
+
+    def test_missing_value(self):
+        form = AddIdentifierForm(
+            data={
+                "type": "namespace1",
+                "value": "",
+                "deprecated": False,
+            },
+            type_choices=self.type_choices,
+        )
+        assert form.is_valid() is False
+        assert "value" in form.errors
+
+    def test_invalid_type(self):
+        form = AddIdentifierForm(
+            data={
+                "type": "invalid_namespace",
+                "value": "ID123",
+                "deprecated": False,
+            },
+            type_choices=self.type_choices,
+        )
+        assert form.is_valid() is False
+        assert "type" in form.errors
+
+    def test_deprecated_checkbox(self):
+        form = AddIdentifierForm(
+            data={
+                "type": "namespace2",
+                "value": "ID999",
+            },
+            type_choices=self.type_choices,
+        )
+        assert form.is_valid() is True
+        assert form.cleaned_data["deprecated"] is False

--- a/judgments/tests/test_document_edit.py
+++ b/judgments/tests/test_document_edit.py
@@ -1,19 +1,12 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-import pytest
-from caselawclient.factories import JudgmentFactory, PressSummaryFactory
+from caselawclient.factories import JudgmentFactory
 from caselawclient.models.documents import DocumentURIString
-from caselawclient.models.identifiers.neutral_citation import (
-    NCNCannotConvertToValidURLSlugException,
-    NCNDoesNotMatchExpectedPatternException,
-    NeutralCitationNumber,
-)
+from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
 from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
 from django.test import TestCase
 from django.urls import reverse
-
-from judgments.views.judgment_edit import CannotUpdateNCNOfNonJudgment, update_ncn_of_document
 
 
 class TestDocumentEdit(TestCase):
@@ -29,7 +22,7 @@ class TestDocumentEdit(TestCase):
     @patch("judgments.views.judgment_edit.api_client")
     @patch("judgments.views.judgment_edit.get_document_by_uri_or_404")
     @patch("judgments.utils.aws.boto3")
-    def test_edit_judgment_no_ncn_change(self, mock_boto, mock_judgment, api_client):
+    def test_edit_judgment(self, mock_boto, mock_judgment, api_client):
         judgment = JudgmentFactory.build(
             uri=DocumentURIString("edittest/4321/123"),
             name="Test v Tested",
@@ -46,7 +39,6 @@ class TestDocumentEdit(TestCase):
             {
                 "judgment_uri": "/edittest/4321/123",
                 "metadata_name": "New Name",
-                "neutral_citation": "[4321] UKSC 123",
                 "court": "Court of Testing",
                 "judgment_date": "2 Jan 2023",
             },
@@ -64,33 +56,6 @@ class TestDocumentEdit(TestCase):
             "/edittest/4321/123",
             "2023-01-02",
         )
-
-    @patch("judgments.views.judgment_edit.update_ncn_of_document")
-    @patch("judgments.views.judgment_edit.api_client")
-    @patch("judgments.views.judgment_edit.get_document_by_uri_or_404")
-    @patch("judgments.utils.aws.boto3")
-    def test_edit_judgment_ncn_change(self, mock_boto, mock_judgment, api_client, mock_update_ncn_of_document):
-        judgment = JudgmentFactory.build(
-            uri=DocumentURIString("uksc/4321/123"),
-            name="Test v Tested",
-        )
-        judgment.identifiers.add(NeutralCitationNumber("[4321] UKSC 123"))
-        mock_judgment.return_value = judgment
-
-        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-        User.objects.get_or_create(username="testuser2")
-
-        self.client.post(
-            "/uksc/4321/123/edit",
-            {
-                "judgment_uri": "/uksc/4321/123",
-                "metadata_name": "New Name",
-                "neutral_citation": "[2023] EWCC 456",
-                "court": "Court of Testing",
-                "judgment_date": "2 Jan 2023",
-            },
-        )
-        mock_update_ncn_of_document.assert_called_once_with(judgment, "[2023] EWCC 456")
 
     @patch("judgments.views.judgment_edit.api_client")
     @patch("judgments.views.judgment_edit.get_document_by_uri_or_404")
@@ -110,7 +75,6 @@ class TestDocumentEdit(TestCase):
             {
                 "judgment_uri": "/edittest/4321/123",
                 "metadata_name": "New Name",
-                "neutral_citation": "[4321] UKSC 123",
                 "court": "Court of Testing",
                 "judgment_date": "Kittens",
             },
@@ -118,78 +82,3 @@ class TestDocumentEdit(TestCase):
 
         messages = list(get_messages(response.wsgi_request))
         assert "Could not parse the date" in messages[0].message
-
-
-class TestUpdateNCNOfDocument(TestCase):
-    @patch("judgments.views.judgment_edit.api_client")
-    def test_update_ncn_of_document_where_change_is_valid(
-        self,
-        api_client,
-    ):
-        document = JudgmentFactory.build(
-            uri=DocumentURIString("uksc/4321/123"),
-            name="Test v Tested",
-        )
-        document.save_identifiers = Mock()  # type:ignore[method-assign]
-        document.identifiers = Mock()
-
-        update_ncn_of_document(document, "[2025] EWCC 456")
-
-        document.identifiers.delete_type.assert_called_once_with(NeutralCitationNumber)
-        document.identifiers.add.assert_called_once()
-        document.save_identifiers.assert_called_once()
-        api_client.set_judgment_citation.assert_called_once_with("uksc/4321/123", "[2025] EWCC 456")
-
-    @patch("judgments.views.judgment_edit.api_client")
-    def test_update_ncn_of_document_rejects_non_judgment(
-        self,
-        api_client,
-    ):
-        document = PressSummaryFactory.build(
-            uri=DocumentURIString("uksc/4321/123"),
-            name="Test v Tested",
-        )
-        document.save_identifiers = Mock()  # type:ignore[method-assign]
-        document.identifiers.add(NeutralCitationNumber("[2023] UKSC 123"))
-
-        with pytest.raises(CannotUpdateNCNOfNonJudgment):
-            update_ncn_of_document(document, "[2025] EWCC 456")
-
-        document.save_identifiers.assert_not_called()
-        api_client.set_judgment_citation.assert_not_called()
-
-    @patch("judgments.views.judgment_edit.api_client")
-    def test_update_ncn_of_document_rejects_malformed_ncn(
-        self,
-        api_client,
-    ):
-        document = JudgmentFactory.build(
-            uri=DocumentURIString("uksc/4321/123"),
-            name="Test v Tested",
-        )
-        document.save_identifiers = Mock()  # type:ignore[method-assign]
-        document.identifiers.add(NeutralCitationNumber("[2023] UKSC 123"))
-
-        with pytest.raises(NCNDoesNotMatchExpectedPatternException):
-            update_ncn_of_document(document, "TEST-123")
-
-        document.save_identifiers.assert_not_called()
-        api_client.set_judgment_citation.assert_not_called()
-
-    @patch("judgments.views.judgment_edit.api_client")
-    def test_update_ncn_of_document_rejects_plausible_but_invalid_ncn(
-        self,
-        api_client,
-    ):
-        document = JudgmentFactory.build(
-            uri=DocumentURIString("uksc/4321/123"),
-            name="Test v Tested",
-        )
-        document.save_identifiers = Mock()  # type:ignore[method-assign]
-        document.identifiers.add(NeutralCitationNumber("[2023] UKSC 123"))
-
-        with pytest.raises(NCNCannotConvertToValidURLSlugException):
-            update_ncn_of_document(document, "[2023] UKSC 123 (Fam)")
-
-        document.save_identifiers.assert_not_called()
-        api_client.set_judgment_citation.assert_not_called()

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -14,7 +14,7 @@ from .views.document_full_text import (
     xml_view_redirect,
 )
 from .views.document_history import DocumentHistoryView
-from .views.document_identifiers import DocumentIdentifiersView
+from .views.document_identifiers import AddDocumentIdentifierView, DocumentIdentifiersView
 from .views.document_reparse import reparse
 from .views.index import index
 from .views.judgment_edit import EditJudgmentView, edit_view_redirect
@@ -99,6 +99,11 @@ urlpatterns = [
         "<path:document_uri>/identifiers",
         DocumentIdentifiersView.as_view(),
         name="document-identifiers",
+    ),
+    path(
+        "<path:document_uri>/identifiers/add",
+        AddDocumentIdentifierView.as_view(),
+        name="document-identifiers-add",
     ),
     path(
         "<path:document_uri>/publish",

--- a/judgments/views/document_identifiers.py
+++ b/judgments/views/document_identifiers.py
@@ -1,4 +1,20 @@
-from judgments.utils.view_helpers import DocumentView
+from typing import TYPE_CHECKING
+
+from caselawclient.models.identifiers.neutral_citation import NCNValidationException
+from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import Button, Layout
+from django import forms
+from django.urls import reverse
+from django.views.generic import FormView
+
+from judgments.utils.view_helpers import DocumentView, DocumentViewMixin
+
+if TYPE_CHECKING:
+    from caselawclient.models.identifiers import Identifier
+
+
+def identifier_types_to_form_list(identifier_types: list[type["Identifier"]]) -> list[tuple[str, str]]:
+    return [(t.schema.namespace, t.schema.name) for t in identifier_types]
 
 
 class DocumentIdentifiersView(DocumentView):
@@ -10,3 +26,84 @@ class DocumentIdentifiersView(DocumentView):
         return context
 
     template_name = "judgment/identifiers.html"
+
+
+class AddIdentifierForm(forms.Form):
+    def __init__(self, *args, type_choices=None, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["type"] = forms.ChoiceField(
+            label="Type",
+            choices=type_choices or [],
+        )
+        self.fields["value"] = forms.CharField(label="Identifier Value", max_length=100)
+        self.fields["deprecated"] = forms.BooleanField(
+            label="Deprecated",
+            help_text="Should this identifier be marked as deprecated?",
+            required=False,
+        )
+        self.helper = FormHelper()
+        self.helper.layout = Layout("type", "value", "deprecated", Button("submit", "Submit"))
+
+
+class AddDocumentIdentifierView(DocumentViewMixin, FormView):
+    template_name = "judgment/identifiers_add.html"
+    form_class = AddIdentifierForm
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["type_choices"] = identifier_types_to_form_list(
+            self.document.identifiers.valid_new_identifier_types(type(self.document)),
+        )
+        return kwargs
+
+    def form_valid(self, form):
+        identifier_namespace = form.cleaned_data["type"]
+        identifier_value = form.cleaned_data["value"]
+        identifier_deprecated = form.cleaned_data["deprecated"]
+
+        # Get the available identifier types for the document, to check
+        identifier_types = self.document.identifiers.valid_new_identifier_types(type(self.document))
+
+        # Find the correct Identifier class by namespace
+        identifier_type: type[Identifier] | None = next(
+            (t for t in identifier_types if t.schema.namespace == identifier_namespace),
+            None,
+        )
+        if identifier_type is None:
+            form.add_error("type", "Invalid identifier type selected.")
+            return self.form_invalid(form)
+
+        # Check that the identifier itself is valid
+        try:
+            identifier_valid_value = identifier_type.schema.validate_identifier_value(identifier_value)
+        except NCNValidationException as e:
+            form.add_error("value", str(e))
+            return self.form_invalid(form)
+        if identifier_valid_value is False:
+            form.add_error(
+                "value",
+                f'Identifier value "{identifier_value}" is not valid according to the {identifier_type.schema.name} schema.',
+            )
+            return self.form_invalid(form)
+
+        # Create a new identifier instance
+        new_identifier = identifier_type(value=identifier_value, deprecated=identifier_deprecated)
+
+        # Add it to the identifiers collection
+        self.document.identifiers.add(new_identifier)
+
+        # Run identifiers collection validations
+        valid, error_messages = self.document.validate_identifiers()
+        if not valid:
+            for error_message in error_messages:
+                form.add_error(None, error_message)
+            return self.form_invalid(form)
+
+        # Everything checks out - save the identifiers to the database.
+        self.document.save_identifiers()
+
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return reverse("document-identifiers", kwargs={"document_uri": self.document.uri})

--- a/judgments/views/judgment_edit.py
+++ b/judgments/views/judgment_edit.py
@@ -1,8 +1,6 @@
 import datetime
 
 from caselawclient.Client import MarklogicAPIError
-from caselawclient.models.documents import Document
-from caselawclient.models.identifiers.neutral_citation import NCNValidationException, NeutralCitationNumber
 from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -12,30 +10,6 @@ from django.views.generic import View
 from judgments.utils import api_client
 from judgments.utils.aws import invalidate_caches
 from judgments.utils.view_helpers import get_document_by_uri_or_404
-
-
-class CannotUpdateNCNOfNonJudgment(Exception):
-    pass
-
-
-def update_ncn_of_document(document: Document, new_neutral_citation_number_string: str) -> None:
-    """Given a document and a new NCN string, validate that NCN and perform necessary operations to update the document with it."""
-
-    # Perform sense-check on document type
-    if document.document_noun != "judgment":
-        msg = f"Cannot update the NCN of non-judgment at {document.uri}"
-        raise CannotUpdateNCNOfNonJudgment(msg)
-
-    # Convert the submitted NCN to a proper class (which will perform validation)
-    new_neutral_citation = NeutralCitationNumber(value=new_neutral_citation_number_string)
-
-    # Set neutral citation in the identifiers
-    document.identifiers.delete_type(NeutralCitationNumber)
-    document.identifiers.add(new_neutral_citation)
-    document.save_identifiers()
-
-    # Set neutral citation in the document XML
-    api_client.set_judgment_citation(document.uri, new_neutral_citation.value)
 
 
 class EditJudgmentView(View):
@@ -53,59 +27,33 @@ class EditJudgmentView(View):
         # TODO: confirm that the stub we are about to set does not already have a mapping that isn't for this document
 
         try:
-            form_neutral_citation = request.POST["neutral_citation"]
+            # Set name
+            new_name = request.POST["metadata_name"]
+            api_client.set_document_name(judgment_uri, new_name)
 
-            existing_preferred_ncn = judgment.identifiers.preferred(NeutralCitationNumber)
+            # Set court
+            new_court = request.POST["court"]
+            api_client.set_document_court_and_jurisdiction(judgment_uri, new_court)
 
-            # If the NCN is now empty and wasn't before, fail out and don't do anything else.
-            # TODO: This is horrible nested logic and needs refactoring into something with better guard clause behaviours
-
-            if form_neutral_citation == "" and existing_preferred_ncn:
+            # Date
+            new_date = request.POST["judgment_date"]
+            try:
+                new_date_as_date = datetime.datetime.strptime(new_date, r"%d %b %Y")
+            except ValueError:
                 messages.error(
                     request,
-                    "A document with a pre-existing NCN cannot be saved with an empty NCN",
+                    f"Could not parse the date '{new_date}', should be like '2 Jan 2024'.",
                 )
+                return HttpResponseRedirect(
+                    reverse(
+                        "full-text-html",
+                        kwargs={"document_uri": kwargs["document_uri"]},
+                    ),
+                )
+            new_date_as_iso = new_date_as_date.strftime(r"%Y-%m-%d")
+            api_client.set_judgment_date(judgment_uri, new_date_as_iso)
 
-            else:
-                # If there is a submitted NCN, and EITHER one doesn't already exist OR one does exist and the value is different, process changes
-                if form_neutral_citation != "" and (
-                    existing_preferred_ncn is None or form_neutral_citation != existing_preferred_ncn.value
-                ):
-                    update_ncn_of_document(judgment, form_neutral_citation)
-
-                # Set name
-                new_name = request.POST["metadata_name"]
-                api_client.set_document_name(judgment_uri, new_name)
-
-                # Set court
-                new_court = request.POST["court"]
-                api_client.set_document_court_and_jurisdiction(judgment_uri, new_court)
-
-                # Date
-                new_date = request.POST["judgment_date"]
-                try:
-                    new_date_as_date = datetime.datetime.strptime(new_date, r"%d %b %Y")
-                except ValueError:
-                    messages.error(
-                        request,
-                        f"Could not parse the date '{new_date}', should be like '2 Jan 2024'.",
-                    )
-                    return HttpResponseRedirect(
-                        reverse(
-                            "full-text-html",
-                            kwargs={"document_uri": kwargs["document_uri"]},
-                        ),
-                    )
-                new_date_as_iso = new_date_as_date.strftime(r"%Y-%m-%d")
-                api_client.set_judgment_date(judgment_uri, new_date_as_iso)
-
-                messages.success(request, "Document successfully updated")
-
-        except (NCNValidationException, CannotUpdateNCNOfNonJudgment) as e:
-            messages.error(
-                request,
-                f"There was an error updating the Document's neutral citation: {e}",
-            )
+            messages.success(request, "Document successfully updated")
 
         except MarklogicAPIError as e:
             messages.error(request, f"There was an error saving the Document: {e}")

--- a/judgments/views/style_guide.py
+++ b/judgments/views/style_guide.py
@@ -26,7 +26,7 @@ class StyleGuide(TemplateView):
             SearchResultFactory.build(metadata={"editor_hold": "true"}),
         ]
 
-        context["judgment"] = JudgmentFactory.build()
+        context["mock_document"] = JudgmentFactory.build()
 
         context["menu_items"] = [
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@nationalarchives/ds-caselaw-frontend": "github:nationalarchives/ds-caselaw-frontend#v2.0.12",
         "@nationalarchives/frontend": "^0.21.0",
+        "govuk-frontend": "^5.7.1",
         "nodemon": "^3.0.3",
         "sass": "^1.58.3"
       },
@@ -4322,6 +4323,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/govuk-frontend": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0.tgz",
+      "integrity": "sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.2.0"
       }
     },
     "node_modules/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@nationalarchives/ds-caselaw-frontend": "github:nationalarchives/ds-caselaw-frontend#v2.0.12",
     "@nationalarchives/frontend": "^0.21.0",
+    "govuk-frontend": "^5.7.1",
     "nodemon": "^3.0.3",
     "sass": "^1.58.3"
   }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,6 +24,7 @@ django-stronghold==0.4.0
 boto3~=1.39.0
 fido2~=2.0.0
 qrcode~=8.2
+crispy-forms-gds==2.0.1
 
 # Type stubs
 mypy-boto3-s3==1.39.2


### PR DESCRIPTION
Now that identifiers are stored in a more structured way, editors need to be able to interact with them.

- Stop editors from using the old NCN field in the metadata
- Allow CRUD operations on identifiers, subject to integrity restrictions

## Jira

FCL-880