### PR TITLE
Do not send unenrichable documents to enrichment

### DIFF
--- a/judgments/management/commands/enrich_next_in_reenrichment_queue.py
+++ b/judgments/management/commands/enrich_next_in_reenrichment_queue.py
@@ -35,5 +35,5 @@ class Command(BaseCommand):
             document = api_client.get_document_by_uri(document_uri)
 
             self.stdout.write(f"Sending document {document.name} to enrichment...")
-            document.enrich()
+            document.enrich(accept_failures=True)
             time.sleep(3)

--- a/judgments/views/enrich.py
+++ b/judgments/views/enrich.py
@@ -8,7 +8,7 @@ from judgments.utils.view_helpers import get_document_by_uri_or_404
 def enrich(request):
     document_uri = request.POST.get("document_uri", None)
     document = get_document_by_uri_or_404(document_uri)
-    enrichment_triggered = document.enrich(accept_failures=True)
+    enrichment_triggered = document.enrich(accept_failures=True, even_if_recent=True)
     if not enrichment_triggered:
         messages.error(
             request,

--- a/judgments/views/enrich.py
+++ b/judgments/views/enrich.py
@@ -8,7 +8,7 @@ from judgments.utils.view_helpers import get_document_by_uri_or_404
 def enrich(request):
     document_uri = request.POST.get("document_uri", None)
     document = get_document_by_uri_or_404(document_uri)
-    enrichment_triggered = document.enrich()
+    enrichment_triggered = document.enrich(accept_failures=True)
     if not enrichment_triggered:
         messages.error(
             request,


### PR DESCRIPTION
## Changes in this PR:

Calling `document.enrich(allow_failures=True)` will return `None` rather than raise an exception if it's not reasonable to enrich the document. This is good for both the cronjob (which will silently ignore and skip) and the UI (which will produce a sensible error)

It's possible that we should instead mark the document so that it is never reconsidered for enrichment in some way.

## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCL-1087