### PR TITLE
Add Developers-only Tools page with missing FCLID report

### DIFF
--- a/docs/user-groups.md
+++ b/docs/user-groups.md
@@ -15,3 +15,8 @@ There are a number of differences in the UI depending on the user's groups:
 
 - See event number, Submission sequence number and Marklogic version
 - See the calling agent
+
+### Developers can access Tools
+
+- View the Tools hub
+- Inspect published documents missing an FCLID

--- a/ds_caselaw_editor_ui/templates/components/navigation.jinja
+++ b/ds_caselaw_editor_ui/templates/components/navigation.jinja
@@ -27,6 +27,11 @@
               <a href="{{ url('reports') }}">Reports</a>
             </li>
           {% endif %}
+          {% if user|is_developer %}
+            <li>
+              <a href="{{ url('tools') }}">Tools</a>
+            </li>
+          {% endif %}
         {% endif %}
         {% if user.is_authenticated %}
           <li>

--- a/ds_caselaw_editor_ui/templates/tools/index.jinja
+++ b/ds_caselaw_editor_ui/templates/tools/index.jinja
@@ -1,0 +1,11 @@
+{% extends "layouts/base.jinja" %}
+{% block content %}
+  <div class="standard-text-template">
+    <h1>Tools</h1>
+    <ul>
+      <li>
+        <a href="{{ url('tools_missing_fclid') }}">Published documents missing FCLID</a>
+      </li>
+    </ul>
+  </div>
+{% endblock content %}

--- a/ds_caselaw_editor_ui/templates/tools/missing_fclid.jinja
+++ b/ds_caselaw_editor_ui/templates/tools/missing_fclid.jinja
@@ -1,0 +1,31 @@
+{% extends "layouts/base.jinja" %}
+{% block content %}
+  <div class="standard-text-template">
+    <h1>Published documents missing FCLID</h1>
+    <p>Published documents which do not have a Find Case Law Identifier (FCLID).</p>
+    {% if results_capped %}
+      <p>
+        Showing the first <b>{{ document_count }}</b> results (capped at {{ report_limit }}).
+        There may be more documents missing an FCLID.
+      </p>
+    {% else %}
+      <p>
+        Found <b>{{ document_count }}</b> documents missing an FCLID.
+      </p>
+    {% endif %}
+    <div class="table">
+      <table>
+        <tr>
+          <th>Document</th>
+        </tr>
+        {% for document in documents %}
+          <tr>
+            <td>
+              <a href="{{ url('full-text-html', document.document_uri) }}">{{ document.document_uri }}</a>
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
+    </div>
+  </div>
+{% endblock content %}

--- a/judgments/tests/test_tools.py
+++ b/judgments/tests/test_tools.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import Group, User
+from django.test import TestCase
+from django.urls import reverse
+
+
+class TestToolsViews(TestCase):
+    def setUp(self):
+        developer_group = Group.objects.create(name="Developers")
+        self.developer_user = User.objects.create(username="dev")
+        self.developer_user.groups.add(developer_group)
+        self.standard_user = User.objects.create(username="alice")
+
+    def test_tools_index_ok_for_developer(self):
+        self.client.force_login(self.developer_user)
+
+        response = self.client.get(reverse("tools"))
+
+        assert response.status_code == 200
+        assert "Tools" in response.content.decode("utf-8")
+        assert "Published documents missing FCLID" in response.content.decode("utf-8")
+
+    def test_tools_index_forbidden_for_non_developer(self):
+        self.client.force_login(self.standard_user)
+
+        response = self.client.get(reverse("tools"))
+
+        assert response.status_code == 403
+
+    def test_tools_index_redirects_unauthenticated(self):
+        response = self.client.get(reverse("tools"))
+
+        assert response.status_code == 302
+        assert "/accounts/login" in response["Location"]
+
+    def test_missing_fclid_forbidden_for_non_developer(self):
+        self.client.force_login(self.standard_user)
+
+        response = self.client.get(reverse("tools_missing_fclid"))
+
+        assert response.status_code == 403
+
+    @patch("judgments.views.tools.api_client")
+    def test_missing_fclid_ok_for_developer(self, mock_api_client):
+        self.client.force_login(self.developer_user)
+        mock_api_client.get_missing_fclid.return_value = ["/ewhc/kb/2025/1.xml"]
+
+        response = self.client.get(reverse("tools_missing_fclid"))
+
+        decoded_response = response.content.decode("utf-8")
+        assert response.status_code == 200
+        assert "Published documents missing FCLID" in decoded_response
+        assert "ewhc/kb/2025/1" in decoded_response
+        mock_api_client.get_missing_fclid.assert_called_once_with(maximum_records=200)

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -4,7 +4,7 @@ from judgments.views.associated_documents import AssociatedDocumentsView
 from judgments.views.delete import DeleteDocumentView, delete
 from judgments.views.enrich import enrich
 
