### PR TITLE
FCLC-2072 | fix pagination on search results

### DIFF
--- a/ds_caselaw_editor_ui/templates/judgment/results.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/results.jinja
@@ -2,7 +2,9 @@
 {% from "components/search_form.jinja" import search_form with context %}
 {% from "components/pagination.jinja" import pagination %}
 {% from "components/documents_table.jinja" import documents_table, documents_table_item %}
+{% from "includes/document_breadcrumbs.jinja" import render_breadcrumbs %}
 {% block breadcrumbs %}
+  {{ render_breadcrumbs('results', 'Search results') }}
 {% endblock breadcrumbs %}
 {% block content %}
   {{ search_form() }}

--- a/ds_caselaw_editor_ui/templates/judgment/results.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/results.jinja
@@ -1,0 +1,13 @@
+{% extends "layouts/base.jinja" %}
+{% from "components/search_form.jinja" import search_form with context %}
+{% from "components/pagination.jinja" import pagination %}
+{% from "components/documents_table.jinja" import documents_table, documents_table_item %}
+{% block breadcrumbs %}
+{% endblock breadcrumbs %}
+{% block content %}
+  {{ search_form() }}
+  {% call documents_table(total_count=total, total_count_postfix="unpublished documents") %}
+    {% for document in documents %}{{ documents_table_item(document=document) }}{% endfor %}
+  {% endcall %}
+  <div class="container">{{ pagination(pagination_data) }}</div>
+{% endblock content %}

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -36,7 +36,7 @@ from .views.judgment_publish import (
     publish,
     unpublish,
 )
-from .views.results import results
+from .views.results import ResultsView
 from .views.signed_asset import redirect_to_signed_asset
 from .views.stub import CreateStubView, create_stub
 from .views.style_guide import (
@@ -60,7 +60,7 @@ urlpatterns = [
         name="components",
     ),
     # Search
-    path("results", results, name="results"),
+    path("results", ResultsView.as_view(), name="results"),
     # redirect to signed asset URLs
     path("signed-asset/<path:key>", redirect_to_signed_asset, name="signed-asset"),
     # Judgment verbs

--- a/judgments/views/results.py
+++ b/judgments/views/results.py
@@ -1,21 +1,42 @@
 from caselawclient.Client import MarklogicAPIError
-from django.http import Http404, HttpResponse
-from django.template import loader
+from django.http import Http404
 
 from judgments.utils.view_helpers import get_search_parameters, get_search_results
 
+from .paginated_view import PaginatedView
 
-def results(request):
-    try:
-        params = get_search_parameters(request.GET)
-        results = get_search_results(params)
-        context = results | {
-            "page_title": "Search results",
-            "query_string": f"query={params['query']}",
-        }
-    except MarklogicAPIError as e:
-        msg = f"Search error, {e}"
-        raise Http404(msg) from e  # TODO: This should be something else!
 
-    template = loader.get_template("judgment/results.html")
-    return HttpResponse(template.render(context, request))
+class ResultsView(PaginatedView):
+    template_engine = "jinja"
+    template_name = "judgment/results.jinja"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        try:
+            params = get_search_parameters(self.request.GET)
+            results = get_search_results(params)
+
+        except MarklogicAPIError as e:
+            msg = f"Search error, {e}"
+            raise Http404(msg) from e  # TODO: This should be something else!
+
+        else:
+            context["documents"] = results["judgments"]
+
+            context.update(results)
+            context.update(
+                {
+                    "page_title": "Search results",
+                    "query_string": f"query={params['query']}",
+                },
+            )
+
+            paginator = results["paginator"]
+
+            context["pagination_data"] = self.get_pagination_context(
+                request=self.request,
+                paginator=paginator,
+            )
+
+            return context


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

We missed migrating the results page to jinja, so it was using the old pagination.

Will follow this PR up with a snapshot test on search results.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2072

## Screenshots of UI changes:

<img width="870" height="729" alt="image" src="https://github.com/user-attachments/assets/dfec7c3e-07c3-470e-a2b1-3b3c274551aa" />
