### PR TITLE
ci: add production smoke test and modernise docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,5 @@
 .pre-commit-config.yaml
 .readthedocs.yml
 .travis.yml
+node_modules
 venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           name: django-image
           path: /tmp/django-image.tar
 
-  build-production-dockerfile:
+  production-smoke-test:
     needs: linter
     runs-on: ubuntu-latest
 
@@ -97,18 +97,25 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Build production Dockerfile
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      - name: Copy .env.example file
+        uses: canastro/copy-file-action@ae66602ce7d214dbd2e298c1db67a81388755a0a
         with:
-          context: .
-          file: ./Dockerfile
-          push: false
-          tags: ds-caselaw-editor-ui:production-test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          source: ".env.example"
+          target: ".env"
+
+      - name: Create external network
+        run: docker network create caselaw
+
+      - name: Build and run production smoke test
+        run: docker compose -f docker-compose.yml -f docker-compose.prod-test.yml up -d --build --wait --wait-timeout 600
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yml -f docker-compose.prod-test.yml logs
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.prod-test.yml down
 
   download-postgres:
     needs: linter
@@ -130,6 +137,9 @@ jobs:
         with:
           source: ".env.example"
           target: ".env"
+
+      - name: Create external network
+        run: docker network create caselaw
 
       - name: Download Postgres image
         run: docker compose pull postgres
@@ -159,6 +169,9 @@ jobs:
         with:
           source: ".env.example"
           target: ".env"
+
+      - name: Create external network
+        run: docker network create caselaw
 
       - name: Download Django image
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -197,6 +210,9 @@ jobs:
         with:
           source: ".env.example"
           target: ".env"
+
+      - name: Create external network
+        run: docker network create caselaw
 
       - name: Download Django image
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -321,10 +337,6 @@ jobs:
           name: playwright-snapshots
           path: "./main/e2e_tests/snapshots"
           retention-days: 7
-
-      # - name: Tear down marklogic
-      #   run: docker compose down
-      #   working-directory: "./marklogic"
 
       - name: Tear down the Stack
         run: docker compose down

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       - id: check-merge-conflict
       - id: check-xml
       - id: check-yaml
+        args: [--unsafe] # Allow !reset tag for clearing inherited volumes in prod test config. See https://github.com/pre-commit/pre-commit-hooks/issues/1090 issue comment for context.
       - id: end-of-file-fixer
       - id: forbid-submodules
       - id: mixed-line-ending

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,24 +62,35 @@ COPY --from=python-build-stage /usr/src/app/wheels  /wheels/
 # use wheels to install python dependencies
 RUN pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \
   && rm -rf /wheels/
-COPY --chown=django:django package-lock.json package-lock.json
-COPY --chown=django:django package.json package.json
+
+# Install Node.js dependencies (as root)
+COPY package-lock.json package.json ./
 RUN npm ci --engine-strict=true
-COPY --chown=django:django ./docker/entrypoint /entrypoint
+
+# Copy application code (owned by root)
+COPY . ${APP_HOME}
+
+# Copy and prepare production scripts (owned by root)
+COPY ./docker/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
 RUN chmod +x /entrypoint
 
-
-COPY --chown=django:django ./docker/start /start
+COPY ./docker/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 
-# copy application code to WORKDIR
-COPY --chown=django:django . ${APP_HOME}
+# Grant django user write access to directories written at runtime:
+# - media/logs: application data
+# - static: build outputs from npm run build (webpack + sass) and collectstatic
+RUN mkdir -p ${APP_HOME}/media ${APP_HOME}/logs ${APP_HOME}/staticfiles \
+    && chown -R django:django \
+    ${APP_HOME}/media \
+    ${APP_HOME}/logs \
+    ${APP_HOME}/ds_caselaw_editor_ui/static \
+    ${APP_HOME}/staticfiles
 
-# make django owner of the WORKDIR directory as well.
-RUN chown django:django ${APP_HOME}
-
+# Run as non-root user in production
+# User can write to media/logs/staticfiles but cannot modify application code
 USER django
 
 ENTRYPOINT ["/entrypoint"]

