### PR TITLE
FCL-1306 | set overflow to initial when viewing judgment in desktop mode

### DIFF
--- a/ds_caselaw_editor_ui/sass/includes/_judgment_text_source.scss
+++ b/ds_caselaw_editor_ui/sass/includes/_judgment_text_source.scss
@@ -31,6 +31,6 @@
   overflow: scroll;
 
   @media (min-width: $grid-breakpoint-medium) {
-    overflow: auto;
+    overflow: initial;
   }
 }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Fixes an issue with the judgment display for judgments that are wider than our default not showing nicely.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-1306
