### PR TITLE
Metadata framework rendering improvements

### DIFF
--- a/ds_caselaw_editor_ui/sass/components/_aside.scss
+++ b/ds_caselaw_editor_ui/sass/components/_aside.scss
@@ -117,6 +117,26 @@
           margin: 0;
         }
       }
+
+      .aside__section-heading {
+        gap: 0;
+        margin-top: $space-2;
+        padding-top: $space-3;
+        border-top: 1px solid colour-var("accent-border");
+
+        &:first-child {
+          margin-top: 0;
+          padding-top: 0;
+          border-top: 0;
+        }
+
+        dt {
+          font-size: $typography-sm-text-size;
+          font-weight: $typography-bold-font-weight;
+          color: colour-var("font-base");
+          text-transform: uppercase;
+        }
+      }
     }
 
     @media (min-width: $grid-breakpoint-medium) {

--- a/ds_caselaw_editor_ui/templates/components/document_metadata.jinja
+++ b/ds_caselaw_editor_ui/templates/components/document_metadata.jinja
@@ -85,13 +85,15 @@
           <dt>Other</dt>
           <dd>
             {% set identifier_list = identifiers.by_score() if identifiers else [] %}
-            {% if preferred_identifier and identifier_list|length > 1 %}
-              {% for identifier in identifier_list %}
-                {% if identifier.uuid != preferred_identifier.uuid %}
-                  {{ badge(content=identifier.schema.name ~ ": " ~ identifier.value) }}
-                {% endif %}
-              {% endfor %}
-            {% else %}
+            {% set preferred_uuid = preferred_identifier.uuid if preferred_identifier else none %}
+            {% set other = namespace(shown=false) %}
+            {% for identifier in identifier_list %}
+              {% if identifier.uuid != preferred_uuid %}
+                {{ badge(content=identifier.schema.name ~ ": " ~ identifier.value) }}
+                {% set other.shown = true %}
+              {% endif %}
+            {% endfor %}
+            {% if not other.shown %}
               {{ None|or_no_data_available_label }}
             {% endif %}
           </dd>

--- a/ds_caselaw_editor_ui/templates/components/document_metadata.jinja
+++ b/ds_caselaw_editor_ui/templates/components/document_metadata.jinja
@@ -1,8 +1,11 @@
 {% from "components/icon.jinja" import icon %}
 {% from "components/button.jinja" import button %}
+{% from "components/badge.jinja" import badge %}
 {% from "components/document_metadata_item.jinja" import document_metadata_item %}
-{% macro document_metadata(document=None, preferred_ncn=None, full_details=True) %}
+{% macro document_metadata(document=None) %}
   {% set metadata = document.metadata if document.metadata is defined else {} %}
+  {% set identifiers = document.identifiers if document.identifiers is defined else none %}
+  {% set preferred_identifier = identifiers.preferred() if identifiers else none %}
   <div class="aside__container" data-aside-toggle>
     <button class="aside__toggle" data-aside-toggle-button>
       <span class="icon icon__chevron-left"></span>
@@ -14,38 +17,91 @@
         {{ button(variant="link", size="small", content="Hide", attrs={"data-aside-toggle-button":""}) }}
       </div>
       <dl>
-        {% if full_details %}
-          <div>
-            <dt>NCN</dt>
-            <dd>
-              {{ preferred_ncn.value|or_no_data_available_label }}
-            </dd>
-          </div>
-          <div>
-            <dt>Court</dt>
-            <dd>
-              {{ document_metadata_item(metadata_item=metadata.court) }}
-            </dd>
-          </div>
-          <div>
-            <dt>Judgment date</dt>
-            <dd>
-              {{ document_metadata_item(metadata_item=metadata.date, date_format="%-d %b %Y") }}
-            </dd>
-          </div>
-          <div>
-            <dt>Name</dt>
-            <dd>
-              {{ document_metadata_item(metadata_item=metadata.title) }}
-            </dd>
-          </div>
-          <div>
-            <dt>Identifiers</dt>
-            <dd>
+        <div class="aside__section-heading"
+             data-test-id="metadata-section-heading">
+          <dt role="heading" aria-level="3">Metadata</dt>
+          <dd aria-hidden="true">
+          </dd>
+        </div>
+        <div>
+          <dt>Title</dt>
+          <dd>
+            {{ document_metadata_item(metadata_item=metadata.title) }}
+          </dd>
+        </div>
+        <div>
+          <dt>Court</dt>
+          <dd>
+            {{ document_metadata_item(metadata_item=metadata.court) }}
+          </dd>
+        </div>
+        <div>
+          <dt>Judgment date</dt>
+          <dd>
+            {{ document_metadata_item(metadata_item=metadata.date, date_format="%-d %b %Y") }}
+          </dd>
+        </div>
+        <div>
+          <dt>Jurisdiction</dt>
+          <dd>
+            {{ document_metadata_item(metadata_item=metadata.jurisdiction) }}
+          </dd>
+        </div>
+        <div>
+          <dt>Case number</dt>
+          <dd>
+            {{ document_metadata_item(metadata_item=metadata.case_number) }}
+          </dd>
+        </div>
+        <div>
+          <dt>Judges</dt>
+          <dd>
+            {{ document_metadata_item(metadata_item=metadata.judges) }}
+          </dd>
+        </div>
+        <div>
+          <dt>Categories</dt>
+          <dd>
+            {{ document_metadata_item(metadata_item=metadata.categories) }}
+          </dd>
+        </div>
+        <div class="aside__section-heading"
+             data-test-id="metadata-section-heading">
+          <dt role="heading" aria-level="3">Identifiers</dt>
+          <dd aria-hidden="true">
+          </dd>
+        </div>
+        <div>
+          <dt>Preferred</dt>
+          <dd>
+            {% if preferred_identifier %}
+              {{ badge(content=preferred_identifier.schema.name ~ ": " ~ preferred_identifier.value) }}
+            {% else %}
               {{ None|or_no_data_available_label }}
-            </dd>
-          </div>
-        {% endif %}
+            {% endif %}
+          </dd>
+        </div>
+        <div>
+          <dt>Other</dt>
+          <dd>
+            {% set identifier_list = identifiers.by_score() if identifiers else [] %}
+            {% if preferred_identifier and identifier_list|length > 1 %}
+              {% for identifier in identifier_list %}
+                {% if identifier.uuid != preferred_identifier.uuid %}
+                  {{ badge(content=identifier.schema.name ~ ": " ~ identifier.value) }}
+                {% endif %}
+              {% endfor %}
+            {% else %}
+              {{ None|or_no_data_available_label }}
+            {% endif %}
+          </dd>
+        </div>
+        <div class="aside__section-heading"
+             data-test-id="metadata-section-heading">
+          <dt role="heading" aria-level="3">Legacy</dt>
+          <dd aria-hidden="true">
+          </dd>
+        </div>
         <div>
           <dt>TDR ref</dt>
           <dd>
@@ -73,18 +129,6 @@
           </dd>
         </div>
         <div>
-          <dt>Jurisdiction</dt>
-          <dd>
-            {{ document_metadata_item(metadata_item=metadata.jurisdiction) }}
-          </dd>
-        </div>
-        <div>
-          <dt>Case number</dt>
-          <dd>
-            {{ document_metadata_item(metadata_item=metadata.case_number) }}
-          </dd>
-        </div>
-        <div>
           <dt>Source name</dt>
           <dd>
             {{ document.source_name|or_no_data_available_label }}
@@ -94,18 +138,6 @@
           <dt>Source email</dt>
           <dd>
             {{ document.source_email|or_no_data_available_label }}
-          </dd>
-        </div>
-        <div>
-          <dt>Judges</dt>
-          <dd>
-            {{ None|or_no_data_available_label }}
-          </dd>
-        </div>
-        <div>
-          <dt>Categories</dt>
-          <dd>
-            {{ document_metadata_item(metadata_item=metadata.categories) }}
           </dd>
         </div>
         <div>

--- a/ds_caselaw_editor_ui/templates/components/document_metadata_item.jinja
+++ b/ds_caselaw_editor_ui/templates/components/document_metadata_item.jinja
@@ -5,7 +5,8 @@
   {% if values is not none %}
     {% if values %}
       {% for value in values %}
-        {{ badge(content=value) }}
+        {% set display_value = value.name if value.name is defined else value %}
+        {{ badge(content=display_value) }}
       {% endfor %}
     {% else %}
       {{ None|or_no_data_available_label }}

--- a/ds_caselaw_editor_ui/templates/judgment/associated_documents.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/associated_documents.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Associated documents for:") }}
-    {{ heading(tag="h2", content=document.body.name) }}
+    {{ heading(tag="h2", content=document.metadata.title.value) }}
     <p>
       <a href="{{ url('full-text-html', linked_document_uri) }}">{{ document.document_noun|title }}</a>
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/associated_documents.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/associated_documents.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Associated documents for:") }}
-    {{ heading(tag="h2", content=document.metadata.title.value) }}
+    {{ heading(tag="h2", content=page_title) }}
     <p>
       <a href="{{ url('full-text-html', linked_document_uri) }}">{{ document.document_noun|title }}</a>
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/delete.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/delete.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="I want to delete:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
     <form action="{{ url('delete') }}" method="post">
       {{ csrf_input }}
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/ds_caselaw_editor_ui/templates/judgment/delete.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/delete.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="I want to delete:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     <form action="{{ url('delete') }}" method="post">
       {{ csrf_input }}
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/ds_caselaw_editor_ui/templates/judgment/downloads.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/downloads.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Download documents for:") }}
-    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     {% if document.docx_url %}
       <p>
         <a href="{{ document.docx_url }}" download>Download .DOCX</a>

--- a/ds_caselaw_editor_ui/templates/judgment/downloads.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/downloads.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Download documents for:") }}
-    {{ heading(tag="h2", weight="normal", content=document.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
     {% if document.docx_url %}
       <p>
         <a href="{{ document.docx_url }}" download>Download .DOCX</a>

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_html.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_html.jinja
@@ -4,7 +4,7 @@
 {% from "components/document_form.jinja" import document_form with context %}
 {% from "components/tabs.jinja" import tabs, tab %}
 {% block aside %}
-  {{ document_metadata(document=document, preferred_ncn=preferred_ncn, full_details=(document_type != "judgment") ) }}
+  {{ document_metadata(document=document) }}
 {% endblock aside %}
 {% block content %}
   {% if document_type == "judgment" %}

--- a/ds_caselaw_editor_ui/templates/judgment/full_text_pdf.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/full_text_pdf.jinja
@@ -3,7 +3,7 @@
 {% from "components/document_form.jinja" import document_form with context %}
 {% from "components/tabs.jinja" import tabs, tab %}
 {% block aside %}
-  {{ document_metadata(document=document, preferred_ncn=preferred_ncn, full_details=(document_type != "judgment") ) }}
+  {{ document_metadata(document=document) }}
 {% endblock aside %}
 {% block content %}
   {% if document_type == "judgment" %}

--- a/ds_caselaw_editor_ui/templates/judgment/hold-success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/hold-success.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation this has been put on hold:") }}
-    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     <p>
       <a href="{{ email_issue_link }}">Email the submitter</a>
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/hold-success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/hold-success.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation this has been put on hold:") }}
-    {{ heading(tag="h2", weight="normal", content=document.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
     <p>
       <a href="{{ email_issue_link }}">Email the submitter</a>
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/hold.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/hold.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="I want to put this on hold:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
     <form action="{{ url('hold') }}" method="post">
       {{ csrf_input }}
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/ds_caselaw_editor_ui/templates/judgment/hold.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/hold.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="I want to put this on hold:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     <form action="{{ url('hold') }}" method="post">
       {{ csrf_input }}
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/ds_caselaw_editor_ui/templates/judgment/identifier_delete.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/identifier_delete.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Delete identifier for:") }}
-    {{ heading(tag="h2", weight="normal", content=document.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
     <p>
       You're about to delete a <b>{{ identifier.schema.name }}</b> with value <b>{{ identifier.value }}</b>.
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/identifier_delete.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/identifier_delete.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Delete identifier for:") }}
-    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     <p>
       You're about to delete a <b>{{ identifier.schema.name }}</b> with value <b>{{ identifier.value }}</b>.
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Identifiers for:") }}
-    {{ heading(tag="h2", weight="normal", content=document.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
     {% if document.identifiers %}
       {{ heading(tag="h2", content="Preferred identifier") }}
       <p>

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Identifiers for:") }}
-    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     {% if document.identifiers %}
       {{ heading(tag="h2", content="Preferred identifier") }}
       <p>

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers_add.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers_add.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Add identifiers for:") }}
-    {{ heading(tag="h2", weight="normal", content=document.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
     {% if document.has_ever_been_published %}
       {% call notification(variant="warning") %}
         You cannot delete new identifiers once added because this document has been published.

--- a/ds_caselaw_editor_ui/templates/judgment/identifiers_add.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/identifiers_add.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Add identifiers for:") }}
-    {{ heading(tag="h2", weight="normal", content=document.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     {% if document.has_ever_been_published %}
       {% call notification(variant="warning") %}
         You cannot delete new identifiers once added because this document has been published.

--- a/ds_caselaw_editor_ui/templates/judgment/metadata.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/metadata.jinja
@@ -11,7 +11,7 @@
 {% endblock aside %}
 {% block content %}
   <div class="container">
-    {{ heading(content="Metadata for " ~ document.metadata.title.value) }}
+    {{ heading(content="Metadata for " ~ page_title) }}
     {% if document.metadata %}
       <form method="post">
         {{ csrf_input }}

--- a/ds_caselaw_editor_ui/templates/judgment/metadata.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/metadata.jinja
@@ -11,7 +11,7 @@
 {% endblock aside %}
 {% block content %}
   <div class="container">
-    {{ heading(content="Metadata for " ~ document.body.name) }}
+    {{ heading(content="Metadata for " ~ document.metadata.title.value) }}
     {% if document.metadata %}
       <form method="post">
         {{ csrf_input }}

--- a/ds_caselaw_editor_ui/templates/judgment/publish-success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/publish-success.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation this has been published") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
     <p>
       <a href="{{ judgment.public_uri }}"
          target="_blank"

--- a/ds_caselaw_editor_ui/templates/judgment/publish-success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/publish-success.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation this has been published") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     <p>
       <a href="{{ judgment.public_uri }}"
          target="_blank"

--- a/ds_caselaw_editor_ui/templates/judgment/publish.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/publish.jinja
@@ -6,7 +6,7 @@
   <div class="container">
     {% if judgment.is_publishable %}
       {{ heading(content="I want to publish:") }}
-      {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
+      {{ heading(tag="h2", weight="normal", content=page_title) }}
       {% call notification() %}
         Once published you will not be able to delete identifiers for this document, only mark them as deprecated.
       {% endcall %}

--- a/ds_caselaw_editor_ui/templates/judgment/publish.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/publish.jinja
@@ -6,7 +6,7 @@
   <div class="container">
     {% if judgment.is_publishable %}
       {{ heading(content="I want to publish:") }}
-      {{ heading(tag="h2", weight="normal", content=judgment.body.name) }}
+      {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
       {% call notification() %}
         Once published you will not be able to delete identifiers for this document, only mark them as deprecated.
       {% endcall %}

--- a/ds_caselaw_editor_ui/templates/judgment/unhold-success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold-success.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation this has been taken off hold:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     <p>
       <a href="{{ url('home') }}">Go back to unpublished documents</a>
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/unhold-success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold-success.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation this has been taken off hold:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
     <p>
       <a href="{{ url('home') }}">Go back to unpublished documents</a>
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/unhold.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="I want to take this off hold:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     <form action="{{ url('unhold') }}" method="post">
       {{ csrf_input }}
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/ds_caselaw_editor_ui/templates/judgment/unhold.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/unhold.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="I want to take this off hold:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
     <form action="{{ url('unhold') }}" method="post">
       {{ csrf_input }}
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/ds_caselaw_editor_ui/templates/judgment/unpublish-success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/unpublish-success.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation this has been unpublished:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
     <p>
       <a href="{{ url('home') }}">Go back to unpublished documents</a>
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/unpublish-success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/unpublish-success.jinja
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation this has been unpublished:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     <p>
       <a href="{{ url('home') }}">Go back to unpublished documents</a>
     </p>

--- a/ds_caselaw_editor_ui/templates/judgment/unpublish.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/unpublish.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="I want to unpublish:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
     <form action="{{ url('unpublish') }}" method="post">
       {{ csrf_input }}
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/ds_caselaw_editor_ui/templates/judgment/unpublish.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/unpublish.jinja
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="I want to unpublish:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     <form action="{{ url('unpublish') }}" method="post">
       {{ csrf_input }}
       <input type="hidden" name="judgment_uri" value="{{ judgment.uri }}" />

--- a/ds_caselaw_editor_ui/templates/judgment/upload.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/upload.jinja
@@ -5,7 +5,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Upload a document against:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
+    {{ heading(tag="h2", weight="normal", content=page_title) }}
     {% if document.is_published %}
       {% call notification(variant="warning") %}
         You cannot upload documents while this document is published. Unpublish it first to upload additional documents.

--- a/ds_caselaw_editor_ui/templates/judgment/upload.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/upload.jinja
@@ -5,7 +5,7 @@
 {% block content %}
   <div class="container">
     {{ heading(content="Upload a document against:") }}
-    {{ heading(tag="h2", weight="normal", content=judgment.body.name) }}
+    {{ heading(tag="h2", weight="normal", content=judgment.metadata.title.value) }}
     {% if document.is_published %}
       {% call notification(variant="warning") %}
         You cannot upload documents while this document is published. Unpublish it first to upload additional documents.

--- a/ds_caselaw_editor_ui/templates/judgment/upload_success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/upload_success.jinja
@@ -4,13 +4,13 @@
 {% from "components/button.jinja" import button %}
 {% block banner %}
   {% call notification(variant="success", marginless=True) %}
-    File successfully uploaded to: {{ document.body.name }}
+    File successfully uploaded to: {{ document.metadata.title.value }}
   {% endcall %}
 {% endblock banner %}
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation that a file has been uploaded for") }}
-    {{ heading(tag="h2", content=document.body.name) }}
+    {{ heading(tag="h2", content=document.metadata.title.value) }}
     {% call button(href='/' ~ document.uri) %}
       Review document
     {% endcall %}

--- a/ds_caselaw_editor_ui/templates/judgment/upload_success.jinja
+++ b/ds_caselaw_editor_ui/templates/judgment/upload_success.jinja
@@ -4,13 +4,13 @@
 {% from "components/button.jinja" import button %}
 {% block banner %}
   {% call notification(variant="success", marginless=True) %}
-    File successfully uploaded to: {{ document.metadata.title.value }}
+    File successfully uploaded to: {{ page_title }}
   {% endcall %}
 {% endblock banner %}
 {% block content %}
   <div class="container">
     {{ heading(content="Confirmation that a file has been uploaded for") }}
-    {{ heading(tag="h2", content=document.metadata.title.value) }}
+    {{ heading(tag="h2", content=page_title) }}
     {% call button(href='/' ~ document.uri) %}
       Review document
     {% endcall %}

--- a/ds_caselaw_editor_ui/templates/layouts/base.jinja
+++ b/ds_caselaw_editor_ui/templates/layouts/base.jinja
@@ -42,7 +42,7 @@
               <a href="{{ url('home') }}">Find and manage case law</a>
             </li>
             {% block breadcrumbs %}
-              {% if document %}{{ render_breadcrumbs("judgment", document.body.name) }}{% endif %}
+              {% if document %}{{ render_breadcrumbs("judgment", document.metadata.title.value) }}{% endif %}
             {% endblock breadcrumbs %}
           </ol>
         </nav>

--- a/ds_caselaw_editor_ui/templates/layouts/base.jinja
+++ b/ds_caselaw_editor_ui/templates/layouts/base.jinja
@@ -42,7 +42,7 @@
               <a href="{{ url('home') }}">Find and manage case law</a>
             </li>
             {% block breadcrumbs %}
-              {% if document %}{{ render_breadcrumbs("judgment", document.metadata.title.value) }}{% endif %}
+              {% if document %}{{ render_breadcrumbs("judgment", page_title) }}{% endif %}
             {% endblock breadcrumbs %}
           </ol>
         </nav>

--- a/ds_caselaw_editor_ui/templates/layouts/judgment.jinja
+++ b/ds_caselaw_editor_ui/templates/layouts/judgment.jinja
@@ -7,7 +7,7 @@
 {% from "components/toolbar.jinja" import toolbar, toolbar_section %}
 {% from "components/document_metadata.jinja" import document_metadata %}
 {% block aside %}
-  {{ document_metadata(document=document, preferred_ncn=preferred_ncn) }}
+  {{ document_metadata(document=document) }}
 {% endblock aside %}
 {% block precontent %}
   {% if current_version_number %}

--- a/judgments/tests/test_document_metadata.py
+++ b/judgments/tests/test_document_metadata.py
@@ -83,7 +83,7 @@ class TestMetadataFieldDisplayDecorator(TestCase):
 
         assert not any(claim.is_faux for claim in section.display_claims)
 
-    def test_faux_suppressed_document_claim_is_added_when_no_document_claim_exists(self):
+    def test_body_claims_are_hidden_when_structured_claims_exist(self):
         judgment = JudgmentFactory.build(
             body=DocumentBodyFactory.build(name="Test v Tested", court="Court of Testing"),
         )
@@ -98,14 +98,10 @@ class TestMetadataFieldDisplayDecorator(TestCase):
         )
 
         section = MetadataFieldDisplayDecorator(judgment, judgment.metadata["court"]).section
-        faux_claims = [claim for claim in section.display_claims if claim.is_faux]
 
-        assert len(faux_claims) == 1
-        assert faux_claims[0].display_value == "Court of Testing"
-        assert faux_claims[0].source_label == "Document"
-        assert faux_claims[0].status == "Suppressed"
-        assert faux_claims[0].is_current is False
-        assert faux_claims[0].can_reject is False
+        assert [claim.display_value for claim in section.display_claims] == ["Editor Court"]
+        assert not any(claim.is_faux for claim in section.display_claims)
+        assert not any(claim.display_value == "Court of Testing" for claim in section.display_claims)
 
     def test_body_derived_judges_can_be_suppressed(self):
         judgment = JudgmentFactory.build(
@@ -236,7 +232,7 @@ class TestDocumentMetadata(TestCase):
     @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")
-    def test_document_metadata_view_shows_faux_suppressed_document_claim(
+    def test_document_metadata_view_hides_body_when_structured_claims_exist(
         self,
         document_type,
         document_exists,
@@ -265,8 +261,8 @@ class TestDocumentMetadata(TestCase):
 
         assert response.status_code == 200
         self.assertContains(response, "Editor Court")
-        self.assertContains(response, "Court of Testing")
-        self.assertContains(response, "Suppressed")
+        self.assertNotContains(response, "Court of Testing")
+        self.assertNotContains(response, "Suppressed")
 
     @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")

--- a/judgments/tests/test_metadata_panel.py
+++ b/judgments/tests/test_metadata_panel.py
@@ -145,6 +145,54 @@ class TestMetadataPanel(TestCase):
 
         assert root.xpath('//dt[text()="TDR ref"]/following-sibling::dd')[0].text_content().strip() == "TDR-999"
 
+    def test_document_metadata_aside_shows_other_identifiers_without_preferred(self):
+        template = environment(loader=PackageLoader("ds_caselaw_editor_ui", "templates")).from_string(
+            '{% from "components/document_metadata.jinja" import document_metadata %}'
+            "{{ document_metadata(document=document) }}",
+        )
+
+        only = SimpleNamespace(
+            schema=SimpleNamespace(name="Find Case Law Identifier"),
+            value="tn4t35ts",
+            uuid="id-only",
+        )
+
+        class FakeIdentifiers:
+            def preferred(self):
+                return None
+
+            def by_score(self):
+                return [only]
+
+        document = SimpleNamespace(
+            metadata={
+                "title": SimpleNamespace(value="Test v Tested"),
+                "court": SimpleNamespace(value="EWCA-Civil"),
+                "date": SimpleNamespace(value=datetime(2025, 5, 23).date()),
+                "jurisdiction": SimpleNamespace(value=""),
+                "case_number": SimpleNamespace(value=""),
+                "judges": SimpleNamespace(values=[]),
+                "categories": SimpleNamespace(values=[]),
+            },
+            identifiers=FakeIdentifiers(),
+            consignment_reference="",
+            document_noun="judgment",
+            has_ever_been_published=False,
+            first_published_datetime_display=None,
+            source_name="",
+            source_email="",
+        )
+
+        rendered = template.render(document=document)
+        root = lxml.html.fromstring(rendered)
+
+        preferred_dd = root.xpath('//dt[text()="Preferred"]/following-sibling::dd')[0]
+        assert preferred_dd.text_content().strip() == "No data available"
+
+        other_dd = root.xpath('//dt[text()="Other"]/following-sibling::dd')[0]
+        assert "Find Case Law Identifier: tn4t35ts" in other_dd.text_content()
+        assert "No data available" not in other_dd.text_content()
+
     @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")
     @patch("judgments.utils.api_client.get_document_type_from_uri")

--- a/judgments/tests/test_metadata_panel.py
+++ b/judgments/tests/test_metadata_panel.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 import lxml.html
 from caselawclient.factories import DocumentBodyFactory, JudgmentFactory
 from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.models.identifiers.fclid import FindCaseLawIdentifier
+from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
 from caselawclient.models.judgments import Judgment
+from caselawclient.types import DocumentCategory
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
@@ -59,8 +64,147 @@ class TestMetadataPanel(TestCase):
 
         rendered = template.render(metadata_item=SimpleNamespace(values=["Tax", "Employment"]))
 
-        assert '<div class="badge badge--info ">Tax</div>' in rendered
-        assert '<div class="badge badge--info ">Employment</div>' in rendered
+        assert "Tax" in rendered
+        assert "Employment" in rendered
+
+    def test_metadata_item_renders_category_names(self):
+        template = environment(loader=PackageLoader("ds_caselaw_editor_ui", "templates")).from_string(
+            '{% from "components/document_metadata_item.jinja" import document_metadata_item %}{{ document_metadata_item(metadata_item=metadata_item) }}',
+        )
+
+        rendered = template.render(
+            metadata_item=SimpleNamespace(values=[DocumentCategory(name="Civil"), DocumentCategory(name="Tax")]),
+        )
+
+        assert "Civil" in rendered
+        assert "Tax" in rendered
+        assert "DocumentCategory" not in rendered
+
+    def test_document_metadata_aside_sections_and_judges(self):
+        template = environment(loader=PackageLoader("ds_caselaw_editor_ui", "templates")).from_string(
+            '{% from "components/document_metadata.jinja" import document_metadata %}'
+            "{{ document_metadata(document=document) }}",
+        )
+
+        preferred = SimpleNamespace(
+            schema=SimpleNamespace(name="Neutral Citation Number"),
+            value="[2023] EWCA Civ 1",
+            uuid="id-preferred",
+        )
+        other = SimpleNamespace(
+            schema=SimpleNamespace(name="Find Case Law Identifier"),
+            value="tn4t35ts",
+            uuid="id-other",
+        )
+
+        class FakeIdentifiers:
+            def preferred(self):
+                return preferred
+
+            def by_score(self):
+                return [preferred, other]
+
+        document = SimpleNamespace(
+            metadata={
+                "title": SimpleNamespace(value="Test v Tested"),
+                "court": SimpleNamespace(value="EWCA-Civil"),
+                "date": SimpleNamespace(value=datetime(2025, 5, 23).date()),
+                "jurisdiction": SimpleNamespace(value=""),
+                "case_number": SimpleNamespace(value=""),
+                "judges": SimpleNamespace(values=["Lord Justice Test", "Lady Justice Example"]),
+                "categories": SimpleNamespace(values=[DocumentCategory(name="Civil")]),
+            },
+            identifiers=FakeIdentifiers(),
+            consignment_reference="TDR-999",
+            document_noun="judgment",
+            has_ever_been_published=False,
+            first_published_datetime_display=None,
+            source_name="",
+            source_email="",
+        )
+
+        rendered = template.render(document=document)
+        root = lxml.html.fromstring(rendered)
+
+        section_headings = root.xpath('//*[@data-test-id="metadata-section-heading"]/dt/text()')
+        assert section_headings == ["Metadata", "Identifiers", "Legacy"]
+
+        judges_dd = root.xpath('//dt[text()="Judges"]/following-sibling::dd')[0]
+        assert "Lord Justice Test" in judges_dd.text_content()
+        assert "Lady Justice Example" in judges_dd.text_content()
+
+        categories_dd = root.xpath('//dt[text()="Categories"]/following-sibling::dd')[0]
+        assert "Civil" in categories_dd.text_content()
+        assert "DocumentCategory" not in categories_dd.text_content()
+
+        preferred_dd = root.xpath('//dt[text()="Preferred"]/following-sibling::dd')[0]
+        assert "Neutral Citation Number: [2023] EWCA Civ 1" in preferred_dd.text_content()
+
+        other_dd = root.xpath('//dt[text()="Other"]/following-sibling::dd')[0]
+        assert "Find Case Law Identifier: tn4t35ts" in other_dd.text_content()
+
+        assert root.xpath('//dt[text()="TDR ref"]/following-sibling::dd')[0].text_content().strip() == "TDR-999"
+
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_metadata_panel_shows_identifiers_from_framework(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri=DocumentURIString("d-9874f350-b187-4e1e-b301-c7d914d5db8c"),
+            identifiers=[
+                NeutralCitationNumber("[2023] EWCA Civ 1"),
+                FindCaseLawIdentifier("tn4t35ts"),
+            ],
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(
+            reverse("full-text-html", kwargs={"document_uri": judgment.uri}),
+        )
+
+        self.assertContains(response, "Identifiers")
+        self.assertContains(response, "Preferred")
+        self.assertContains(response, "Other")
+        preferred = judgment.identifiers.preferred()
+        assert preferred is not None
+        self.assertContains(response, preferred.value)
+        for identifier in judgment.identifiers.by_score():
+            if identifier.uuid != preferred.uuid:
+                self.assertContains(response, identifier.value)
+
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    @patch("judgments.utils.api_client.document_exists")
+    @patch("judgments.utils.api_client.get_document_type_from_uri")
+    def test_metadata_panel_shows_framework_judges(self, document_type, document_exists, mock_judgment):
+        document_type.return_value = Judgment
+        document_exists.return_value = None
+
+        judgment = JudgmentFactory.build(
+            uri=DocumentURIString("d-9874f350-b187-4e1e-b301-c7d914d5db8c"),
+        )
+        judgment.metadata_fields.add(
+            MetadataField(
+                name="judges",
+                value="Lord Justice Underhill",
+                source=MetadataSource.DOCUMENT,
+            ),
+        )
+        mock_judgment.return_value = judgment
+
+        self.client.force_login(User.objects.get_or_create(username="testuser")[0])
+
+        response = self.client.get(
+            reverse("full-text-html", kwargs={"document_uri": judgment.uri}),
+        )
+
+        self.assertContains(response, 'data-test-id="metadata-section-heading"')
+        self.assertContains(response, "Legacy")
+        self.assertContains(response, "Lord Justice Underhill")
 
     @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
     @patch("judgments.utils.api_client.document_exists")

--- a/judgments/tests/test_view_helpers.py
+++ b/judgments/tests/test_view_helpers.py
@@ -7,9 +7,10 @@ from caselawclient.factories import DocumentBodyFactory, JudgmentFactory
 from caselawclient.models.documents import DocumentURIString
 from django.contrib.auth.models import Group, User
 from django.http import Http404
-from django.test import Client, TestCase
+from django.test import Client, RequestFactory, TestCase
 
 from judgments.utils.view_helpers import (
+    DocumentView,
     get_document_by_uri_or_404,
     user_is_developer,
     user_is_editor,
@@ -118,3 +119,21 @@ class TestDocumentView(TestCase):
         mock_get_document_by_uri.assert_called_with("eat/2023/1_xml_versions/1-1")
         assert b"capybara" in response.content
         assert b"assets/eat/2023/1/cat.jpg" in response.content
+
+    @patch("judgments.utils.view_helpers.get_linked_document_uri")
+    @patch("judgments.utils.view_helpers.get_document_by_uri_or_404")
+    def test_document_view_falls_back_to_untitled_document_without_title(
+        self,
+        mock_get_document_by_uri,
+        mock_get_linked_document_uri,
+    ):
+        judgment = JudgmentFactory.build(uri=DocumentURIString("eat/2023/1"))
+        judgment.metadata.pop("title", None)
+        mock_get_document_by_uri.return_value = judgment
+
+        request = RequestFactory().get("/eat/2023/1")
+        request.user = User.objects.get_or_create(username="testuser")[0]
+        view = DocumentView()
+        view.setup(request, document_uri="eat/2023/1")
+
+        assert view.get_context_data()["page_title"] == "Untitled document"

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import ds_caselaw_utils as caselawutils
 import environ
@@ -14,6 +14,9 @@ from judgments.templatetags.document_utils import display_datetime
 from judgments.utils import api_client, editors_dict, extract_version_number_from_filename, get_linked_document_uri
 from judgments.utils.link_generators import build_jira_create_link
 from judgments.utils.paginator import paginator
+
+if TYPE_CHECKING:
+    from caselawclient.models.documents.metadata.types.name import NameMetadata
 
 env = environ.Env()
 RESULTS_ORDER = "-date"
@@ -137,7 +140,7 @@ class DocumentViewMixin(TemplateView):
         else:
             context["document_html"] = self.document.content_as_html()
 
-        title = self.document.metadata.get("title")
+        title = cast("NameMetadata | None", self.document.metadata.get("title"))
         context["page_title"] = title.value if title else "Untitled document"
         context["courts"] = caselawutils.courts.get_all(with_jurisdictions=True)
 

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -137,7 +137,7 @@ class DocumentViewMixin(TemplateView):
         else:
             context["document_html"] = self.document.content_as_html()
 
-        context["page_title"] = self.document.body.name
+        context["page_title"] = self.document.metadata["title"].value
         context["courts"] = caselawutils.courts.get_all(with_jurisdictions=True)
 
         context["editors"] = editors_dict()

--- a/judgments/utils/view_helpers.py
+++ b/judgments/utils/view_helpers.py
@@ -137,7 +137,8 @@ class DocumentViewMixin(TemplateView):
         else:
             context["document_html"] = self.document.content_as_html()
 
-        context["page_title"] = self.document.metadata["title"].value
+        title = self.document.metadata.get("title")
+        context["page_title"] = title.value if title else "Untitled document"
         context["courts"] = caselawutils.courts.get_all(with_jurisdictions=True)
 
         context["editors"] = editors_dict()

--- a/judgments/views/document_metadata.py
+++ b/judgments/views/document_metadata.py
@@ -69,9 +69,7 @@ class MetadataFieldDisplayDecorator:
         if not self.resolved.has_any_claims:
             return self._fallback_document_claims()
 
-        display_claims = [self._real_claim(claim) for claim in reversed(self.resolved.all_claims)]
-        display_claims.extend(self._faux_suppressed_document_claims())
-        return display_claims
+        return [self._real_claim(claim) for claim in reversed(self.resolved.all_claims)]
 
     def _real_claim(self, claim):
         if claim.rejected:
@@ -119,24 +117,6 @@ class MetadataFieldDisplayDecorator:
                 reject_input_id_prefix=(f"suppress-body-judge-{index}" if self.metadata_item.key == "judges" else None),
             )
             for index, value in enumerate(self._body_values(), start=1)
-        ]
-
-    def _faux_suppressed_document_claims(self):
-        if any(claim.source is MetadataSource.DOCUMENT for claim in self.resolved.all_claims):
-            return []
-
-        return [
-            MetadataDisplayClaim(
-                value=value,
-                display_value=self._format_value(value),
-                source_label="Document",
-                status="Suppressed" if self.active_claims else "Current",
-                status_badge_variant="failure" if self.active_claims else "success",
-                is_current=not self.active_claims,
-                can_reject=False,
-                is_faux=True,
-            )
-            for value in self._body_values()
         ]
 
     def _body_values(self):


### PR DESCRIPTION
A series of improvements to how we render stuff using the updated metadata framework:

- Clearer sections in the metadata sidebar about where stuff comes from
- Page titles actually lean on the new metadata layer, not the old `Document` property
- We no longer display fallback body-based metadata values where we have materialised ones