### PR TITLE
NCN on stub page

### DIFF
--- a/judgments/tests/test_stub.py
+++ b/judgments/tests/test_stub.py
@@ -28,6 +28,7 @@ post_data = {
     "respondents": "Cathy\nDarren",
     "appellants": "Emily\nFred",
     "defendants": "Gertrude",
+    "ncn": "[2024] UKSC 123",
 }
 
 # The data actually sent to the renderer
@@ -47,6 +48,7 @@ formatted_data = {
         {"role": "Appellant", "name": "Fred"},
         {"role": "Defendant", "name": "Gertrude"},
     ],
+    "ncn": "[2024] UKSC 123",
 }
 
 
@@ -71,7 +73,16 @@ class TestStubView(TestCase):
     @patch("judgments.views.stub.render_stub_xml")
     @patch("judgments.views.stub.api_client.insert_document_xml")
     @patch("judgments.views.stub.api_client.set_property")
-    def test_judgment_stub_post(self, mock_set_property, mock_insert_xml, mock_render_stub, mock_uuid, mock_courts):
+    @patch("judgments.views.stub.api_client.get_document_by_uri")
+    def test_judgment_stub_post(  # noqa: PLR0913 -- too many args
+        self,
+        mock_get_doc,
+        mock_set_property,
+        mock_insert_xml,
+        mock_render_stub,
+        mock_uuid,
+        mock_courts,
+    ):
         judgment_template_path = Path(ROOT_DIR) / "models" / "documents" / "templates" / "judgment.xml"
         with (judgment_template_path).open("rb") as f:
             template = f.read()

--- a/judgments/tests/test_stub.py
+++ b/judgments/tests/test_stub.py
@@ -1,7 +1,5 @@
-from pathlib import Path
 from unittest.mock import ANY, MagicMock, call, patch
 
-from caselawclient.Client import ROOT_DIR
 from caselawclient.models.judgments import Judgment
 from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
@@ -83,10 +81,10 @@ class TestStubView(TestCase):
         mock_uuid,
         mock_courts,
     ):
-        judgment_template_path = Path(ROOT_DIR) / "models" / "documents" / "templates" / "judgment.xml"
-        with (judgment_template_path).open("rb") as f:
-            template = f.read()
-        mock_render_stub.return_value = template
+        # judgment_template_path = Path(ROOT_DIR) / "models" / "documents" / "templates" / "judgment.xml"
+        # with (judgment_template_path).open("rb") as f:
+        #     template = f.read()
+        mock_render_stub.return_value = '<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"><uk:test/></akomaNtoso>'
         superuser = User.objects.create_superuser(username="clark")
         self.client.force_login(superuser)
         _response = self.client.post(

--- a/judgments/views/stub.py
+++ b/judgments/views/stub.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from caselawclient.models.documents.stub import EditorStubData, PartyData, render_stub_xml
 from caselawclient.models.documents.versions import VersionAnnotation, VersionType
+from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber, NeutralCitationNumberSchema
 from caselawclient.models.judgments import Judgment
 from caselawclient.types import DocumentURIString
 from django import forms
@@ -36,6 +37,14 @@ def is_valid_court(court_code):
     except CourtNotFoundException as error:
         msg = f"Court code {court_code} not recognised"
         raise ValidationError(msg) from error
+
+
+def is_valid_or_empty_ncn(ncn):
+    if not ncn:
+        return
+    if not NeutralCitationNumberSchema.validate_identifier_value(ncn):
+        msg = f"NCN '{ncn}' is not valid"
+        raise ValidationError(msg)
 
 
 class GovukDateInputWidgetBase(forms.Widget):
@@ -119,6 +128,15 @@ class StubForm(forms.Form):
             "required": "Enter the submitter email address",
         },
     )
+    ncn = forms.CharField(
+        label="Neutral citation",
+        validators=[is_valid_or_empty_ncn],
+        error_messages={
+            "invalid": "Enter a valid NCN, or remove it",
+        },
+        required=False,
+    )
+
     decision_date = GovukDateField(
         label="Decision date",
         error_messages={
@@ -143,6 +161,7 @@ class StubForm(forms.Form):
     year = forms.IntegerField(
         label="Year",
         min_value=1001,
+        help_text="This must agree with the NCN, if available",
         error_messages={
             "required": "Enter the year of the case",
         },
@@ -229,6 +248,7 @@ def create_stub(request):
     respondents = list_from_string(stub_form["respondents"].value())
     appellants = list_from_string(stub_form["appellants"].value())
     defendants = list_from_string(stub_form["defendants"].value())
+    ncn = stub_form["ncn"].value()
 
     parties = (
         [PartyData(role="Claimant", name=claimant) for claimant in claimants]
@@ -246,10 +266,12 @@ def create_stub(request):
             "year": str(stub_form["year"].value()),
             "case_numbers": case_numbers,
             "parties": parties,
+            "ncn": ncn,
         },
     )
 
     document_uri = DocumentURIString("d-" + str(uuid4()))
+
     rendered_stub = render_stub_xml(stub_data)
     element = etree.fromstring(rendered_stub)
 
@@ -263,6 +285,11 @@ def create_stub(request):
     api_client.set_property(document_uri, "source-name", stub_form["source_name"].value())
     api_client.set_property(document_uri, "source-email", stub_form["source_email"].value())
     api_client.set_property(document_uri, "email-received-at", stub_form["email_received_at"].value())
+
+    if ncn.strip():
+        document = api_client.get_document_by_uri(document_uri)
+        document.identifiers.add(NeutralCitationNumber(ncn.strip()))
+        document.save_identifiers()
 
     messages.success(
         request,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ requests~=2.34.0
 xmltodict~=1.0.2
 requests-toolbelt~=1.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==46.1.1
+ds-caselaw-marklogic-api-client==47.0.0
 ds-caselaw-utils==4.7.0
 rollbar
 django-stronghold==0.4.0


### PR DESCRIPTION
This needs to change in sync with the version of the API client as the spec for the data passed is in the API client.

This requires https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/1782 merged in the API client.

## Changes in this PR:
<img width="839" height="353" alt="image" src="https://github.com/user-attachments/assets/e8cc9e6c-a9d5-4225-a966-8f8d779ea4e4" />

<img width="911" height="219" alt="image" src="https://github.com/user-attachments/assets/1e9b2b79-9554-4160-b9ad-4fa095d11ff7" />
