### PR TITLE
migrate to lxml

### DIFF
--- a/judgments/tests/test_stub.py
+++ b/judgments/tests/test_stub.py
@@ -3,10 +3,10 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 from caselawclient.Client import ROOT_DIR
 from caselawclient.models.judgments import Judgment
-from defusedxml import ElementTree
 from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
 from django.test import TestCase
+from lxml import etree
 
 from judgments.views.stub import ANNOTATION
 
@@ -73,7 +73,7 @@ class TestStubView(TestCase):
     @patch("judgments.views.stub.api_client.set_property")
     def test_judgment_stub_post(self, mock_set_property, mock_insert_xml, mock_render_stub, mock_uuid, mock_courts):
         judgment_template_path = Path(ROOT_DIR) / "models" / "documents" / "templates" / "judgment.xml"
-        with (judgment_template_path).open("r") as f:
+        with (judgment_template_path).open("rb") as f:
             template = f.read()
         mock_render_stub.return_value = template
         superuser = User.objects.create_superuser(username="clark")
@@ -107,7 +107,7 @@ class TestStubView(TestCase):
             ],
         )
 
-        document_xml_bytes = ElementTree.tostring(mock_insert_xml.call_args.kwargs["document_xml"])
+        document_xml_bytes = etree.tostring(mock_insert_xml.call_args.kwargs["document_xml"])
 
         assert b"ns0" not in document_xml_bytes
         assert b"<uk:" in document_xml_bytes
@@ -115,7 +115,7 @@ class TestStubView(TestCase):
 
     @patch("judgments.views.stub.courts.get_all", return_value=[make_mock_court()])
     @patch("judgments.views.stub.uuid4", return_value="uuid")
-    @patch("judgments.views.stub.render_stub_xml", return_value="<xml />")
+    @patch("judgments.views.stub.render_stub_xml", return_value=b"<xml />")
     @patch("judgments.views.stub.api_client.insert_document_xml")
     def test_judgment_stub_post_invalid_court(self, mock_insert_xml, mock_render_stub, mock_uuid, mock_courts):
         superuser = User.objects.create_superuser(username="clark")

--- a/judgments/views/stub.py
+++ b/judgments/views/stub.py
@@ -1,4 +1,3 @@
-import xml.etree.ElementTree as ET
 from datetime import UTC, date, datetime
 from uuid import uuid4
 
@@ -6,8 +5,6 @@ from caselawclient.models.documents.stub import EditorStubData, PartyData, rende
 from caselawclient.models.documents.versions import VersionAnnotation, VersionType
 from caselawclient.models.judgments import Judgment
 from caselawclient.types import DocumentURIString
-from caselawclient.xml_helpers import DEFAULT_NAMESPACES
-from defusedxml import ElementTree
 from django import forms
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -17,6 +14,7 @@ from django.shortcuts import render
 from django.views.generic import TemplateView
 from ds_caselaw_utils.courts import CourtNotFoundException, courts
 from ds_caselaw_utils.types import CourtCode
+from lxml import etree
 
 from judgments.utils import api_client
 from judgments.utils.view_helpers import (
@@ -30,12 +28,6 @@ ANNOTATION = VersionAnnotation(
     message="Stub document created",
     payload={},
 )
-
-# avoid "<ns0:...>" appearing in XML output
-for namespace_name, namespace_uri in DEFAULT_NAMESPACES.items():
-    actual_namespace_name = "" if namespace_name == "akn" else namespace_name
-    # register namespace does not exist on defusedxml, unhelpfully.
-    ET.register_namespace(actual_namespace_name, namespace_uri)
 
 
 def is_valid_court(court_code):
@@ -259,8 +251,7 @@ def create_stub(request):
 
     document_uri = DocumentURIString("d-" + str(uuid4()))
     rendered_stub = render_stub_xml(stub_data)
-
-    element = ElementTree.fromstring(rendered_stub)
+    element = etree.fromstring(rendered_stub)
 
     # create document in Marklogic
     api_client.insert_document_xml(


### PR DESCRIPTION
FCLC-1930

Support the breaking changes in the API client's most recent version which migrates from xml/defusedxml to lxml

<!-- Amend as appropriate -->

## Changes in this PR:

## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
