### PR TITLE
Fclc 2009/fix postgress download setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,7 @@ jobs:
       run:
         working-directory: ./main
 
+    if: always()
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5.2.0
         with:
-          version: v29.5.3
+          version: v29.5.2
 
       - name: Copy .env.example file
         uses: canastro/copy-file-action@ae66602ce7d214dbd2e298c1db67a81388755a0a


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Explicitly make the e2e required to always run so github doesn't skip it if the prerequisites fail.

Fixed the version issue on the postgres download step.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2009
