### PR TITLE
[FCLC-2254] Add document metadata page with per-field claim provenance

### DIFF
--- a/ds_caselaw_editor_ui/templates/components/document_metadata_claim_value.jinja
+++ b/ds_caselaw_editor_ui/templates/components/document_metadata_claim_value.jinja
@@ -1,0 +1,10 @@
+{% macro document_metadata_claim_value(claim) %}
+  {% if claim.value.name is defined %}
+    {{ claim.value.name }}
+    {% if claim.value.parent %}
+      <span class="muted">({{ claim.value.parent }})</span>
+    {% endif %}
+  {% else %}
+    {{ claim.value }}
+  {% endif %}
+{% endmacro %}

--- a/ds_caselaw_editor_ui/templates/judgment/metadata.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/metadata.jinja
@@ -1,0 +1,87 @@
+{% extends "layouts/judgment.jinja" %}
+{% from "components/heading.jinja" import heading %}
+{% from "components/notification.jinja" import notification %}
+{% from "components/document_metadata_item.jinja" import document_metadata_item %}
+{% from "components/document_metadata_claim_value.jinja" import document_metadata_claim_value %}
+{% block content %}
+  <div class="container">
+    {{ heading(content="Metadata for:") }}
+    {{ heading(tag="h2", weight="normal", content=document.body.name) }}
+    {% if document.metadata %}
+      {% for key, metadata_item in document.metadata.items() %}
+        {% set resolved = document.metadata_fields.resolve(metadata_item.key) %}
+        {% set active_claims = resolved.claims %}
+        {% set winning_claim = active_claims[-1] if active_claims else none %}
+        {% set is_single_value = metadata_item.value is defined %}
+        <section>
+          {{ heading(tag="h2", content=metadata_item.title) }}
+          {% if metadata_item.description %}
+            <p class="muted">{{ metadata_item.description }}</p>
+          {% endif %}
+          {% if resolved.has_any_claims %}
+            <div class="table">
+              <table>
+                <tr>
+                  <th>Status</th>
+                  <th>Value</th>
+                  <th>Source</th>
+                  <th>First seen</th>
+                  {% if user|is_developer %}
+                    <th>Claim id</th>
+                  {% endif %}
+                </tr>
+                {% for claim in resolved.all_claims|reversed %}
+                  {% if claim.rejected %}
+                    {% set is_current = false %}
+                  {% elif is_single_value and winning_claim and claim.id == winning_claim.id %}
+                    {% set is_current = true %}
+                  {% elif not is_single_value %}
+                    {% set is_current = true %}
+                  {% else %}
+                    {% set is_current = false %}
+                  {% endif %}
+                  <tr {% if claim.rejected %}class="muted"{% endif %}>
+                    <td>
+                      {% if claim.rejected %}
+                        Rejected
+                      {% elif is_current %}
+                        Current
+                      {% else %}
+                        Superseded
+                      {% endif %}
+                    </td>
+                    <td>{{ document_metadata_claim_value(claim) }}</td>
+                    <td>{{ claim.source.value|title }}</td>
+                    <td>{{ claim.timestamp|date("%-d %b %Y %H:%M") }}</td>
+                    {% if user|is_developer %}
+                      <td>
+                        <code>{{ claim.id }}</code>
+                      </td>
+                    {% endif %}
+                  </tr>
+                {% endfor %}
+              </table>
+            </div>
+          {% else %}
+            <p>
+              <strong>Current value:</strong>
+              {% if metadata_item.key == "date" %}
+                {{ document_metadata_item(metadata_item=metadata_item, date_format="%-d %b %Y") }}
+              {% else %}
+                {{ document_metadata_item(metadata_item=metadata_item) }}
+              {% endif %}
+              (from document body)
+            </p>
+            {% call notification() %}
+              No stored claims for this field. The current value comes from the document body.
+            {% endcall %}
+          {% endif %}
+        </section>
+      {% endfor %}
+    {% else %}
+      {% call notification() %}
+        This document does not have any structured metadata.
+      {% endcall %}
+    {% endif %}
+  </div>
+{% endblock content %}

--- a/judgments/templatetags/navigation_tags.py
+++ b/judgments/templatetags/navigation_tags.py
@@ -1,7 +1,10 @@
 from django import template
 from django.urls import reverse
+from waffle import flag_is_active
 
 register = template.Library()
+
+DOCUMENT_METADATA_FLAG = "document_metadata"
 
 
 def get_document_url(view, document):
@@ -96,13 +99,26 @@ def get_identifiers_navigation_item(view, document):
     }
 
 
