### PR TITLE
[FCL-1289] Add additional messaging for editors to warn about identifier locking

### DIFF
--- a/ds_caselaw_editor_ui/templates/judgment/identifiers.html
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers.html
@@ -9,6 +9,11 @@
       <h2>Preferred identifier</h2>
       <b>{{ document.identifiers.preferred.schema.name }}: {{ document.identifiers.preferred.value }}</b>
       <h2>All identifiers</h2>
+      {% if document.has_ever_been_published %}
+        <div class="page-notification--info">
+          <span class="icon icon__circle-info"></span> You are not able to delete identifiers for this document because it has been published.
+        </div>
+      {% endif %}
       <div class="table">
         <table>
           <tr>

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers_add.html
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers_add.html
@@ -5,6 +5,11 @@
   <div class="container">
     <h1 class="judgment-component__confirmation-title">Add identifier for:</h1>
     <h2 class="judgment-component__confirmation-subtitle">{{ document.body.name }}</h2>
+    {% if document.has_ever_been_published %}
+      <div class="page-notification--warning">
+        <span class="icon icon__triangle-exclamation"></span> You cannot delete new identifiers once added because this document has been published.
+      </div>
+    {% endif %}
     {% error_summary form %}
     {% crispy form %}
   </div>

--- a/ds_caselaw_editor_ui/templates/judgment/publish.html
+++ b/ds_caselaw_editor_ui/templates/judgment/publish.html
@@ -6,6 +6,9 @@
     {% if judgment.is_publishable %}
       <h1 class="judgment-component__confirmation-title">I want to publish:</h1>
       <h2 class="judgment-component__confirmation-subtitle">{{ judgment.body.name }}</h2>
+      <div class="page-notification--info">
+        <span class="icon icon__circle-info"></span> Once published you will not be able to delete identifiers for this document, only mark them as deprecated.
+      </div>
       <form aria-label="publish judgment"
             action="{% url 'publish' %}"
             method="post">


### PR DESCRIPTION
## Changes in this PR

Add three new information/warning messages:

- On identifier list for published documents, explain why identifiers can't be deleted
- On add new identifier page for published document, warn that new identifiers will be undeletable
- On publish document page, warn that identifeirs will become undeletable

## Jira

FCL-1289

## Screenshots of UI changes

### Identifier list

<img width="1176" height="170" alt="Screenshot 2025-09-16 at 11 40 42" src="https://github.com/user-attachments/assets/40b36e60-e822-4a93-84fe-34d4d6f202c7" />

### Add identifier

<img width="1183" height="495" alt="Screenshot 2025-09-16 at 11 40 54" src="https://github.com/user-attachments/assets/7d1a1cb5-bf33-46d2-b604-15b91ca3343b" />

### Publish document

<img width="1174" height="269" alt="Screenshot 2025-09-16 at 11 42 05" src="https://github.com/user-attachments/assets/75a94e0d-5b8c-469c-af5f-d69a4ff9da22" />



