### PR TITLE
Ensure docker doesn't expose ports externally

### DIFF
--- a/docker-compose.prod-test.yml
+++ b/docker-compose.prod-test.yml
@@ -14,7 +14,8 @@ services:
     environment:
       DJANGO_SETTINGS_MODULE: config.settings.production
     ports:
-      - "5001:5000"
+      - "127.0.0.1:5001:5000"
+      - "[::1]:5001:5000"
     command: ["/start"]
     healthcheck:
       test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,8 @@ services:
     env_file:
       - ./.env
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
+      - "[::1]:3000:3000"
     command: tail -f /dev/null
 
   postgres:
@@ -51,7 +52,8 @@ services:
       timeout: 3s
       retries: 10
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
+      - "[::1]:5432:5432"
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-ds_judgments_editor_ui}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
@@ -84,7 +86,8 @@ services:
     volumes:
       - marklogic_data:/var/opt/MarkLogic
     ports:
-      - 8000-8010:8000-8010
+      - "127.0.0.1:8000-8010:8000-8010"
+      - "[::1]:8000-8010:8000-8010"
 
   e2e_tests:
     container_name: e2e_tests_container


### PR DESCRIPTION
[There is a warning about exposing all ports in the docker docs](https://docs.docker.com/engine/network/port-publishing/)

> Publishing container ports is insecure by default. Meaning, when you publish a container's ports it becomes available not only to the Docker host, but to the outside world as well.
> If you include the localhost IP address (127.0.0.1, or ::1) with the publish flag, only the Docker host can access the published container port.
> `docker run -p 127.0.0.1:8080:80 -p '[::1]:8080:80' nginx`

A similar warning exists for [ports](https://docs.docker.com/reference/compose-file/services/#ports).

* Ensure we only expose to localhost (ipv4 or ipv6 respectively) for `docker compose` and `docker run`