-def get_navigation_items_logic(view, document, linked_document_uri=None):
+def get_metadata_navigation_item(view, document, request=None):
+    if not request or not flag_is_active(request, DOCUMENT_METADATA_FLAG):
+        return None
+
+    return {
+        "id": "metadata",
+        "selected": view == "document_metadata",
+        "label": "Metadata",
+        "url": get_document_url("document-metadata", document),
+    }
+
+
+def get_navigation_items_logic(view, document, linked_document_uri=None, request=None):
 
     base_navigation = [
         get_review_navigation_item(view, document),
         get_hold_navigation_item(view, document),
         get_publishing_navigation_item(view, document),
         get_identifiers_navigation_item(view, document),
+        get_metadata_navigation_item(view, document, request=request),
         get_history_navigation_item(view, document),
         get_download_navigation_item(view, document),
         get_upload_navigation_item(view=view, document=document),
@@ -118,28 +134,12 @@ def get_navigation_items_logic(view, document, linked_document_uri=None):
 
 @register.simple_tag(takes_context=True)
 def get_navigation_items(context):
-    view, document, linked_document_uri = (
-        context.get("view"),
-        context.get("document"),
-        context.get("linked_document_uri"),
+    return get_navigation_items_logic(
+        view=context.get("view"),
+        document=context.get("document"),
+        linked_document_uri=context.get("linked_document_uri"),
+        request=context.get("request"),
     )
-
-    base_navigation = [
-        get_review_navigation_item(view, document),
-        get_hold_navigation_item(view, document),
-        get_publishing_navigation_item(view, document),
-        get_identifiers_navigation_item(view, document),
-        get_history_navigation_item(view, document),
-        get_download_navigation_item(view, document),
-        get_upload_navigation_item(view=view, document=document),
-    ]
-
-    filtered_navigation = [item for item in base_navigation if item is not None]
-
-    if linked_document_uri:
-        return [*filtered_navigation, get_associated_documents_navigation_item(view, document)]
-
-    return filtered_navigation
 
 
 @register.simple_tag(takes_context=True)

--- a/judgments/tests/test_document_metadata.py
+++ b/judgments/tests/test_document_metadata.py
@@ -1,0 +1,63 @@
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from caselawclient.factories import DocumentBodyFactory, JudgmentFactory
+from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.models.judgments import Judgment
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+
+class TestDocumentMetadata(TestCase):
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_document_metadata_view(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri=DocumentURIString("d-a1b2c3"),
+            body=DocumentBodyFactory.build(name="Test v Tested", court="Court of Testing"),
+        )
+        judgment.metadata_fields.add(
+            MetadataField(
+                name="court",
+                value="Legacy Court",
+                source=MetadataSource.DOCUMENT,
+                timestamp=datetime(2020, 1, 1, tzinfo=UTC),
+            ),
+        )
+        judgment.metadata_fields.add(
+            MetadataField(
+                name="court",
+                value="Winning Court",
+                source=MetadataSource.EDITOR,
+                timestamp=datetime(2024, 6, 1, tzinfo=UTC),
+            ),
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        metadata_uri = reverse("document-metadata", kwargs={"document_uri": judgment.uri})
+
+        assert metadata_uri == "/d-a1b2c3/metadata"
+
+        response = self.client.get(metadata_uri)
+
+        assert response.status_code == 200
+        self.assertContains(response, "Metadata for:")
+        self.assertContains(response, "Test v Tested", html=True)
+        self.assertContains(response, "Winning Court")
+        self.assertContains(response, "Legacy Court")
+        self.assertContains(response, "<th>Status</th>", html=True)
+        self.assertContains(response, "<th>Source</th>", html=True)
+        self.assertContains(response, "<td>Current</td>", html=True)
+        self.assertContains(response, "<td>Superseded</td>", html=True)
+
+        for metadata_item in judgment.metadata.values():
+            self.assertContains(response, metadata_item.title)

--- a/judgments/tests/test_navigation_tags.py
+++ b/judgments/tests/test_navigation_tags.py
@@ -1,16 +1,21 @@
 from caselawclient.factories import JudgmentFactory
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
+from waffle.testutils import override_flag
 
-from judgments.templatetags.navigation_tags import get_navigation_items
+from judgments.templatetags.navigation_tags import DOCUMENT_METADATA_FLAG, get_navigation_items
 
 
 class TestNavigationTags(TestCase):
+    def setUp(self):
+        self.request = RequestFactory().get("/")
+
     def test_get_navigation_items(self):
         judgment = JudgmentFactory.build(is_published=False)
 
         context = {
             "view": "judgment_html",
             "document": judgment,
+            "request": self.request,
         }
 
         navigation_items = get_navigation_items(context)
@@ -24,6 +29,26 @@ class TestNavigationTags(TestCase):
             {"id": "downloads", "selected": False, "label": "Downloads", "url": "/test/2023/123/downloads"},
             {"id": "upload", "selected": False, "label": "Upload", "url": "/test/2023/123/upload"},
         ]
+        assert not any(item["id"] == "metadata" for item in navigation_items)
+
+    @override_flag(DOCUMENT_METADATA_FLAG, active=True)
+    def test_get_navigation_items_includes_metadata_when_flag_active(self):
+        judgment = JudgmentFactory.build(is_published=False)
+
+        context = {
+            "view": "judgment_html",
+            "document": judgment,
+            "request": self.request,
+        }
+
+        navigation_items = get_navigation_items(context)
+
+        assert {
+            "id": "metadata",
+            "selected": False,
+            "label": "Metadata",
+            "url": "/test/2023/123/metadata",
+        } in navigation_items
 
     def test_get_navigation_items_published(self):
         judgment = JudgmentFactory.build(is_published=True)
@@ -31,6 +56,7 @@ class TestNavigationTags(TestCase):
         context = {
             "view": "judgment_html",
             "document": judgment,
+            "request": self.request,
         }
 
         navigation_items = get_navigation_items(context)
@@ -38,17 +64,20 @@ class TestNavigationTags(TestCase):
         assert not any(item["id"] == "take-off-hold" for item in navigation_items)
         assert not any(item["id"] == "put-on-hold" for item in navigation_items)
 
+    @override_flag(DOCUMENT_METADATA_FLAG, active=True)
     def test_get_navigation_items_selected_pages(self):
         judgment = JudgmentFactory.build(is_published=False)
 
         base_context = {
             "document": judgment,
+            "request": self.request,
         }
 
         tests = [
             {"expected_selected_id": "review", "view": "judgment_html"},
             {"expected_selected_id": "review", "view": "judgment_pdf"},
             {"expected_selected_id": "history", "view": "document_history"},
+            {"expected_selected_id": "metadata", "view": "document_metadata"},
             {"expected_selected_id": "publish", "view": "publish_judgment"},
             {"expected_selected_id": "publish", "view": "unpublish_judgment"},
             {"expected_selected_id": "downloads", "view": "document_downloads"},
@@ -70,6 +99,7 @@ class TestNavigationTags(TestCase):
             "view": "associated_documents",
             "document": judgment,
             "linked_document_uri": judgment.uri,
+            "request": self.request,
         }
 
         navigation_items = get_navigation_items(context)

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -16,6 +16,7 @@ from .views.document_full_text import (
 )
 from .views.document_history import DocumentHistoryView
 from .views.document_identifiers import AddDocumentIdentifierView, DeleteDocumentIdentifierView, DocumentIdentifiersView
+from .views.document_metadata import DocumentMetadataView
 from .views.document_reparse import reparse
 from .views.errors import NotFoundView, PermissionDeniedView, ServerErrorView
 from .views.index import HomeView
@@ -122,6 +123,11 @@ urlpatterns = [
         "<path:document_uri>/identifiers",
         DocumentIdentifiersView.as_view(),
         name="document-identifiers",
+    ),
+    path(
+        "<path:document_uri>/metadata",
+        DocumentMetadataView.as_view(),
+        name="document-metadata",
     ),
     path(
         "<path:document_uri>/identifiers/add",

--- a/judgments/views/document_metadata.py
+++ b/judgments/views/document_metadata.py
@@ -1,0 +1,11 @@
+from judgments.utils.view_helpers import DocumentView
+
+
+class DocumentMetadataView(DocumentView):
+    template_engine = "jinja"
+    template_name = "judgment/metadata.jinja"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["view"] = "document_metadata"
+        return context

--- a/judgments/views/upload.py
+++ b/judgments/views/upload.py
@@ -62,6 +62,7 @@ class UploadDocumentSuccessView(DocumentView):
         context["navigation_items"] = get_navigation_items_logic(
             view=context["view"],
             document=document,
+            request=self.request,
         )
 
         if document:


### PR DESCRIPTION
This introduces a new "Metadata" page for each document, where the entire provenance chain for all the document's metadata can be inspected. This is intended to support the building of the editable metadata stack.

Navigation is behind the `document_metadata` flag for now.

## Jira

FCLC-2254