### PR TITLE
FCLC-2160 | add query param to disable redirect for debugging documents

### DIFF
--- a/judgments/views/document_full_text.py
+++ b/judgments/views/document_full_text.py
@@ -14,7 +14,7 @@ class DocumentReviewHTMLView(DocumentView):
         if self.document.failed_to_parse:
             return super().dispatch(request, args, kwargs)
 
-        if not self.document.content_as_html():
+        if not self.document.content_as_html() and not request.GET.get("no-redirect", False):
             redirect_path = reverse("full-text-pdf", kwargs={"document_uri": self.document.uri})
             return HttpResponseRedirect(redirect_path)
 
@@ -33,7 +33,7 @@ class DocumentReviewPDFView(DocumentView):
     template_name = "judgment/full_text_pdf.jinja"
 
     def dispatch(self, request, *args, **kwargs):
-        if not self.document.pdf_url:
+        if not self.document.pdf_url and not request.GET.get("no-redirect", False):
             redirect_path = reverse("full-text-html", kwargs={"document_uri": self.document.uri})
             return HttpResponseRedirect(redirect_path)
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Allow the user to bypass the content redirect when reviewing documents for debugging.

For testing, add ?no-redirect=true to the url

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2160