-from .views import reports
+from .views import reports, tools
 from .views.components import ComponentsView
 from .views.document_downloads import DocumentDownloadsView
 from .views.document_full_text import (
@@ -102,6 +102,13 @@ urlpatterns = [
         "reports/locked-documents",
         reports.LockedDocuments.as_view(),
         name="report_locked_documents",
+    ),
+    # Tools (Developers group only)
+    path("tools", tools.ToolsIndex.as_view(), name="tools"),
+    path(
+        "tools/missing-fclid",
+        tools.MissingFclid.as_view(),
+        name="tools_missing_fclid",
     ),
     # Different views on judgments
     path("<path:document_uri>/associated-documents", AssociatedDocumentsView.as_view(), name="associated-documents"),

--- a/judgments/views/tools.py
+++ b/judgments/views/tools.py
@@ -1,5 +1,6 @@
 from caselawclient.types import MarkLogicDocumentURIString
-from django.core.exceptions import PermissionDenied
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.http import HttpRequest
 from django.views.generic import TemplateView
 
 from judgments.utils import api_client
@@ -8,12 +9,12 @@ from judgments.utils.view_helpers import user_is_developer
 MISSING_FCLID_REPORT_LIMIT = 200
 
 
-class DeveloperRequiredMixin:
-    def dispatch(self, request, *args, **kwargs):
-        if not user_is_developer(request.user):
-            msg = "Only developers can access tools"
-            raise PermissionDenied(msg)
-        return super().dispatch(request, *args, **kwargs)
+class DeveloperRequiredMixin(UserPassesTestMixin):
+    raise_exception = True
+    request: HttpRequest
+
+    def test_func(self) -> bool:
+        return bool(user_is_developer(self.request.user))
 
 
 class ToolsIndex(DeveloperRequiredMixin, TemplateView):

--- a/judgments/views/tools.py
+++ b/judgments/views/tools.py
@@ -1,0 +1,49 @@
+from caselawclient.types import MarkLogicDocumentURIString
+from django.core.exceptions import PermissionDenied
+from django.views.generic import TemplateView
+
+from judgments.utils import api_client
+from judgments.utils.view_helpers import user_is_developer
+
+MISSING_FCLID_REPORT_LIMIT = 200
+
+
+class DeveloperRequiredMixin:
+    def dispatch(self, request, *args, **kwargs):
+        if not user_is_developer(request.user):
+            msg = "Only developers can access tools"
+            raise PermissionDenied(msg)
+        return super().dispatch(request, *args, **kwargs)
+
+
+class ToolsIndex(DeveloperRequiredMixin, TemplateView):
+    template_engine = "jinja"
+    template_name = "tools/index.jinja"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Tools"
+        return context
+
+
+class MissingFclid(DeveloperRequiredMixin, TemplateView):
+    template_engine = "jinja"
+    template_name = "tools/missing_fclid.jinja"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Published documents missing FCLID"
+        context["report_limit"] = MISSING_FCLID_REPORT_LIMIT
+
+        marklogic_uris = api_client.get_missing_fclid(maximum_records=MISSING_FCLID_REPORT_LIMIT)
+        context["documents"] = [
+            {
+                "marklogic_uri": marklogic_uri,
+                "document_uri": MarkLogicDocumentURIString(marklogic_uri).as_document_uri(),
+            }
+            for marklogic_uri in marklogic_uris
+        ]
+        context["document_count"] = len(context["documents"])
+        context["results_capped"] = context["document_count"] >= MISSING_FCLID_REPORT_LIMIT
+
+        return context


### PR DESCRIPTION
- Add a Developers-group-gated **Tools** hub (`/tools`) with a nav link
- Add a read-only **Published documents missing FCLID** report (`/tools/missing-fclid`) using `api_client.get_missing_fclid` (capped at 200)