### PR TITLE
fix: handle missing metadata fields in sidebar item macro

### DIFF
--- a/ds_caselaw_editor_ui/templates/components/document_metadata_item.jinja
+++ b/ds_caselaw_editor_ui/templates/components/document_metadata_item.jinja
@@ -1,20 +1,24 @@
 {% from "components/badge.jinja" import badge %}
 {% macro document_metadata_item(metadata_item, date_format=None) %}
-  {% set values = metadata_item.values if metadata_item.values is defined else none %}
-  {% set value = metadata_item.value if metadata_item.value is defined else none %}
-  {% if values is not none %}
-    {% if values %}
-      {% for value in values %}
-        {{ badge(content=value) }}
-      {% endfor %}
-    {% else %}
-      {{ None|or_no_data_available_label }}
-    {% endif %}
+  {% if metadata_item is not defined or metadata_item is none %}
+    {{ None|or_no_data_available_label }}
   {% else %}
-    {% if date_format and value %}
-      {{ value | date(date_format) }}
+    {% set values = metadata_item.values if metadata_item.values is defined else none %}
+    {% set value = metadata_item.value if metadata_item.value is defined else none %}
+    {% if values is not none %}
+      {% if values %}
+        {% for value in values %}
+          {{ badge(content=value) }}
+        {% endfor %}
+      {% else %}
+        {{ None|or_no_data_available_label }}
+      {% endif %}
     {% else %}
-      {{ value|or_no_data_available_label }}
+      {% if date_format and value %}
+        {{ value | date(date_format) }}
+      {% else %}
+        {{ value|or_no_data_available_label }}
+      {% endif %}
     {% endif %}
   {% endif %}
 {% endmacro %}

--- a/judgments/tests/test_metadata_panel.py
+++ b/judgments/tests/test_metadata_panel.py
@@ -62,6 +62,15 @@ class TestMetadataPanel(TestCase):
         assert '<div class="badge badge--info ">Tax</div>' in rendered
         assert '<div class="badge badge--info ">Employment</div>' in rendered
 
+    def test_metadata_item_handles_missing_value(self):
+        template = environment(loader=PackageLoader("ds_caselaw_editor_ui", "templates")).from_string(
+            '{% from "components/document_metadata_item.jinja" import document_metadata_item %}{{ document_metadata_item(metadata_item=metadata.jurisdiction) }}',
+        )
+
+        rendered = template.render(metadata={})
+
+        assert "No data available" in rendered
+
     @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")


### PR DESCRIPTION
- Guard `document_metadata_item` against undefined/none metadata items so missing keys (e.g. `jurisdiction` on the `{}` fallback) render as “No data available” instead of 500ing the judgment page
- Add a regression test for the empty-dict missing-key case