### PR TITLE
You must be logged in to visit urls with `/check` prefix unless they're literally `/check`

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -299,7 +299,7 @@ MFA_ADAPTER = "allauth.mfa.adapter.DefaultMFAAdapter"
 
 STRONGHOLD_PUBLIC_URLS = (
     r"^/accounts/",
-    r"^/check",
+    r"^/check$",
 )
 
 CRISPY_ALLOWED_TEMPLATE_PACKS = ["gds"]

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -28,3 +28,17 @@ class TestSearchResults(TestCase):
                 page=1,
             ),
         )
+
+
+class TestCheckPrefixUrls(TestCase):
+    def test_just_check_ok(self):
+        """The /check endpoint can be used when not logged in"""
+        response = self.client.get("/check")
+        assert response.status_code == 200
+        assert b'"OK"' in response.content
+
+    def test_check_prefix_not_ok(self):
+        """Urls starting with /check cannot be used when not logged in"""
+        response = self.client.get("/checkblahblahblah")
+        assert response.status_code == 302
+        assert response["Location"] == "/accounts/login/?next=/checkblahblahblah"


### PR DESCRIPTION
We noticed an attacker got a 500 trying to visit `/checkout/paypal.env`, rather than a 403 or redirect to login.
We were allowing any urls starting /check to be visited when not logged in, rather than just the /check endpoint.