--- a/README.md
+++ b/README.md
@@ -22,16 +22,37 @@ manager or [download a `.deb` or
 
 Once installed, we need to build our containers. We use
 [`docker compose`](https://docs.docker.com/compose/) to orchestrate the
-building of the project's containers, one for each each service:
+building of the project's containers:
 
-### `django`
+### Services
 
-Our custom container responsible for running the application. Built from the
-official [python 3.12](https://hub.docker.com/_/python/) base image
+- **`django`** — The application container, built from a local dev Dockerfile by default
+- **`postgres`** — PostgreSQL database
+- **`marklogic`** — Local MarkLogic instance (included in compose by default)
+- **`e2e_tests`** — Playwright end-to-end tests (opt-in via `--profile e2e_tests`)
 
-### `postgres`
+### Compose files
 
-The database service built from the official [postgres](https://hub.docker.com/_/postgres/) image
+#### `docker-compose.yml` — Local development (default)
+
+The base compose file uses the local dev Dockerfile (`compose/local/django/Dockerfile`). This stage installs all dependencies (including dev dependencies) but does **not** run the application server — instead it runs `tail -f /dev/null` so the container stays alive and you use `fab run` or `docker exec` to start the Django dev server, watch Sass, etc. Source code is mounted from the host (`.:/app:z`) so edits are reflected immediately without rebuilding.
+
+#### `docker-compose.prod-test.yml` — Production image verification
+
+This override file targets the production `Dockerfile`, which is the same image deployed to AWS ECS. Key differences from the local stage:
+
+- **No volume mounts** — the app runs entirely from the files baked into the image, exactly as it would in production.
+- **Separate entrypoint and start scripts** — `docker/entrypoint` waits for Postgres and runs migrations, then `docker/start` compiles frontend assets (`npm run build`), collects static files (`collectstatic`), and starts gunicorn on port 5000.
+- **Runs as the `django` user** — not root, matching the production security model.
+- **Includes a healthcheck** — polls `http://localhost:5000/check` to confirm the app is actually serving traffic, not just that the container started.
+
+You won't use this during normal development, but it lets you catch production-only failures locally — for example, file permission issues, missing static assets, or entrypoint bugs that volume mounts would mask. CI runs this automatically on every push using `docker compose ... up --build --wait` to verify the production image builds and starts successfully before merging.
+
+To verify the production image locally:
+
+```console
+docker compose -f docker-compose.yml -f docker-compose.prod-test.yml up --build --wait
+```
 
 ## Getting started
 
@@ -45,31 +66,26 @@ The database service built from the official [postgres](https://hub.docker.com/_
 $ cp .env.example .env
 ```
 
-### 2. Get access to Marklogic
+### 2. MarkLogic
 
-This app is intended to edit Judgments in the Marklogic database defined in [ds-find-caselaw-docs/marklogic](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/marklogic).
+This app connects to the MarkLogic database defined in [ds-find-caselaw-docs/marklogic](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/marklogic).
 
-If you wish to run your own Marklogic instance, you will need to follow the setup instructions for it at
-[ds-find-caselaw-docs/marklogic](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/marklogic).
+A basic local MarkLogic instance is included in `docker-compose.yml` and starts automatically with `fab run` / `docker compose up`. This is enough to get the application running without needing a separate repo or VPN access, but the local MarkLogic setup may need further development — see the [ds-find-caselaw-docs/marklogic](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/marklogic) repo for full configuration details.
 
-For TNA/dxw developers, it is simpler to access the shared [staging Marklogic database](https://national-archives.atlassian.net/wiki/spaces/DFCL/pages/1152974873/MarkLogic+database+location) via VPN,
-and then set the `MARKLOGIC_HOST`, `MARKLOGIC_USER`, and `MARKLOGIC_PASSWORD` variables in your `.env` file.
+Alternatively, TNA/dxw developers can connect to the shared [staging MarkLogic database](https://national-archives.atlassian.net/wiki/spaces/DFCL/pages/1152974873/MarkLogic+database+location) via VPN by setting `MARKLOGIC_HOST`, `MARKLOGIC_USER`, and `MARKLOGIC_PASSWORD` in your `.env` file.
 
-### 3. Build Docker containers
+### 3. Create Docker network
+
+The compose files in this repo and in other caselaw services share an external network named `caselaw`. Create it if it does not yet exist:
+
+```console
+docker network create caselaw
+```
+
+### 4. Build Docker containers
 
 ```console
 $ fab build
-```
-
-### 4. Run Marklogic
-
-**Note** If you are using the staging instance of Marklogic, you do not need to
-follow this step.
-
-Switch to the location of `ds-find-caselaw-docs/marklogic` and run:
-
-```console
-$ docker compose up
 ```
 
 ### 5. Start Docker containers
@@ -79,15 +95,6 @@ you can run these.
 
 ```console
 $ fab start
-```
-
-#### Create Docker network
-
-You may need to create a docker network if you are running the docker containers for the first time. If you see an
-error message referring to a docker network, run:
-
-```console
-$ docker network create caselaw
 ```
 
 ### 6. Add a django user so you can log in

--- a/docker-compose.prod-test.yml
+++ b/docker-compose.prod-test.yml
@@ -1,0 +1,30 @@
+# Production image verification.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.prod-test.yml up --build --wait
+services:
+  django:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      args:
+        BUILD_ENVIRONMENT: production
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes: !reset []
+    environment:
+      DJANGO_SETTINGS_MODULE: config.settings.production
+    ports:
+      - "5001:5000"
+    command: ["/start"]
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:5000/check')",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 120s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,47 +5,101 @@ services:
       context: .
       dockerfile: ./compose/local/django/Dockerfile
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+      marklogic:
+        condition: service_healthy
+    init: true
     volumes:
       - .:/app:z
       - ../ds-caselaw-custom-api-client:/apiclient
-    init: true
     environment:
-      DATABASE_URL: "postgres://postgres:admin@postgres:5432/ds_judgments_editor_ui"
-      DJANGO_SETTINGS_MODULE: "config.settings.local"
-      SECRET_KEY: local_dev_secret_key
-      SECURE_SSL_REDIRECT: "false"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-admin}@postgres:5432/${POSTGRES_DB:-ds_judgments_editor_ui}"
+      DJANGO_SETTINGS_MODULE: config.settings.local
+      SECRET_KEY: ${SECRET_KEY:-local_dev_secret_key}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-local_dev_secret_key}
+      DJANGO_ADMIN_URL: ${DJANGO_ADMIN_URL:-admin/}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1,0.0.0.0}
+      ROLLBAR_ACCESS_TOKEN: ${ROLLBAR_ACCESS_TOKEN:-}
+      ROLLBAR_ENV: ${ROLLBAR_ENV:-development}
+      SECURE_SSL_REDIRECT: ${SECURE_SSL_REDIRECT:-false}
+      DJANGO_SECURE_SSL_REDIRECT: ${DJANGO_SECURE_SSL_REDIRECT:-false}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: ${POSTGRES_DB:-ds_judgments_editor_ui}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin}
+      MARKLOGIC_HOST: ${MARKLOGIC_HOST:-marklogic}
+      MARKLOGIC_USER: ${MARKLOGIC_USER:-admin}
+      MARKLOGIC_PASSWORD: ${MARKLOGIC_PASSWORD:-admin}
+      MARKLOGIC_USE_HTTPS: ${MARKLOGIC_USE_HTTPS:-false}
+      WSGI_AUTH_EXCLUDE_PATHS: ${WSGI_AUTH_EXCLUDE_PATHS:-/check}
+      JIRA_INSTANCE: ${JIRA_INSTANCE:-placeholder.atlassian.net}
+      MAILGUN_API_KEY: ${MAILGUN_API_KEY:-placeholder}
+      MAILGUN_DOMAIN: ${MAILGUN_DOMAIN:-placeholder}
     env_file:
       - ./.env
     ports:
       - "3000:3000"
-    # do nothing forever - exec commands elsewhere
     command: tail -f /dev/null
 
   postgres:
     image: postgres:18.2@sha256:b6b4d0b75c699a2c94dfc5a94fe09f38630f3b67ab0e1653ede1b7ac8e13c197
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_DB: ds_judgments_editor_ui
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: admin
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      PGDATABASE: ds_judgments_editor_ui
-      PGUSER: postgres
-      PGPASSWORD: admin
+      POSTGRES_DB: ${POSTGRES_DB:-ds_judgments_editor_ui}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin}
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - ./database_backups:/backups:z
+
+  marklogic:
+    image: progressofficial/marklogic-db:12.0.1-ubi-rootless-2.2.4@sha256:2159236c8d6a52d41a84a50822864d99d528789489e8247e81dd2922cb0711c6
+    container_name: marklogic
+    hostname: marklogic
+    dns_search: ""
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'curl http://localhost:8002/manage/v2?view=healthcheck -u "admin:admin" || exit 1',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    environment:
+      - MARKLOGIC_INIT=true
+      - MARKLOGIC_ADMIN_USERNAME=admin
+      - MARKLOGIC_ADMIN_PASSWORD=admin
+      - REALM=public
+      - TZ=Europe/London
+    volumes:
+      - marklogic_data:/var/opt/MarkLogic
+    ports:
+      - 8000-8010:8000-8010
 
   e2e_tests:
     container_name: e2e_tests_container
     build:
       context: ./e2e_tests
       dockerfile: "../compose/local/e2e_tests/Dockerfile"
-
     profiles: [e2e_tests]
     volumes:
       - "./e2e_tests:/app:z"
     tty: true
+
+volumes:
+  marklogic_data:
+
+networks:
+  default:
+    name: caselaw
+    external: true


### PR DESCRIPTION
## Changes in this PR:

Get EUI inline with changes to dockerfile/compose made in PUI for consistency.

- Replace build-only CI step with compose-based production smoke test
- Add docker-compose.prod-test.yml overlay targeting production Dockerfile
- Add MarkLogic and postgres healthchecks with service_healthy depends_on
- Replace hardcoded env vars and env_file with ${VAR:-default} syntax
- Fix Dockerfile permissions: app owned by root, only runtime dirs chowned
- Add node_modules to .dockerignore, --unsafe to check-yaml pre-commit
- Update README with compose files, MarkLogic, and network docs



## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-624