### PR TITLE
Use Document.metadata layer in metadata panel

### DIFF
--- a/ds_caselaw_editor_ui/templates/components/document_metadata.jinja
+++ b/ds_caselaw_editor_ui/templates/components/document_metadata.jinja
@@ -1,7 +1,8 @@
-{% from "components/badge.jinja" import badge %}
 {% from "components/icon.jinja" import icon %}
 {% from "components/button.jinja" import button %}
+{% from "components/document_metadata_item.jinja" import document_metadata_item %}
 {% macro document_metadata(document=None, preferred_ncn=None, full_details=True) %}
+  {% set metadata = document.metadata if document.metadata is defined else {} %}
   <div class="aside__container" data-aside-toggle>
     <button class="aside__toggle" data-aside-toggle-button>
       <span class="icon icon__chevron-left"></span>
@@ -23,19 +24,19 @@
           <div>
             <dt>Court</dt>
             <dd>
-              {{ document.body.court_and_jurisdiction_identifier_string|or_no_data_available_label }}
+              {{ document_metadata_item(metadata_item=metadata.court) }}
             </dd>
           </div>
           <div>
             <dt>Judgment date</dt>
             <dd>
-              {{ document.body.document_date_as_date | date("%-d %b %Y") }}
+              {{ document_metadata_item(metadata_item=metadata.date, date_format="%-d %b %Y") }}
             </dd>
           </div>
           <div>
             <dt>Name</dt>
             <dd>
-              {{ document.body.name }}
+              {{ document_metadata_item(metadata_item=metadata.name) }}
             </dd>
           </div>
           <div>
@@ -74,13 +75,13 @@
         <div>
           <dt>Jurisdiction</dt>
           <dd>
-            {{ document.body.jurisdiction|or_no_data_available_label }}
+            {{ document_metadata_item(metadata_item=metadata.jurisdiction) }}
           </dd>
         </div>
         <div>
           <dt>Case number</dt>
           <dd>
-            {{ document.body.case_number|or_no_data_available_label }}
+            {{ document_metadata_item(metadata_item=metadata.case_number) }}
           </dd>
         </div>
         <div>
@@ -104,13 +105,7 @@
         <div>
           <dt>Categories</dt>
           <dd>
-            {% if document.body.categories %}
-              {% for category in document.body.categories %}
-                {{ badge(content=category) }}
-              {% endfor %}
-            {% else %}
-              {{ None|or_no_data_available_label }}
-            {% endif %}
+            {{ document_metadata_item(metadata_item=metadata.categories) }}
           </dd>
         </div>
         <div>

--- a/ds_caselaw_editor_ui/templates/components/document_metadata_item.jinja
+++ b/ds_caselaw_editor_ui/templates/components/document_metadata_item.jinja
@@ -1,18 +1,20 @@
 {% from "components/badge.jinja" import badge %}
 {% macro document_metadata_item(metadata_item, date_format=None) %}
-  {% if metadata_item.values is defined %}
-    {% if metadata_item.values %}
-      {% for value in metadata_item.values %}
+  {% set values = metadata_item.values if metadata_item.values is defined else none %}
+  {% set value = metadata_item.value if metadata_item.value is defined else none %}
+  {% if values is not none %}
+    {% if values %}
+      {% for value in values %}
         {{ badge(content=value) }}
       {% endfor %}
     {% else %}
       {{ None|or_no_data_available_label }}
     {% endif %}
   {% else %}
-    {% if date_format and metadata_item.value %}
-      {{ metadata_item.value | date(date_format) }}
+    {% if date_format and value %}
+      {{ value | date(date_format) }}
     {% else %}
-      {{ metadata_item.value|or_no_data_available_label }}
+      {{ value|or_no_data_available_label }}
     {% endif %}
   {% endif %}
 {% endmacro %}

--- a/ds_caselaw_editor_ui/templates/components/document_metadata_item.jinja
+++ b/ds_caselaw_editor_ui/templates/components/document_metadata_item.jinja
@@ -1,0 +1,18 @@
+{% from "components/badge.jinja" import badge %}
+{% macro document_metadata_item(metadata_item, date_format=None) %}
+  {% if metadata_item.values is defined %}
+    {% if metadata_item.values %}
+      {% for value in metadata_item.values %}
+        {{ badge(content=value) }}
+      {% endfor %}
+    {% else %}
+      {{ None|or_no_data_available_label }}
+    {% endif %}
+  {% else %}
+    {% if date_format and metadata_item.value %}
+      {{ metadata_item.value | date(date_format) }}
+    {% else %}
+      {{ metadata_item.value|or_no_data_available_label }}
+    {% endif %}
+  {% endif %}
+{% endmacro %}

--- a/judgments/tests/test_metadata_panel.py
+++ b/judgments/tests/test_metadata_panel.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import lxml.html
@@ -8,6 +9,9 @@ from caselawclient.models.judgments import Judgment
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
+from jinja2 import PackageLoader
+
+from judgments.jinja import environment
 
 
 class TestMetadataPanel(TestCase):
@@ -37,6 +41,26 @@ class TestMetadataPanel(TestCase):
         assert root.xpath("//input[@id='court']/@value")[0] == "Court of Testing"
         assert root.xpath("//textarea[@id='metadata_name']")[0].text == "Test v Tested"
         assert response.status_code == 200
+
+    def test_metadata_item_renders_scalar_value(self):
+        template = environment(loader=PackageLoader("ds_caselaw_editor_ui", "templates")).from_string(
+            '{% from "components/document_metadata_item.jinja" import document_metadata_item %}{{ document_metadata_item(metadata_item=metadata_item) }}',
+        )
+
+        rendered = template.render(metadata_item=SimpleNamespace(value="Court of Testing"))
+
+        assert "Court of Testing" in rendered
+        assert "badge" not in rendered
+
+    def test_metadata_item_renders_multi_value_badges(self):
+        template = environment(loader=PackageLoader("ds_caselaw_editor_ui", "templates")).from_string(
+            '{% from "components/document_metadata_item.jinja" import document_metadata_item %}{{ document_metadata_item(metadata_item=metadata_item) }}',
+        )
+
+        rendered = template.render(metadata_item=SimpleNamespace(values=["Tax", "Employment"]))
+
+        assert '<div class="badge badge--info ">Tax</div>' in rendered
+        assert '<div class="badge badge--info ">Employment</div>' in rendered
 
     @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")


### PR DESCRIPTION
## What

Switches the document metadata panel to read from the new `Document.metadata` dict introduced in `ds-caselaw-marklogic-api-client` v47, rather than going directly to `document.body.*`.

Adds a small reusable `document_metadata_item` component that accepts a metadata entry object and handles the two shapes the API exposes:
- `.value` — single scalar value (name, court, jurisdiction, date, case_number)
- `.values` — list (categories, always rendered as badges)

## Why

`Document.metadata` is the intended abstraction layer for document metadata going forward. Reading from `document.body.*` directly bypasses it.

## Notes

Fields not yet represented in `Document.metadata` (TDR ref, first published, source name, source email) are left on their existing `document.*` attributes for now.