### PR TITLE
[FCL-1050] Remove CodeClimate reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,16 +198,8 @@ jobs:
       - name: Run DB Migrations
         run: docker compose run --rm django python manage.py migrate --settings=config.settings.test
 
-      - name: Run Django Tests with coverage
-        run: docker compose run django coverage run -m pytest
-
-      - name: Generate coverage XML
-        run: docker compose run django coverage xml
-
-      - name: Upload coverage to CodeClimate
-        uses: paambaati/codeclimate-action@f429536ee076d758a24705203199548125a28ca7 # v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      - name: Run Django Tests
+        run: docker compose run django pytest
 
       - name: Tear down the Stack
         run: docker compose down

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is part of the [Find Case Law](https://caselaw.nationalarchives.
 
 # Editor Interface
 
-![Tests](https://img.shields.io/github/actions/workflow/status/nationalarchives/ds-caselaw-editor-ui/ci.yml?branch=main&label=tests) ![Coverage](https://img.shields.io/codeclimate/coverage/nationalarchives/ds-caselaw-editor-ui) ![Maintainability](https://img.shields.io/codeclimate/maintainability/nationalarchives/ds-caselaw-editor-ui)
+![Tests](https://img.shields.io/github/actions/workflow/status/nationalarchives/ds-caselaw-editor-ui/ci.yml?branch=main&label=tests)
 
 An interface for editors to modify content metadata for the Find Case Law service.
 


### PR DESCRIPTION
We are migrating to CodeCov, but remove all coverage reporting to unblock CI.