### PR TITLE
Remove explicit lxml dependency, rely on API client

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,6 @@ factory-boy==3.3.3  # https://github.com/FactoryBoy/factory_boy
 requests~=2.32.3
 xmltodict~=0.14.1
 requests-toolbelt~=1.0.0
-lxml~=5.4.0
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=39.1.0
 ds-caselaw-utils~=2.4.0


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Remove the explicit lxml dependency, rely on api-client ([which is moving to v6](https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/1144) at some point)
