### PR TITLE
[FCL-1275] Display first published values in the EUI

### DIFF
--- a/ds_caselaw_editor_ui/templates/includes/judgment/first_published_datetime_component.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/first_published_datetime_component.html
@@ -1,0 +1,9 @@
+{% if document.has_ever_been_published %}
+  {% if document.first_published_datetime_display %}
+    {{ document.first_published_datetime_display|date:"SHORT_DATETIME_FORMAT" }}
+  {% else %}
+    Unknown
+  {% endif %}
+{% else %}
+  &mdash;
+{% endif %}

--- a/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
@@ -49,7 +49,7 @@
           <aside for="metadata_name" class="metadata-component__main-labels">
             TDR ref
           </aside>
-          <p>{{ judgment.consignment_reference }}</p>
+          <p>{% firstof judgment.consignment_reference "&mdash;" %}</p>
         </div>
         <div>
           <aside for="metadata_name" class="metadata-component__main-labels">

--- a/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
@@ -45,13 +45,13 @@
         </div>
       </div>
       <div class="metadata-component__right-column">
-        <div class="metadata-component__tdr">
+        <div>
           <aside for="metadata_name" class="metadata-component__main-labels">
             TDR ref
           </aside>
           <p>{{ judgment.consignment_reference }}</p>
         </div>
-        <div class="metadata-component__type">
+        <div>
           <aside for="metadata_name" class="metadata-component__main-labels">
             Type
           </aside>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/judgment_metadata_form.html
@@ -57,6 +57,12 @@
           </aside>
           <p>{{ judgment.document_noun|title }}</p>
         </div>
+        <div>
+          <aside for="metadata_name" class="metadata-component__main-labels">
+            First pub
+          </aside>
+          <p>{% include "includes/judgment/first_published_datetime_component.html" with document=judgment %}</p>
+        </div>
         <div class="metadata-component__actions">
           <input type="hidden" name="judgment_uri" value="{{ document_uri }}" />
           <input type="submit" value="Save" />

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -32,8 +32,8 @@
         <span class="judgment-metadata-panel__value">{{ judgment.document_noun|title }}</span>
       </li>
       <li>
-        <span class="judgment-metadata-panel__key">TDR ref</span>
-        <span class="judgment-metadata-panel__value">{{ judgment.consignment_reference }}</span>
+        <span class="judgment-metadata-panel__key">TDR reference</span>
+        <span class="judgment-metadata-panel__value">{% firstof judgment.consignment_reference "&mdash;" %}</span>
       </li>
     </ul>
   </div>

--- a/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
+++ b/ds_caselaw_editor_ui/templates/includes/judgment/metadata_panel_static.html
@@ -35,6 +35,12 @@
         <span class="judgment-metadata-panel__key">TDR reference</span>
         <span class="judgment-metadata-panel__value">{% firstof judgment.consignment_reference "&mdash;" %}</span>
       </li>
+      <li>
+        <span class="judgment-metadata-panel__key">First published</span>
+        <span class="judgment-metadata-panel__value">
+          {% include "includes/judgment/first_published_datetime_component.html" with document=judgment %}
+        </span>
+      </li>
     </ul>
   </div>
 </div>

--- a/judgments/tests/test_metadata_panel.py
+++ b/judgments/tests/test_metadata_panel.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import patch
 
 import lxml.html
@@ -36,3 +37,131 @@ class TestMetadataPanel(TestCase):
         assert root.xpath("//input[@id='court']/@value")[0] == "Court of Testing"
         assert root.xpath("//textarea[@class='metadata-component__metadata-name-input']")[0].text == "Test v Tested"
         assert response.status_code == 200
+
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_metadata_panel_tdr_reference(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri=DocumentURIString("d-9874f350-b187-4e1e-b301-c7d914d5db8c"),
+            consignment_reference="TDR-1234",
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(
+            reverse("full-text-html", kwargs={"document_uri": judgment.uri}),
+        )
+
+        self.assertContains(
+            response,
+            '<aside for="metadata_name" class="metadata-component__main-labels">TDR ref</aside><p>TDR-1234</p>',
+            html=True,
+        )
+
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_metadata_panel_no_tdr_reference(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri=DocumentURIString("d-9874f350-b187-4e1e-b301-c7d914d5db8c"),
+            consignment_reference=None,
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(
+            reverse("full-text-html", kwargs={"document_uri": judgment.uri}),
+        )
+
+        self.assertContains(
+            response,
+            '<aside for="metadata_name" class="metadata-component__main-labels">TDR ref</aside><p>&mdash;</p>',
+            html=True,
+        )
+
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_metadata_panel_first_published_not_published(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri=DocumentURIString("d-9874f350-b187-4e1e-b301-c7d914d5db8c"),
+            first_published_datetime=None,
+            has_ever_been_published=False,
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(
+            reverse("full-text-html", kwargs={"document_uri": judgment.uri}),
+        )
+
+        self.assertContains(
+            response,
+            '<aside for="metadata_name" class="metadata-component__main-labels">First pub</aside><p>&mdash;</p>',
+            html=True,
+        )
+
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_metadata_panel_first_published_unknown(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri=DocumentURIString("d-9874f350-b187-4e1e-b301-c7d914d5db8c"),
+            first_published_datetime=None,
+            has_ever_been_published=True,
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(
+            reverse("full-text-html", kwargs={"document_uri": judgment.uri}),
+        )
+
+        self.assertContains(
+            response,
+            '<aside for="metadata_name" class="metadata-component__main-labels">First pub</aside><p>Unknown</p>',
+            html=True,
+        )
+
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_metadata_panel_first_published_known(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri=DocumentURIString("d-9874f350-b187-4e1e-b301-c7d914d5db8c"),
+            first_published_datetime=datetime(2025, 8, 31, 12, 34),
+            has_ever_been_published=True,
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(
+            reverse("full-text-html", kwargs={"document_uri": judgment.uri}),
+        )
+
+        self.assertContains(
+            response,
+            '<aside for="metadata_name" class="metadata-component__main-labels">First pub</aside><p>31/08/2025 12:34 p.m.</p>',
+            html=True,
+        )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ requests~=2.32.3
 xmltodict~=0.15.0
 requests-toolbelt~=1.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=40.0.0
+ds-caselaw-marklogic-api-client~=41.1.0
 ds-caselaw-utils~=2.7.0
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
## Changes in this PR

- Tidy up some redundant classes
- Better handle null TDR references
- Display first published dates where known

## Jira

FCL-1275

## Screenshots of UI

### TDR and published

<img width="1656" height="253" alt="grc-md" src="https://github.com/user-attachments/assets/fdd5f549-5422-4254-a322-9239235b2f39" />

<img width="1154" height="149" alt="grc-static" src="https://github.com/user-attachments/assets/e194bfce-2fcd-4d9d-a0fe-3819397046ee" />

### TDR, not published

<img width="1656" height="253" alt="kbd-md" src="https://github.com/user-attachments/assets/94198fd8-1c2f-411d-9532-f6122d35091c" />

<img width="1154" height="149" alt="kbd-static" src="https://github.com/user-attachments/assets/51790177-bf07-4c26-b9a2-86eef3420635" />

### No TDR, published at unknown date

<img width="1656" height="253" alt="ukist-md" src="https://github.com/user-attachments/assets/dc4928bb-12d7-4195-b938-e1e756b22a29" />

<img width="1154" height="149" alt="ukist-static" src="https://github.com/user-attachments/assets/daf9caee-6f73-4472-be57-7f525c8a0a7e" />